### PR TITLE
fix(starbase): protect crew PTYs from renderer-driven GC

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -23,6 +23,8 @@ type PtyEntry = {
 
 export class PtyManager {
   private ptys = new Map<string, PtyEntry>();
+  /** PTYs that must not be killed by the renderer-driven GC (e.g. Star Command crews). */
+  private protectedPtys = new Set<string>();
 
   create(opts: PtyCreateOptions): PtyCreateResult {
     if (this.ptys.has(opts.paneId)) {
@@ -64,11 +66,16 @@ export class PtyManager {
     }
   }
 
+  protect(paneId: string): void {
+    this.protectedPtys.add(paneId);
+  }
+
   kill(paneId: string): void {
     const entry = this.ptys.get(paneId);
     if (entry) {
       entry.process.kill();
       this.ptys.delete(paneId);
+      this.protectedPtys.delete(paneId);
     }
   }
 
@@ -103,11 +110,11 @@ export class PtyManager {
     return this.ptys.get(paneId)?.process.pid;
   }
 
-  /** Kill any PTY whose paneId is not in the given set of active IDs. */
+  /** Kill any PTY whose paneId is not in the given set of active IDs (and not protected). */
   gc(activePaneIds: Set<string>): string[] {
     const killed: string[] = [];
     for (const paneId of this.ptys.keys()) {
-      if (!activePaneIds.has(paneId)) {
+      if (!activePaneIds.has(paneId) && !this.protectedPtys.has(paneId)) {
         this.kill(paneId);
         killed.push(paneId);
       }
@@ -127,6 +134,7 @@ export class PtyManager {
     if (entry) {
       entry.process.onExit(({ exitCode }) => {
         this.ptys.delete(paneId);
+        this.protectedPtys.delete(paneId);
         callback(exitCode);
       });
     }

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -80,7 +80,7 @@ export class Hull {
       this.handleTimeout(ptyManager);
     }, timeoutMin * 60 * 1000);
 
-    // Spawn agent PTY
+    // Spawn agent PTY and protect it from the renderer-driven GC
     try {
       const result = ptyManager.create({
         paneId,
@@ -88,6 +88,7 @@ export class Hull {
         cmd: `claude --yes --dangerously-skip-permissions -p "${prompt.replace(/"/g, '\\"')}"`,
       });
       this.pid = result.pid;
+      ptyManager.protect(paneId);
       db.prepare('UPDATE crew SET pid = ? WHERE id = ?').run(result.pid, crewId);
     } catch (err) {
       this.cleanup('error', `Spawn failed: ${err instanceof Error ? err.message : 'unknown'}`);


### PR DESCRIPTION
## Summary
- Star Command crew PTYs were being killed by the 30s renderer-driven GC because they are spawned directly in the main process and never registered in the renderer's workspace store
- Added `protect(paneId)` to `PtyManager` — protected PTYs are skipped by `gc()`
- `Hull.start()` now calls `ptyManager.protect(paneId)` after spawning the crew PTY; protection is automatically released on `kill()` or `onExit()`

## Test plan
- [ ] Deploy a Star Command crew and let it run past 30 seconds — confirm it is not killed
- [ ] Close a regular tab and wait for GC cycle — confirm orphaned renderer PTYs are still cleaned up
- [ ] Recall a crew manually — confirm it is killed correctly and protection is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)