### PR TITLE
feat(hull): set crew claude sessions to use sonnet 4.6 model

### DIFF
--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -116,7 +116,7 @@ export class Hull {
       const result = ptyManager.create({
         paneId,
         cwd: worktreePath,
-        cmd: `claude --dangerously-skip-permissions -p "Read and execute the mission prompt in ${promptFile}. Delete the file when done."`,
+        cmd: `claude --dangerously-skip-permissions --model claude-sonnet-4-6 -p "Read and execute the mission prompt in ${promptFile}. Delete the file when done."`,
         env: this.opts.env
       })
       this.pid = result.pid


### PR DESCRIPTION
Crew Claude Code sessions were using the default model. Explicitly pass --model claude-sonnet-4-6 to the claude CLI invocation so crew agents use Sonnet 4.6 consistently.