### PR TITLE
feat: add command palette, pane toolbar, and centralized shortcut system

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import { VisualizerPanel } from './components/visualizer/VisualizerPanel';
 import { ShortcutsHint } from './components/ShortcutsHint';
 import { SettingsModal } from './components/SettingsModal';
 import { ShortcutsPanel } from './components/ShortcutsPanel';
+import { CommandPalette } from './components/CommandPalette';
 
 const UNDO_TOAST_DURATION = 5000;
 const PTY_GC_INTERVAL = 30_000; // 30 seconds
@@ -47,6 +48,7 @@ export function App() {
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [updateReady, setUpdateReady] = useState(false);
 
   // Load settings on startup
@@ -71,6 +73,13 @@ export function App() {
     const handler = () => setShortcutsOpen((prev) => !prev);
     document.addEventListener('fleet:toggle-shortcuts', handler);
     return () => document.removeEventListener('fleet:toggle-shortcuts', handler);
+  }, []);
+
+  // Command palette toggle
+  useEffect(() => {
+    const handler = () => setCommandPaletteOpen((prev) => !prev);
+    document.addEventListener('fleet:toggle-command-palette', handler);
+    return () => document.removeEventListener('fleet:toggle-command-palette', handler);
   }, []);
 
   // Auto-updater
@@ -274,6 +283,7 @@ export function App() {
       )}
       <SettingsModal isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <ShortcutsPanel isOpen={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
+      <CommandPalette isOpen={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
     </div>
   );
 }

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { createCommandRegistry, fuzzyMatch, formatCommandShortcut } from '../lib/commands';
+
+type CommandPaletteProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const commands = useMemo(() => createCommandRegistry(), []);
+
+  const filtered = useMemo(() => {
+    return commands.filter((cmd) => fuzzyMatch(query, cmd.label));
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setSelectedIndex(0);
+      // Defer focus so the input is mounted
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  if (!isOpen) return null;
+
+  const executeSelected = () => {
+    const cmd = filtered[selectedIndex];
+    if (cmd) {
+      onClose();
+      cmd.execute();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      executeSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="mt-[15vh] w-[480px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-3 py-2 border-b border-neutral-800">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a command..."
+            className="w-full bg-transparent text-sm text-white outline-none placeholder-neutral-500"
+          />
+        </div>
+        <div className="overflow-y-auto py-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-4 text-sm text-neutral-500 text-center">No matching commands</div>
+          ) : (
+            filtered.map((cmd, i) => {
+              const shortcutLabel = formatCommandShortcut(cmd);
+              return (
+                <button
+                  key={cmd.id}
+                  className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left transition-colors ${
+                    i === selectedIndex ? 'bg-neutral-700 text-white' : 'text-neutral-300 hover:bg-neutral-800'
+                  }`}
+                  onMouseEnter={() => setSelectedIndex(i)}
+                  onClick={() => {
+                    onClose();
+                    cmd.execute();
+                  }}
+                >
+                  <span>{cmd.label}</span>
+                  {shortcutLabel && (
+                    <kbd className="text-xs text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-700">
+                      {shortcutLabel}
+                    </kbd>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/PaneGrid.tsx
+++ b/src/renderer/src/components/PaneGrid.tsx
@@ -3,6 +3,11 @@ import type { PaneNode } from '../../../shared/types';
 import { TerminalPane } from './TerminalPane';
 import { useWorkspaceStore } from '../store/workspace-store';
 
+type PaneActions = {
+  splitPane: (paneId: string, direction: 'horizontal' | 'vertical') => void;
+  closePane: (paneId: string) => void;
+};
+
 type PaneGridProps = {
   root: PaneNode;
   activePaneId: string | null;
@@ -13,6 +18,8 @@ type PaneGridProps = {
 };
 
 export function PaneGrid({ root, activePaneId, onPaneFocus, serializedPanes, fontFamily, fontSize }: PaneGridProps) {
+  const { splitPane, closePane } = useWorkspaceStore();
+
   return (
     <div className="h-full w-full">
       <PaneNodeRenderer
@@ -23,6 +30,7 @@ export function PaneGrid({ root, activePaneId, onPaneFocus, serializedPanes, fon
         serializedPanes={serializedPanes}
         fontFamily={fontFamily}
         fontSize={fontSize}
+        actions={{ splitPane, closePane }}
       />
     </div>
   );
@@ -36,9 +44,10 @@ type PaneNodeRendererProps = {
   serializedPanes?: Map<string, string>;
   fontFamily?: string;
   fontSize?: number;
+  actions: PaneActions;
 };
 
-function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPanes, fontFamily, fontSize }: PaneNodeRendererProps) {
+function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPanes, fontFamily, fontSize, actions }: PaneNodeRendererProps) {
   if (node.type === 'leaf') {
     return (
       <TerminalPane
@@ -49,6 +58,9 @@ function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPan
         serializedContent={serializedPanes?.get(node.id)}
         fontFamily={fontFamily}
         fontSize={fontSize}
+        onSplitHorizontal={() => actions.splitPane(node.id, 'horizontal')}
+        onSplitVertical={() => actions.splitPane(node.id, 'vertical')}
+        onClose={() => actions.closePane(node.id)}
       />
     );
   }
@@ -74,6 +86,7 @@ function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPan
           serializedPanes={serializedPanes}
           fontFamily={fontFamily}
           fontSize={fontSize}
+          actions={actions}
         />
       </div>
 
@@ -93,6 +106,7 @@ function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPan
           serializedPanes={serializedPanes}
           fontFamily={fontFamily}
           fontSize={fontSize}
+          actions={actions}
         />
       </div>
     </div>

--- a/src/renderer/src/components/PaneToolbar.tsx
+++ b/src/renderer/src/components/PaneToolbar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Columns2, Rows2, Search, X } from 'lucide-react';
+import { formatShortcut, getShortcut } from '../lib/shortcuts';
+
+type PaneToolbarProps = {
+  visible: boolean;
+  onSplitHorizontal: () => void;
+  onSplitVertical: () => void;
+  onClose: () => void;
+  onSearch: () => void;
+};
+
+export function PaneToolbar({ visible, onSplitHorizontal, onSplitVertical, onClose, onSearch }: PaneToolbarProps) {
+  return (
+    <div
+      className={`absolute top-2 right-2 z-20 transition-opacity flex items-center gap-0.5 bg-neutral-800/80 backdrop-blur-sm rounded-md border border-neutral-700/50 p-0.5 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+    >
+      <button
+        onClick={(e) => { e.stopPropagation(); onSplitHorizontal(); }}
+        className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title={`Split Right (${formatShortcut(getShortcut('split-right')!)})`}
+      >
+        <Columns2 size={14} />
+      </button>
+      <button
+        onClick={(e) => { e.stopPropagation(); onSplitVertical(); }}
+        className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title={`Split Down (${formatShortcut(getShortcut('split-down')!)})`}
+      >
+        <Rows2 size={14} />
+      </button>
+      <button
+        onClick={(e) => { e.stopPropagation(); onSearch(); }}
+        className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title={`Search (${formatShortcut(getShortcut('search')!)})`}
+      >
+        <Search size={14} />
+      </button>
+      <button
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title={`Close Pane (${formatShortcut(getShortcut('close-pane')!)})`}
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/src/components/SearchBar.tsx
+++ b/src/renderer/src/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 
 type SearchBarProps = {
   isOpen: boolean;
@@ -44,10 +45,24 @@ export function SearchBar({ isOpen, onClose, onSearch, onSearchPrevious }: Searc
         className="bg-transparent text-sm text-white outline-none w-48 placeholder-neutral-500"
       />
       <button
-        onClick={onClose}
-        className="text-neutral-500 hover:text-white text-sm"
+        onClick={() => onSearchPrevious(query)}
+        className="p-0.5 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title="Previous match (Shift+Enter)"
       >
-        ×
+        <ChevronUp size={14} />
+      </button>
+      <button
+        onClick={() => onSearch(query)}
+        className="p-0.5 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+        title="Next match (Enter)"
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button
+        onClick={onClose}
+        className="text-neutral-500 hover:text-white text-sm ml-1"
+      >
+        &times;
       </button>
     </div>
   );

--- a/src/renderer/src/components/ShortcutsHint.tsx
+++ b/src/renderer/src/components/ShortcutsHint.tsx
@@ -1,10 +1,15 @@
+import { formatShortcut, getShortcut } from '../lib/shortcuts';
+
 export function ShortcutsHint() {
+  const shortcutsDef = getShortcut('shortcuts');
+  const hint = shortcutsDef ? formatShortcut(shortcutsDef) : 'Ctrl+/';
+
   return (
     <div className="absolute bottom-3 right-3 z-30">
       <button
         onClick={() => document.dispatchEvent(new CustomEvent('fleet:toggle-shortcuts'))}
         className="w-6 h-6 rounded-full bg-neutral-800/80 border border-neutral-700 text-neutral-500 hover:text-neutral-300 hover:bg-neutral-700/80 text-xs flex items-center justify-center transition-colors"
-        title="Keyboard Shortcuts (Ctrl+/)"
+        title={`Keyboard Shortcuts (${hint})`}
       >
         ?
       </button>

--- a/src/renderer/src/components/ShortcutsPanel.tsx
+++ b/src/renderer/src/components/ShortcutsPanel.tsx
@@ -1,32 +1,8 @@
-const isMac = typeof navigator !== 'undefined' && navigator.platform.includes('Mac');
+import { ALL_SHORTCUTS, formatShortcut } from '../lib/shortcuts';
 
-const SHORTCUTS = isMac
-  ? [
-      { keys: 'Ctrl+T', action: 'New tab' },
-      { keys: 'Ctrl+W', action: 'Close pane' },
-      { keys: 'Ctrl+D', action: 'Split horizontal' },
-      { keys: 'Ctrl+Shift+D', action: 'Split vertical' },
-      { keys: 'Ctrl+[/]', action: 'Navigate panes' },
-      { keys: 'Ctrl+1-9', action: 'Switch tabs' },
-      { keys: 'F2', action: 'Rename tab' },
-      { keys: 'Ctrl+F', action: 'Search in pane' },
-      { keys: 'Ctrl+Shift+V', action: 'Toggle visualizer' },
-      { keys: 'Ctrl+,', action: 'Settings' },
-      { keys: 'Ctrl+/', action: 'Show shortcuts' },
-    ]
-  : [
-      { keys: 'Ctrl+T', action: 'New tab' },
-      { keys: 'Ctrl+Shift+W', action: 'Close pane' },
-      { keys: 'Ctrl+Shift+D', action: 'Split horizontal' },
-      { keys: 'Ctrl+Shift+Alt+D', action: 'Split vertical' },
-      { keys: 'Ctrl+[/]', action: 'Navigate panes' },
-      { keys: 'Ctrl+1-9', action: 'Switch tabs' },
-      { keys: 'F2', action: 'Rename tab' },
-      { keys: 'Ctrl+Shift+F', action: 'Search in pane' },
-      { keys: 'Ctrl+Shift+V', action: 'Toggle visualizer' },
-      { keys: 'Ctrl+,', action: 'Settings' },
-      { keys: 'Ctrl+/', action: 'Show shortcuts' },
-    ];
+const SHORTCUTS = ALL_SHORTCUTS
+  .filter((s) => s.id !== 'command-palette')
+  .map((s) => ({ keys: formatShortcut(s), action: s.label }));
 
 type ShortcutsPanelProps = {
   isOpen: boolean;

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useWorkspaceStore, collectPaneIds } from '../store/workspace-store';
 import { useNotificationStore } from '../store/notification-store';
 import { useCwdStore } from '../store/cwd-store';
 import { clearCreatedPty, serializePane } from '../hooks/use-terminal';
+import { formatShortcut, getShortcut } from '../lib/shortcuts';
 import type { Workspace } from '../../../shared/types';
 
 const AUTO_SAVE_DEBOUNCE_MS = 2000;
@@ -289,7 +290,7 @@ export function Sidebar() {
           <button
             className="text-neutral-500 hover:text-white text-lg leading-none px-1 rounded hover:bg-neutral-800 transition-colors"
             onClick={() => addTab(undefined, window.fleet.homeDir)}
-            title="New Tab (Ctrl+T)"
+            title={`New Tab (${formatShortcut(getShortcut('new-tab')!)})`}
           >
             +
           </button>

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -1,5 +1,7 @@
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useTerminal } from '../hooks/use-terminal';
+import { PaneToolbar } from './PaneToolbar';
+import { SearchBar } from './SearchBar';
 
 type TerminalPaneProps = {
   paneId: string;
@@ -9,15 +11,34 @@ type TerminalPaneProps = {
   serializedContent?: string;
   fontFamily?: string;
   fontSize?: number;
+  onSplitHorizontal?: () => void;
+  onSplitVertical?: () => void;
+  onClose?: () => void;
 };
 
-export function TerminalPane({ paneId, cwd, isActive, onFocus, serializedContent, fontFamily, fontSize }: TerminalPaneProps) {
+export function TerminalPane({ paneId, cwd, isActive, onFocus, serializedContent, fontFamily, fontSize, onSplitHorizontal, onSplitVertical, onClose }: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { fit, focus } = useTerminal(containerRef, { paneId, cwd, serializedContent, isActive, fontFamily, fontSize });
+  const { fit, focus, search, searchPrevious, clearSearch } = useTerminal(containerRef, { paneId, cwd, serializedContent, isActive, fontFamily, fontSize });
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  // Listen for search toggle events targeted at this pane
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.paneId === paneId) {
+        setSearchOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('fleet:toggle-search', handler);
+    return () => document.removeEventListener('fleet:toggle-search', handler);
+  }, [paneId]);
 
   return (
     <div
-      className={`h-full w-full overflow-hidden p-3 transition-[box-shadow] duration-0 ${isActive ? 'ring-2 ring-blue-500/70 bg-[#151515]' : 'ring-1 ring-neutral-800/50 bg-[#131313]'}`}
+      className={`relative h-full w-full overflow-hidden p-3 transition-[box-shadow] duration-0 ${isActive ? 'ring-2 ring-blue-500/70 bg-[#151515]' : 'ring-1 ring-neutral-800/50 bg-[#131313]'}`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       onFocus={onFocus}
       onClick={() => {
         onFocus();
@@ -25,6 +46,23 @@ export function TerminalPane({ paneId, cwd, isActive, onFocus, serializedContent
         fit();
       }}
     >
+      <PaneToolbar
+        visible={hovered}
+        onSplitHorizontal={() => onSplitHorizontal?.()}
+        onSplitVertical={() => onSplitVertical?.()}
+        onClose={() => onClose?.()}
+        onSearch={() => setSearchOpen(true)}
+      />
+      <SearchBar
+        isOpen={searchOpen}
+        onClose={() => {
+          setSearchOpen(false);
+          clearSearch();
+          focus();
+        }}
+        onSearch={(q) => search(q)}
+        onSearchPrevious={(q) => searchPrevious(q)}
+      />
       <div ref={containerRef} className="h-full w-full" />
     </div>
   );

--- a/src/renderer/src/hooks/use-pane-navigation.ts
+++ b/src/renderer/src/hooks/use-pane-navigation.ts
@@ -1,6 +1,11 @@
 import { useEffect } from 'react';
 import { useWorkspaceStore, collectPaneIds } from '../store/workspace-store';
 import { useVisualizerStore } from '../store/visualizer-store';
+import { ALL_SHORTCUTS, matchesShortcut } from '../lib/shortcuts';
+
+function sc(id: string) {
+  return ALL_SHORTCUTS.find((s) => s.id === id)!;
+}
 
 export function usePaneNavigation() {
   const { workspace, activeTabId, activePaneId, addTab, closePane, splitPane, setActiveTab } =
@@ -8,90 +13,107 @@ export function usePaneNavigation() {
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      // F2 to rename active tab (no modifier needed)
-      if (e.key === 'F2') {
+      // F2 to rename active tab
+      if (matchesShortcut(e, sc('rename-tab'))) {
         e.preventDefault();
         document.dispatchEvent(new CustomEvent('fleet:rename-active-tab'));
         return;
       }
 
-      if (!e.ctrlKey) return;
-
-      if (e.key === 't') {
+      if (matchesShortcut(e, sc('new-tab'))) {
         e.preventDefault();
         addTab(undefined, window.fleet.homeDir);
+        return;
       }
 
-      if (e.key === 'w') {
+      if (matchesShortcut(e, sc('close-pane'))) {
         e.preventDefault();
         if (activePaneId) closePane(activePaneId);
+        return;
       }
 
-      // Ctrl+Shift+D for vertical split (check before Ctrl+D)
-      if (e.shiftKey && e.key === 'D') {
+      // Split down must be checked before split right (superset modifiers)
+      if (matchesShortcut(e, sc('split-down'))) {
         e.preventDefault();
         if (activePaneId) splitPane(activePaneId, 'vertical');
-      } else if (e.key === 'd') {
-        e.preventDefault();
-        if (activePaneId) splitPane(activePaneId, 'horizontal');
+        return;
       }
 
-      // Ctrl+[ / Ctrl+] to navigate panes within current tab only
-      if (e.key === '[' || e.key === ']') {
+      if (matchesShortcut(e, sc('split-right'))) {
+        e.preventDefault();
+        if (activePaneId) splitPane(activePaneId, 'horizontal');
+        return;
+      }
+
+      // Navigate panes
+      if (matchesShortcut(e, sc('navigate-prev')) || matchesShortcut(e, sc('navigate-next'))) {
         e.preventDefault();
         const state = useWorkspaceStore.getState();
         const activeTab = state.workspace.tabs.find(t => t.id === state.activeTabId);
         if (!activeTab) return;
         const tabPaneIds = collectPaneIds(activeTab.splitRoot);
         const currentIndex = activePaneId ? tabPaneIds.indexOf(activePaneId) : -1;
-        const nextIndex = e.key === ']'
+        const forward = matchesShortcut(e, sc('navigate-next'));
+        const nextIndex = forward
           ? (currentIndex + 1) % tabPaneIds.length
           : (currentIndex - 1 + tabPaneIds.length) % tabPaneIds.length;
         if (tabPaneIds[nextIndex]) {
           state.setActivePane(tabPaneIds[nextIndex]);
         }
+        return;
       }
 
-      // Ctrl+Tab / Ctrl+Shift+Tab to switch tabs
-      if (e.key === 'Tab') {
+      // Cycle tabs
+      if (matchesShortcut(e, sc('cycle-tab-next')) || matchesShortcut(e, sc('cycle-tab-prev'))) {
         e.preventDefault();
         const tabIndex = workspace.tabs.findIndex(t => t.id === activeTabId);
-        const nextIndex = e.shiftKey
-          ? (tabIndex - 1 + workspace.tabs.length) % workspace.tabs.length
-          : (tabIndex + 1) % workspace.tabs.length;
+        const forward = matchesShortcut(e, sc('cycle-tab-next'));
+        const nextIndex = forward
+          ? (tabIndex + 1) % workspace.tabs.length
+          : (tabIndex - 1 + workspace.tabs.length) % workspace.tabs.length;
         if (workspace.tabs[nextIndex]) setActiveTab(workspace.tabs[nextIndex].id);
+        return;
       }
 
-      // Ctrl+F to toggle search
-      if (e.key === 'f') {
+      if (matchesShortcut(e, sc('search'))) {
         e.preventDefault();
-        document.dispatchEvent(new CustomEvent('fleet:toggle-search'));
+        document.dispatchEvent(new CustomEvent('fleet:toggle-search', { detail: { paneId: activePaneId } }));
+        return;
       }
 
-      // Ctrl+Shift+V to toggle visualizer
-      if (e.shiftKey && e.key === 'V') {
+      if (matchesShortcut(e, sc('visualizer'))) {
         e.preventDefault();
         useVisualizerStore.getState().toggleVisible();
+        return;
       }
 
-      // Ctrl+, to toggle settings
-      if (e.key === ',') {
+      if (matchesShortcut(e, sc('settings'))) {
         e.preventDefault();
         document.dispatchEvent(new CustomEvent('fleet:toggle-settings'));
+        return;
       }
 
-      // Ctrl+/ to toggle shortcuts
-      if (e.key === '/') {
+      if (matchesShortcut(e, sc('shortcuts'))) {
         e.preventDefault();
         document.dispatchEvent(new CustomEvent('fleet:toggle-shortcuts'));
+        return;
       }
 
-      // Ctrl+1-9 to switch tabs
-      if (e.key >= '1' && e.key <= '9') {
+      if (matchesShortcut(e, sc('command-palette'))) {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent('fleet:toggle-command-palette'));
+        return;
+      }
+
+      // Cmd/Ctrl+1-9 to switch tabs (check metaKey on mac, ctrlKey on other)
+      const isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+      const modHeld = isMac ? e.metaKey : e.ctrlKey;
+      if (modHeld && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '9') {
         e.preventDefault();
         const index = parseInt(e.key) - 1;
         const tab = workspace.tabs[index];
         if (tab) setActiveTab(tab.id);
+        return;
       }
     }
 

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -207,6 +207,7 @@ export function useTerminal(
     fit: () => fitAddonRef.current?.fit(),
     search: (query: string) => searchAddonRef.current?.findNext(query),
     searchPrevious: (query: string) => searchAddonRef.current?.findPrevious(query),
+    clearSearch: () => searchAddonRef.current?.clearDecorations(),
     serialize: () => serializeAddonRef.current?.serialize(),
   };
 }

--- a/src/renderer/src/lib/commands.ts
+++ b/src/renderer/src/lib/commands.ts
@@ -1,0 +1,110 @@
+import { ALL_SHORTCUTS, formatShortcut, type ShortcutDef } from './shortcuts';
+import { useWorkspaceStore } from '../store/workspace-store';
+import { useVisualizerStore } from '../store/visualizer-store';
+
+export type Command = {
+  id: string;
+  label: string;
+  shortcut?: ShortcutDef;
+  category: string;
+  execute: () => void;
+};
+
+function sc(id: string): ShortcutDef | undefined {
+  return ALL_SHORTCUTS.find((s) => s.id === id);
+}
+
+export function createCommandRegistry(): Command[] {
+  return [
+    {
+      id: 'new-tab',
+      label: 'New Tab',
+      shortcut: sc('new-tab'),
+      category: 'Tabs',
+      execute: () => useWorkspaceStore.getState().addTab(undefined, window.fleet.homeDir),
+    },
+    {
+      id: 'close-pane',
+      label: 'Close Pane',
+      shortcut: sc('close-pane'),
+      category: 'Panes',
+      execute: () => {
+        const { activePaneId, closePane } = useWorkspaceStore.getState();
+        if (activePaneId) closePane(activePaneId);
+      },
+    },
+    {
+      id: 'split-right',
+      label: 'Split Right',
+      shortcut: sc('split-right'),
+      category: 'Panes',
+      execute: () => {
+        const { activePaneId, splitPane } = useWorkspaceStore.getState();
+        if (activePaneId) splitPane(activePaneId, 'horizontal');
+      },
+    },
+    {
+      id: 'split-down',
+      label: 'Split Down',
+      shortcut: sc('split-down'),
+      category: 'Panes',
+      execute: () => {
+        const { activePaneId, splitPane } = useWorkspaceStore.getState();
+        if (activePaneId) splitPane(activePaneId, 'vertical');
+      },
+    },
+    {
+      id: 'search',
+      label: 'Search in Pane',
+      shortcut: sc('search'),
+      category: 'Panes',
+      execute: () => {
+        const { activePaneId } = useWorkspaceStore.getState();
+        document.dispatchEvent(new CustomEvent('fleet:toggle-search', { detail: { paneId: activePaneId } }));
+      },
+    },
+    {
+      id: 'toggle-visualizer',
+      label: 'Toggle Visualizer',
+      shortcut: sc('visualizer'),
+      category: 'View',
+      execute: () => useVisualizerStore.getState().toggleVisible(),
+    },
+    {
+      id: 'settings',
+      label: 'Open Settings',
+      shortcut: sc('settings'),
+      category: 'App',
+      execute: () => document.dispatchEvent(new CustomEvent('fleet:toggle-settings')),
+    },
+    {
+      id: 'shortcuts',
+      label: 'Show Shortcuts',
+      shortcut: sc('shortcuts'),
+      category: 'App',
+      execute: () => document.dispatchEvent(new CustomEvent('fleet:toggle-shortcuts')),
+    },
+    {
+      id: 'rename-tab',
+      label: 'Rename Tab',
+      shortcut: sc('rename-tab'),
+      category: 'Tabs',
+      execute: () => document.dispatchEvent(new CustomEvent('fleet:rename-active-tab')),
+    },
+  ];
+}
+
+export function fuzzyMatch(query: string, label: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  const l = label.toLowerCase();
+  let qi = 0;
+  for (let li = 0; li < l.length && qi < q.length; li++) {
+    if (l[li] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}
+
+export function formatCommandShortcut(cmd: Command): string | undefined {
+  return cmd.shortcut ? formatShortcut(cmd.shortcut) : undefined;
+}

--- a/src/renderer/src/lib/shortcuts.ts
+++ b/src/renderer/src/lib/shortcuts.ts
@@ -1,0 +1,142 @@
+export const PLATFORM: 'mac' | 'other' =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
+    ? 'mac'
+    : 'other';
+
+export type KeyCombo = {
+  key: string;
+  meta?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+};
+
+export type ShortcutDef = {
+  id: string;
+  label: string;
+  mac: KeyCombo;
+  other: KeyCombo;
+};
+
+export const ALL_SHORTCUTS: ShortcutDef[] = [
+  {
+    id: 'new-tab',
+    label: 'New tab',
+    mac: { key: 't', meta: true },
+    other: { key: 't', ctrl: true },
+  },
+  {
+    id: 'close-pane',
+    label: 'Close pane',
+    mac: { key: 'w', meta: true },
+    other: { key: 'W', ctrl: true, shift: true },
+  },
+  {
+    id: 'split-right',
+    label: 'Split right',
+    mac: { key: 'd', meta: true },
+    other: { key: 'D', ctrl: true, shift: true },
+  },
+  {
+    id: 'split-down',
+    label: 'Split down',
+    mac: { key: 'D', meta: true, shift: true },
+    other: { key: 'D', ctrl: true, shift: true, alt: true },
+  },
+  {
+    id: 'navigate-prev',
+    label: 'Previous pane',
+    mac: { key: '[', meta: true },
+    other: { key: '[', ctrl: true, shift: true },
+  },
+  {
+    id: 'navigate-next',
+    label: 'Next pane',
+    mac: { key: ']', meta: true },
+    other: { key: ']', ctrl: true, shift: true },
+  },
+  {
+    id: 'cycle-tab-next',
+    label: 'Next tab',
+    mac: { key: 'Tab', ctrl: true },
+    other: { key: 'Tab', ctrl: true },
+  },
+  {
+    id: 'cycle-tab-prev',
+    label: 'Previous tab',
+    mac: { key: 'Tab', ctrl: true, shift: true },
+    other: { key: 'Tab', ctrl: true, shift: true },
+  },
+  {
+    id: 'search',
+    label: 'Search in pane',
+    mac: { key: 'f', meta: true },
+    other: { key: 'F', ctrl: true, shift: true },
+  },
+  {
+    id: 'visualizer',
+    label: 'Toggle visualizer',
+    mac: { key: 'V', meta: true, shift: true },
+    other: { key: 'V', ctrl: true, shift: true },
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    mac: { key: ',', meta: true },
+    other: { key: ',', ctrl: true },
+  },
+  {
+    id: 'shortcuts',
+    label: 'Show shortcuts',
+    mac: { key: '/', meta: true },
+    other: { key: '/', ctrl: true },
+  },
+  {
+    id: 'rename-tab',
+    label: 'Rename tab',
+    mac: { key: 'F2' },
+    other: { key: 'F2' },
+  },
+  {
+    id: 'command-palette',
+    label: 'Command palette',
+    mac: { key: 'P', meta: true, shift: true },
+    other: { key: 'P', ctrl: true, shift: true },
+  },
+];
+
+export function matchesShortcut(e: KeyboardEvent, def: ShortcutDef): boolean {
+  const combo = PLATFORM === 'mac' ? def.mac : def.other;
+  if (e.key !== combo.key && e.key.toLowerCase() !== combo.key.toLowerCase()) return false;
+  // For shifted keys, e.key is uppercase — also match case-insensitively
+  if (combo.shift && !e.shiftKey) return false;
+  if (!combo.shift && e.shiftKey && combo.key !== 'Tab') return false;
+  if (combo.meta && !e.metaKey) return false;
+  if (!combo.meta && e.metaKey) return false;
+  if (combo.ctrl && !e.ctrlKey) return false;
+  if (!combo.ctrl && e.ctrlKey) return false;
+  if (combo.alt && !e.altKey) return false;
+  if (!combo.alt && e.altKey) return false;
+  return true;
+}
+
+function modLabel(platform: 'mac' | 'other'): string {
+  return platform === 'mac' ? 'Cmd' : 'Ctrl';
+}
+
+export function formatShortcut(def: ShortcutDef): string {
+  const combo = PLATFORM === 'mac' ? def.mac : def.other;
+  const parts: string[] = [];
+  if (combo.ctrl) parts.push('Ctrl');
+  if (combo.meta) parts.push(modLabel(PLATFORM));
+  if (combo.alt) parts.push('Alt');
+  if (combo.shift) parts.push('Shift');
+  // Display key nicely
+  const keyLabel = combo.key === 'Tab' ? 'Tab' : combo.key.toUpperCase();
+  parts.push(keyLabel);
+  return parts.join('+');
+}
+
+export function getShortcut(id: string): ShortcutDef | undefined {
+  return ALL_SHORTCUTS.find((s) => s.id === id);
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,11 +3,13 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './index.css';
 
-const root = document.getElementById('root');
-if (root) {
-  createRoot(root).render(
-    <StrictMode>
-      <App />
-    </StrictMode>
-  );
-}
+;(() => {
+  const root = document.getElementById('root');
+  if (root) {
+    createRoot(root).render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+  }
+})();


### PR DESCRIPTION
## Summary
- Add centralized shortcuts lib (`lib/shortcuts.ts`) with platform-aware key definitions (Cmd on mac, Ctrl elsewhere) and a matching engine, replacing hardcoded keybindings throughout the app
- Add command palette (`Cmd+Shift+P`) with fuzzy search over all registered commands and their shortcuts
- Add hover pane toolbar with split right/down, search, and close buttons
- Improve search bar with previous/next navigation arrows

## Test plan
- [ ] Verify command palette opens with `Cmd+Shift+P` (mac) / `Ctrl+Shift+P` (other)
- [ ] Verify fuzzy search filters commands and Enter executes the selected one
- [ ] Verify pane toolbar appears on hover with working split/search/close buttons
- [ ] Verify all existing keyboard shortcuts still work as before
- [ ] Verify search bar prev/next arrows navigate matches correctly
- [ ] Test on both macOS and Linux/Windows for correct modifier keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)