### PR TITLE
fix(terminal): prevent scroll-to-top race during fast output

### DIFF
--- a/docs/learnings/2026-03-16-scroll-to-top-bug.md
+++ b/docs/learnings/2026-03-16-scroll-to-top-bug.md
@@ -38,3 +38,11 @@ if (!savedPinned) {
 ## Related: Programmatic scrollToBottom doesn't fire onScroll
 
 When calling `term.scrollToBottom()` programmatically, `onScroll` may not fire. If you're tracking scroll state (e.g., to show/hide a "scroll to bottom" button), manually notify after the programmatic scroll.
+
+## Follow-up: onScroll race condition during fast output (same-pane jump to top)
+
+Even with `pinnedToBottom` tracking, the viewport could randomly jump to the top while Claude Code was running in the **active, visible** pane. Root cause: `term.onScroll(() => updatePinnedState())` called `updatePinnedState` on every content-driven scroll event. During fast output, `baseY` advances before `viewportY` catches up, so `viewportY < baseY - 2` is briefly true, falsely flipping `pinnedToBottom = false`. If `fitPreservingScroll` fires at that moment (ResizeObserver, click), it restores position instead of following bottom, and `fit()` can reset viewport to 0.
+
+**Fix:** `onScroll` must only **re-pin** (set `pinnedToBottom = true` when at bottom), never **unpin**. Only `wheel` events should unpin, since they represent actual user scroll intent. Additionally, `fitPreservingScroll` reconciles the flag before acting: if `pinnedToBottom` is false but `isAtBottom()` is true, correct it.
+
+**Key insight:** `term.onScroll` only fires for content-driven scrolling (new lines added), never for user wheel/keyboard scrolling (confirmed by xterm.js issues #3864, #3201). It must never be used to infer user scroll-up intent. This is a known class of bug — Tabby terminal has the same issue with Claude Code (Tabby #10648).

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -146,6 +146,13 @@ function createTerminal(container: HTMLElement, options: UseTerminalOptions): {
     // Skip while hidden — viewportY is stale and fit() can't measure correctly
     if (container.offsetParent === null) return;
 
+    // Reconcile: if flag says unpinned but viewport is actually at bottom,
+    // correct it before acting. Catches any edge case that falsely unpinned.
+    if (!pinnedToBottom && isAtBottom()) {
+      pinnedToBottom = true;
+      options.onScrollStateChange?.(false);
+    }
+
     const savedPinned = pinnedToBottom;
     const savedViewportY = term.buffer.active.viewportY;
 
@@ -160,15 +167,38 @@ function createTerminal(container: HTMLElement, options: UseTerminalOptions): {
     }
   };
 
-  // Update pinned state on xterm scroll events (fires when buffer scrolls from new content)
-  term.onScroll(() => updatePinnedState());
+  // Re-pin when content scrolls us to bottom (e.g. new output while following).
+  // IMPORTANT: onScroll only fires for content-driven scroll (new lines added),
+  // NOT for user wheel/keyboard scroll. During fast output, viewportY can briefly
+  // lag behind baseY, so we must NOT unpin here — only re-pin when at bottom.
+  // Unpinning is handled exclusively by the wheel event listener below.
+  term.onScroll(() => {
+    if (container.offsetParent === null) return;
+    if (isAtBottom()) {
+      pinnedToBottom = true;
+      options.onScrollStateChange?.(false);
+    }
+  });
 
-  // Fallback: wheel events on the container (xterm onScroll may not fire for trackpad/mouse wheel)
+  // User-initiated scroll detection: wheel (trackpad/mouse) and keyboard (PageUp/PageDown).
+  // These are the ONLY events that should unpin — onScroll is content-driven only.
   const wheelHandler = (): void => {
     requestAnimationFrame(() => updatePinnedState());
   };
   container.addEventListener('wheel', wheelHandler, { passive: true });
-  const scrollCleanup = (): void => container.removeEventListener('wheel', wheelHandler);
+
+  const keyScrollHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'PageUp' || e.key === 'PageDown' ||
+        ((e.metaKey || e.ctrlKey) && (e.key === 'ArrowUp' || e.key === 'ArrowDown'))) {
+      requestAnimationFrame(() => updatePinnedState());
+    }
+  };
+  container.addEventListener('keydown', keyScrollHandler);
+
+  const scrollCleanup = (): void => {
+    container.removeEventListener('wheel', wheelHandler);
+    container.removeEventListener('keydown', keyScrollHandler);
+  };
 
   // Debounced PTY resize — sends SIGWINCH once after resizing settles,
   // preventing rapid-fire signals that corrupt TUI cursor positions


### PR DESCRIPTION
## Summary
- **Fixed** the terminal randomly jumping to top during fast Claude Code output in the active pane
- **Root cause**: `term.onScroll` (content-driven only) was calling `updatePinnedState()`, which could falsely unpin during fast output when `viewportY` briefly lags behind `baseY`. If `fitPreservingScroll` fires at that moment, `fit()` resets viewport to line 0.
- **Fix**: `onScroll` now only re-pins (sets `pinnedToBottom = true`), never unpins. Only `wheel` and keyboard scroll events (PageUp/PageDown) can unpin. Added reconciliation check in `fitPreservingScroll` as a safety net.

This is a known class of xterm.js bug — Tabby terminal has the same issue with Claude Code ([Tabby #10648](https://github.com/Eugeny/tabby/issues/10648)). Confirmed by xterm.js issues [#3864](https://github.com/xtermjs/xterm.js/issues/3864) and [#3201](https://github.com/xtermjs/xterm.js/issues/3201) that `onScroll` only fires for content-driven scroll, not user scroll.

## Test plan
- [ ] Run Claude Code in a single pane, let it stream output for 30+ seconds — viewport should stay pinned to bottom
- [ ] Scroll up with wheel/trackpad during output — should unpin, show "Bottom" button
- [ ] Click "Bottom" button — should re-pin and follow output
- [ ] Switch tabs while output is streaming, switch back — should still be pinned to bottom
- [ ] Use PageUp/PageDown during output — should correctly unpin/re-pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)