### PR TITLE
fix(terminal): prevent scroll-to-top bug when switching tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12341,7 +12341,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -132,6 +132,9 @@ function createTerminal(container: HTMLElement, options: UseTerminalOptions): {
   };
 
   const updatePinnedState = (): void => {
+    // Don't read buffer state while hidden (display:none) — viewportY is stale
+    // and would incorrectly flip pinnedToBottom to false.
+    if (container.offsetParent === null) return;
     pinnedToBottom = isAtBottom();
     options.onScrollStateChange?.(!pinnedToBottom);
   };
@@ -140,6 +143,9 @@ function createTerminal(container: HTMLElement, options: UseTerminalOptions): {
   // Without this, fitAddon.fit() can reset the viewport to the top when
   // the container is resized (e.g. adding splits, switching tabs).
   const fitPreservingScroll = (): void => {
+    // Skip while hidden — viewportY is stale and fit() can't measure correctly
+    if (container.offsetParent === null) return;
+
     const savedPinned = pinnedToBottom;
     const savedViewportY = term.buffer.active.viewportY;
 


### PR DESCRIPTION
## Summary
- Fixed terminal jumping to top when switching tabs with active output
- Added visibility guards to skip reading xterm buffer state while container is hidden (display: none)
- Preserves user's intended scroll position across tab switches

## Test plan
- [ ] Create a terminal tab with active Claude Code session
- [ ] Scroll up in the terminal while code is running
- [ ] Switch to another tab
- [ ] Switch back to the first tab
- **Expected:** Terminal stays at the scrolled-up position (not jumping to top)
- [ ] Create another tab and let Claude Code stream output
- [ ] Switch to another tab
- [ ] Switch back
- **Expected:** Terminal stays pinned to bottom (following new output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)