### PR TITLE
fix(starbase): remove hull map leak and prune stale worktrees on startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -154,6 +154,9 @@ app.whenReady().then(() => {
     commandHandler.setPhase2Services(crewService, missionService);
   }
 
+  // Prune stale push-pending worktrees from previous sessions
+  crewService?.pruneStaleWorktrees();
+
   // Start socket API
   socketApi.start().catch((err) => {
     console.error('Failed to start socket API:', err);

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -131,6 +131,7 @@ export class CrewService {
       db,
       lifesignIntervalSec: lifesignSec,
       timeoutMin,
+      onComplete: () => this.hulls.delete(crewId),
     });
 
     // Update crew record with avatar
@@ -174,5 +175,38 @@ export class CrewService {
   observeCrew(crewId: string): string {
     const hull = this.hulls.get(crewId);
     return hull?.getOutputBuffer() ?? '';
+  }
+
+  /**
+   * Remove worktrees for push-pending missions older than maxAgeHours.
+   * Called on startup to recover disk space from previously failed missions.
+   */
+  pruneStaleWorktrees(maxAgeHours = 2): void {
+    const { db, worktreeManager } = this.deps;
+
+    const stale = db.prepare(`
+      SELECT m.id, c.worktree_path, c.sector_path
+      FROM missions m
+      JOIN crew c ON m.crew_id = c.id
+      WHERE m.status = 'push-pending'
+        AND c.created_at < datetime('now', '-${maxAgeHours} hours')
+        AND c.worktree_path IS NOT NULL
+        AND c.sector_path IS NOT NULL
+    `).all() as Array<{ id: number; worktree_path: string; sector_path: string }>;
+
+    for (const row of stale) {
+      try {
+        worktreeManager.remove(row.worktree_path, row.sector_path);
+        db.prepare("UPDATE missions SET status = 'aborted', result = 'Worktree pruned on startup' WHERE id = ?")
+          .run(row.id);
+        console.log(`[starbase] Pruned stale worktree for mission ${row.id}: ${row.worktree_path}`);
+      } catch (err) {
+        console.error(`[starbase] Failed to prune worktree for mission ${row.id}:`, err);
+      }
+    }
+
+    if (stale.length > 0) {
+      console.log(`[starbase] Pruned ${stale.length} stale push-pending worktree(s)`);
+    }
   }
 }

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -14,6 +14,7 @@ export type HullOpts = {
   db: Database.Database;
   lifesignIntervalSec?: number;
   timeoutMin?: number;
+  onComplete?: () => void;
 };
 
 type HullStatus = 'pending' | 'active' | 'complete' | 'error' | 'timeout' | 'aborted';
@@ -243,6 +244,8 @@ export class Hull {
           }
         }
       }
+
+      this.opts.onComplete?.();
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Hull Map leak**: `CrewService.hulls` never removed entries on natural exit — only `recallCrew()` did. Added `onComplete` callback to `HullOpts`, fired from `cleanup()`'s `finally` block, so every exit path (success, error, timeout, abort) removes the hull from the map.
- **Stale worktree pruning**: Push-pending worktrees from failed missions were left on disk indefinitely. Added `CrewService.pruneStaleWorktrees()` which runs on startup and removes worktrees for push-pending missions older than 2 hours, reclaiming disk space.

## Test plan
- [ ] Deploy a crewmate, let it complete naturally — verify hull is removed from internal map (no accumulation across multiple missions)
- [ ] Trigger a push-pending mission (disable network), restart Fleet — verify worktree is pruned and mission status becomes `aborted`
- [ ] Deploy multiple crewmates sequentially — verify memory stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)