### PR TITLE
fix(renderer): restore parseUnifiedDiff hunk extraction for @git-diff-view/core

### DIFF
--- a/src/renderer/src/components/GitChangesModal.tsx
+++ b/src/renderer/src/components/GitChangesModal.tsx
@@ -57,6 +57,10 @@ export function GitChangesModal({ isOpen, onClose, cwd }: GitChangesModalProps) 
     window.fleet.git.getStatus(cwd).then((result) => {
       setData(result);
       setLoading(false);
+    }).catch((err) => {
+      console.error('Failed to fetch git status:', err);
+      setData({ isRepo: true, branch: '', files: [], diff: '', error: String(err) });
+      setLoading(false);
     });
   }, [isOpen, cwd]);
 

--- a/src/renderer/src/components/__tests__/parseUnifiedDiff.test.ts
+++ b/src/renderer/src/components/__tests__/parseUnifiedDiff.test.ts
@@ -92,4 +92,38 @@ index 0000000..abc1234
     expect(result[0].hunks[0].startsWith('@@')).toBe(true);
     expect(result[0].hunks[0]).not.toContain('new file mode');
   });
+
+  it('binary file diffs produce empty hunks array', () => {
+    const diff = `diff --git a/image.png b/image.png
+index abc1234..def5678 100644
+Binary files a/image.png and b/image.png differ`;
+
+    const result = parseUnifiedDiff(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].fileName).toBe('image.png');
+    expect(result[0].hunks).toEqual([]);
+  });
+
+  it('handles renamed file diffs correctly', () => {
+    const diff = `diff --git a/old-name.ts b/new-name.ts
+similarity index 95%
+rename from old-name.ts
+rename to new-name.ts
+index abc1234..def5678 100644
+--- a/old-name.ts
++++ b/new-name.ts
+@@ -1,3 +1,3 @@
+ line1
+-old
++new
+ line3`;
+
+    const result = parseUnifiedDiff(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].fileName).toBe('new-name.ts');
+    expect(result[0].hunks).toHaveLength(1);
+    expect(result[0].hunks[0].startsWith('@@')).toBe(true);
+    expect(result[0].hunks[0]).not.toContain('rename from');
+    expect(result[0].hunks[0]).not.toContain('similarity index');
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed parseUnifiedDiff to correctly produce @@-prefixed hunk strings for @git-diff-view/core
- Added unit tests for the parsing logic
- Fixed unhandled promise rejection in useEffect IPC call

## Test plan
- Unit tests for parseUnifiedDiff cover single/multi-file, binary, renamed, and empty diffs
- Manual verification that diff modal renders additions/deletions correctly