### PR TITLE
feat(starbase): gate crew deployment on available memory

### DIFF
--- a/src/main/__tests__/crew-service.test.ts
+++ b/src/main/__tests__/crew-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { CrewService } from '../starbase/crew-service';
+import { CrewService, InsufficientMemoryError } from '../starbase/crew-service';
 import { StarbaseDB } from '../starbase/db';
 import { SectorService } from '../starbase/sector-service';
 import { MissionService } from '../starbase/mission-service';
@@ -59,5 +59,23 @@ describe('CrewService', () => {
 
   it('should list crew (empty initially)', () => {
     expect(crewSvc.listCrew()).toHaveLength(0);
+  });
+
+  it('should throw InsufficientMemoryError and queue mission when free RAM is below threshold', async () => {
+    // Set an impossibly high threshold so any real machine will fail the check
+    const configSvc = crewSvc['deps'].configService;
+    configSvc.set('min_deploy_free_memory_gb', 999999);
+
+    const mockPtyManager = {} as Parameters<typeof crewSvc.deployCrew>[1];
+    const createTab = () => 'tab-1';
+
+    await expect(
+      crewSvc.deployCrew({ sectorId: 'api', prompt: 'do something' }, mockPtyManager, createTab)
+    ).rejects.toBeInstanceOf(InsufficientMemoryError);
+
+    // Mission should be created and queued (not failed)
+    const missions = db.getDb().prepare("SELECT status FROM missions WHERE sector_id = 'api'").all() as { status: string }[];
+    expect(missions).toHaveLength(1);
+    expect(missions[0].status).toBe('queued');
   });
 });

--- a/src/main/starbase/available-memory.ts
+++ b/src/main/starbase/available-memory.ts
@@ -1,0 +1,39 @@
+import { freemem } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Returns available system memory in bytes.
+ *
+ * On macOS, os.freemem() only reports truly "free" pages — memory that macOS
+ * hasn't assigned to anything. But macOS aggressively caches files in RAM, so
+ * "free" is often tiny (< 500 MB) even when gigabytes are *available* (free +
+ * inactive + purgeable). This causes false memory_warning alerts.
+ *
+ * This function parses `vm_stat` on macOS to compute available memory as
+ * (free + inactive) * page_size, which matches what Activity Monitor reports.
+ * On other platforms it falls back to os.freemem().
+ */
+export async function getAvailableMemoryBytes(): Promise<number> {
+  if (process.platform === 'darwin') {
+    try {
+      const { stdout } = await execFileAsync('vm_stat', [], { timeout: 5_000 });
+
+      const pageSize = parseInt(stdout.match(/page size of (\d+) bytes/)?.[1] ?? '0', 10);
+      if (pageSize === 0) return freemem();
+
+      const free = parseInt(stdout.match(/Pages free:\s+(\d+)/)?.[1] ?? '0', 10);
+      const inactive = parseInt(stdout.match(/Pages inactive:\s+(\d+)/)?.[1] ?? '0', 10);
+
+      const availableBytes = (free + inactive) * pageSize;
+      // Sanity check — if parsing went wrong, fall back
+      return availableBytes > 0 ? availableBytes : freemem();
+    } catch {
+      return freemem();
+    }
+  }
+
+  return freemem();
+}

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
 import { randomBytes } from 'crypto';
+import { getAvailableMemoryBytes } from './available-memory';
 import type { SectorService } from './sector-service';
 import type { MissionService } from './mission-service';
 import type { ConfigService } from './config-service';
@@ -7,6 +8,13 @@ import { WorktreeLimitError, type WorktreeManager } from './worktree-manager';
 import { Hull } from './hull';
 import type { PtyManager } from '../pty-manager';
 import type { EventBus } from '../event-bus';
+
+export class InsufficientMemoryError extends Error {
+  constructor(freeGb: number, requiredGb: number) {
+    super(`Insufficient memory to deploy crew: ${freeGb.toFixed(2)}GB free, ${requiredGb}GB required`);
+    this.name = 'InsufficientMemoryError';
+  }
+}
 
 type CrewRow = {
   id: string;
@@ -73,7 +81,7 @@ export class CrewService {
 
     const baseBranch = sector.base_branch || 'main';
 
-    // 2. Create mission if not provided
+    // 2. Create mission if not provided (before memory gate so we can queue it on failure)
     let missionId = opts.missionId;
     if (!missionId) {
       const mission = missionService.addMission({
@@ -84,7 +92,15 @@ export class CrewService {
       missionId = mission.id;
     }
 
-    // 3. Generate crew ID
+    // 3. Memory gate — queue the mission instead of deploying if free RAM is insufficient
+    const minFreeGb = configService.get('min_deploy_free_memory_gb') as number;
+    const availableGb = (await getAvailableMemoryBytes()) / (1024 * 1024 * 1024);
+    if (availableGb < minFreeGb) {
+      db.prepare("UPDATE missions SET status = 'queued' WHERE id = ?").run(missionId);
+      throw new InsufficientMemoryError(availableGb, minFreeGb);
+    }
+
+    // 4. Generate crew ID
     const crewId = this.generateCrewId(sector.id);
 
     // 4. Create worktree

--- a/src/main/starbase/migrations.ts
+++ b/src/main/starbase/migrations.ts
@@ -151,5 +151,6 @@ export const CONFIG_DEFAULTS: Record<string, unknown> = {
   comms_retention_days: 30,
   cargo_retention_days: 14,
   ships_log_retention_days: 30,
-  forward_failed_cargo: false
+  forward_failed_cargo: false,
+  min_deploy_free_memory_gb: 1.5
 }

--- a/src/main/starbase/sentinel.ts
+++ b/src/main/starbase/sentinel.ts
@@ -2,9 +2,9 @@ import type Database from 'better-sqlite3';
 import { existsSync } from 'fs';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { freemem } from 'os';
 import type { ConfigService } from './config-service';
 import type { EventBus } from '../event-bus';
+import { getAvailableMemoryBytes } from './available-memory';
 
 const execFileAsync = promisify(execFile);
 
@@ -33,6 +33,8 @@ export class Sentinel {
   private sweepCount = 0;
   private diskCacheBytes: number | null = null;
   private diskCacheTime = 0;
+  /** Last sent alert level per type — only re-send when level changes or clears */
+  private lastAlertLevel: Record<string, string | null> = {};
 
   constructor(private deps: SentinelDeps) {}
 
@@ -129,20 +131,28 @@ export class Sentinel {
     if (diskBytes !== null) {
       const usedGb = diskBytes / (1024 * 1024 * 1024);
       const pct = (usedGb / diskBudgetGb) * 100;
-      if (pct >= 90) {
+      const diskLevel = pct >= 90 ? 'warning' : null;
+      if (diskLevel && this.lastAlertLevel['disk_warning'] !== diskLevel) {
+        this.lastAlertLevel['disk_warning'] = diskLevel;
         db.prepare(
           "INSERT INTO comms (to_crew, type, payload) VALUES ('admiral', 'disk_warning', ?)",
         ).run(JSON.stringify({ usedGb: usedGb.toFixed(2), budgetGb: diskBudgetGb, percent: pct.toFixed(0) }));
+      } else if (!diskLevel) {
+        this.lastAlertLevel['disk_warning'] = null;
       }
     }
 
-    // 6. System memory check
-    const freeBytes = freemem();
-    const freeGb = freeBytes / (1024 * 1024 * 1024);
-    if (freeGb < 1) {
+    // 6. System memory check (uses available memory, not just free pages)
+    const availableBytes = await getAvailableMemoryBytes();
+    const availableGb = availableBytes / (1024 * 1024 * 1024);
+    const memLevel = availableGb < 0.5 ? 'critical' : availableGb < 1 ? 'warning' : null;
+    if (memLevel && this.lastAlertLevel['memory_warning'] !== memLevel) {
+      this.lastAlertLevel['memory_warning'] = memLevel;
       db.prepare(
         "INSERT INTO comms (to_crew, type, payload) VALUES ('admiral', 'memory_warning', ?)",
-      ).run(JSON.stringify({ freeGb: freeGb.toFixed(2), level: freeGb < 0.5 ? 'critical' : 'warning' }));
+      ).run(JSON.stringify({ freeMemoryGb: availableGb.toFixed(2), level: memLevel }));
+    } else if (!memLevel) {
+      this.lastAlertLevel['memory_warning'] = null;
     }
 
     // 7. Comms rate limit reset (every 6th sweep = ~60 seconds)


### PR DESCRIPTION
## Summary
- Check available system memory before deploying crew; queue mission if below threshold (default 1.5GB)
- Switch sentinel from `os.freemem()` to actual available memory (includes reclaimable cache)
- Add alert-level deduplication so sentinel doesn't spam repeated disk/memory warnings

## Test plan
- [ ] Deploy crew with sufficient RAM — deploys normally
- [ ] Set `min_deploy_free_memory_gb` to 999999 — mission gets queued, throws InsufficientMemoryError
- [ ] Sentinel memory warnings only fire when level changes (not every sweep)
- [ ] crew-service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)