### PR TITLE
feat(admiral): add workspace reset, fleet bin path, PTY rewiring

### DIFF
--- a/src/main/__tests__/workspace-templates.test.ts
+++ b/src/main/__tests__/workspace-templates.test.ts
@@ -182,23 +182,36 @@ describe('generateSettings', () => {
     expect(() => JSON.parse(result)).not.toThrow()
   })
 
-  it('includes PreToolUse hook', () => {
+  it('includes PreToolUse hook with correct nested structure', () => {
     const parsed = JSON.parse(generateSettings())
     expect(parsed.hooks).toBeDefined()
     expect(parsed.hooks.PreToolUse).toBeDefined()
     expect(Array.isArray(parsed.hooks.PreToolUse)).toBe(true)
     expect(parsed.hooks.PreToolUse.length).toBeGreaterThan(0)
-  })
 
-  it('PreToolUse hook has fleet comms check command', () => {
-    const parsed = JSON.parse(generateSettings())
-    const hook = parsed.hooks.PreToolUse[0]
+    // Verify nested hooks array with type field (Claude Code settings schema)
+    const matcher = parsed.hooks.PreToolUse[0]
+    expect(matcher.hooks).toBeDefined()
+    expect(Array.isArray(matcher.hooks)).toBe(true)
+    const hook = matcher.hooks[0]
+    expect(hook.type).toBe('command')
     expect(hook.command).toContain('fleet comms check')
   })
 
-  it('hook has a description', () => {
+  it('includes permissions allowing fleet commands', () => {
     const parsed = JSON.parse(generateSettings())
-    const hook = parsed.hooks.PreToolUse[0]
-    expect(hook.description).toBeTruthy()
+    expect(parsed.permissions).toBeDefined()
+    expect(parsed.permissions.allow).toContain('Bash(fleet:*)')
+  })
+
+  it('includes FLEET_BIN_DIR env when fleetBinDir is provided', () => {
+    const parsed = JSON.parse(generateSettings('/home/user/.fleet/bin'))
+    expect(parsed.env).toBeDefined()
+    expect(parsed.env.FLEET_BIN_DIR).toBe('/home/user/.fleet/bin')
+  })
+
+  it('omits env section when fleetBinDir is not provided', () => {
+    const parsed = JSON.parse(generateSettings())
+    expect(parsed.env).toBeUndefined()
   })
 })

--- a/src/main/install-fleet-cli.ts
+++ b/src/main/install-fleet-cli.ts
@@ -52,7 +52,7 @@ exec node "$FLEET_DIR/lib/fleet-cli.js" "$@"
     // Dev mode: resolve the TypeScript source file
     // import.meta.url points to the compiled .mjs in out/main/
     // The TS source lives at src/main/fleet-cli.ts relative to project root
-    const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+    const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
     const tsSource = join(projectRoot, 'src', 'main', 'fleet-cli.ts')
 
     // Write a thin JS entrypoint that delegates to the TS source via tsx

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -208,8 +208,34 @@ export function registerIpcHandlers(
   // Phase 3: Admiral + Comms handlers
   if (admiralProcess) {
     ipcMain.handle(IPC_CHANNELS.ADMIRAL_PANE_ID, () => admiralProcess.paneId)
+
+    // Wire PTY data forwarding for a newly started Admiral pane
+    const wireAdmiralPty = (paneId: string): void => {
+      ptyManager.onData(paneId, (data) => {
+        notificationDetector.scan(paneId, data)
+        const w = getWindow()
+        if (w && !w.isDestroyed()) {
+          w.webContents.send(IPC_CHANNELS.PTY_DATA, { paneId, data })
+        }
+      })
+      ptyManager.onExit(paneId, (exitCode) => {
+        const w = getWindow()
+        if (w && !w.isDestroyed()) {
+          w.webContents.send(IPC_CHANNELS.PTY_EXIT, { paneId, exitCode })
+        }
+        eventBus.emit('pty-exit', { type: 'pty-exit', paneId, exitCode })
+      })
+      cwdPoller.startPolling(paneId, ptyManager.getPid(paneId) ?? 0)
+    }
+
     ipcMain.handle(IPC_CHANNELS.ADMIRAL_RESTART, async () => {
       const paneId = await admiralProcess.restart()
+      wireAdmiralPty(paneId)
+      return paneId
+    })
+    ipcMain.handle(IPC_CHANNELS.ADMIRAL_RESET, async () => {
+      const paneId = await admiralProcess.reset()
+      wireAdmiralPty(paneId)
       return paneId
     })
   }

--- a/src/main/starbase/admiral-process.ts
+++ b/src/main/starbase/admiral-process.ts
@@ -100,9 +100,9 @@ export class AdmiralProcess {
     const skillPath = path.join(this.workspace, '.claude', 'skills', 'fleet', 'SKILL.md')
     fs.writeFileSync(skillPath, generateSkillMd(), 'utf-8')
 
-    // 5. Always overwrite settings
+    // 5. Always overwrite settings (include fleet bin path so Claude can find the CLI)
     const settingsPath = path.join(this.workspace, '.claude', 'settings.json')
-    fs.writeFileSync(settingsPath, generateSettings(), 'utf-8')
+    fs.writeFileSync(settingsPath, generateSettings(this.fleetBinPath), 'utf-8')
   }
 
   async start(): Promise<string> {
@@ -165,6 +165,16 @@ export class AdmiralProcess {
 
   async restart(): Promise<string> {
     await this.stop()
+    return this.start()
+  }
+
+  /**
+   * Stop the Admiral, delete the entire workspace, and restart fresh.
+   * This regenerates CLAUDE.md, skills, settings, and re-inits git.
+   */
+  async reset(): Promise<string> {
+    await this.stop()
+    fs.rmSync(this.workspace, { recursive: true, force: true })
     return this.start()
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -93,6 +93,7 @@ const fleetApi = {
     getPaneId: (): Promise<string | null> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_PANE_ID),
     ensureStarted: (): Promise<string | null> => ipcRenderer.invoke('admiral:ensure-started'),
     restart: (): Promise<string> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_RESTART),
+    reset: (): Promise<string> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_RESET),
     onStatusChanged: (callback: (payload: { status: string; paneId: string | null; error?: string }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: { status: string; paneId: string | null; error?: string }) => callback(payload)
       ipcRenderer.on(IPC_CHANNELS.ADMIRAL_STATUS_CHANGED, handler)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,6 +46,7 @@ export const IPC_CHANNELS = {
   STARBASE_RETENTION_VACUUM: 'starbase:retention-vacuum',
   ADMIRAL_STATUS_CHANGED: 'admiral:status-changed',
   ADMIRAL_RESTART: 'admiral:restart',
+  ADMIRAL_RESET: 'admiral:reset',
   ADMIRAL_PANE_ID: 'admiral:pane-id',
   PTY_DRAIN: 'fleet:pty-drain',
 } as const


### PR DESCRIPTION
## Summary
- Add `admiral:reset` IPC command that nukes the workspace and restarts fresh
- Pass `fleetBinDir` to `generateSettings()` so hooks resolve the fleet binary correctly
- Wire PTY data/exit forwarding after admiral restart/reset to fix detached terminal
- Fix `install-fleet-cli` projectRoot path (was one level too deep)

## Test plan
- [ ] Admiral restart reconnects terminal output
- [ ] Admiral reset creates a fresh workspace with updated CLAUDE.md/settings
- [ ] Fleet CLI hooks work in Admiral workspace (uses full binary path)
- [ ] Workspace-templates tests pass (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)