### PR TITLE
feat(starbase): interactive crew sessions with stream-json protocol

### DIFF
--- a/src/main/__tests__/crew-service.test.ts
+++ b/src/main/__tests__/crew-service.test.ts
@@ -67,11 +67,8 @@ describe('CrewService', () => {
     const configSvc = crewSvc['deps'].configService;
     configSvc.set('min_deploy_free_memory_gb', 999999);
 
-    const mockPtyManager = {} as Parameters<typeof crewSvc.deployCrew>[1];
-    const createTab = () => 'tab-1';
-
     await expect(
-      crewSvc.deployCrew({ sectorId: 'api', prompt: 'do something' }, mockPtyManager, createTab)
+      crewSvc.deployCrew({ sectorId: 'api', prompt: 'do something' })
     ).rejects.toBeInstanceOf(InsufficientMemoryError);
 
     // Mission should be created and queued (not failed)

--- a/src/main/__tests__/hull.test.ts
+++ b/src/main/__tests__/hull.test.ts
@@ -1,12 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { Hull, HullOpts } from '../starbase/hull'
 import { StarbaseDB } from '../starbase/db'
 import { SectorService } from '../starbase/sector-service'
 import { MissionService } from '../starbase/mission-service'
-import { rmSync, mkdirSync, writeFileSync, existsSync } from 'fs'
+import { rmSync, mkdirSync, writeFileSync } from 'fs'
 import { execSync } from 'child_process'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { EventEmitter } from 'events'
+
+// Mock child_process.spawn before importing Hull (ESM modules need top-level mock)
+let mockProc: any = null
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    spawn: vi.fn((..._args: any[]) => mockProc),
+  }
+})
+
+// Import Hull AFTER mock is set up
+import { Hull, HullOpts } from '../starbase/hull'
 
 const TEST_DIR = join(tmpdir(), 'fleet-test-hull')
 const WORKSPACE_DIR = join(TEST_DIR, 'workspace')
@@ -89,39 +102,24 @@ describe('Hull', () => {
 /**
  * Gate 2 tests: verify_command and lint_command
  *
- * These tests exercise the cleanup method by mocking child_process.execSync
- * and using a mock PtyManager to trigger the exit handler.
+ * These tests exercise the cleanup method by mocking child_process.spawn
+ * and triggering the exit event on the mock process.
  */
 describe('Hull Gate 2 — verify and lint', () => {
-  // We need to intercept execSync calls to simulate verify/lint behavior
-  // while still allowing real git commands to work in beforeEach.
-  // Strategy: create a hull in 'active' state via start(), then trigger
-  // cleanup via the onExit callback.
-
-  function createMockPtyManager() {
-    const handlers: Record<
-      string,
-      { onData?: (d: string) => void; onExit?: (code: number) => void }
-    > = {}
-    return {
-      create: vi.fn(({ paneId }: { paneId: string }) => {
-        handlers[paneId] = {}
-        return { pid: 12345 }
-      }),
-      onData: vi.fn((paneId: string, cb: (d: string) => void) => {
-        if (handlers[paneId]) handlers[paneId].onData = cb
-      }),
-      onExit: vi.fn((paneId: string, cb: (code: number) => void) => {
-        if (handlers[paneId]) handlers[paneId].onExit = cb
-      }),
-      has: vi.fn(() => false),
-      kill: vi.fn(),
-      protect: vi.fn(),
-      triggerExit: (paneId: string, code: number) => {
-        handlers[paneId]?.onExit?.(code)
-      }
-    }
+  function createMockProcess() {
+    const proc = new EventEmitter() as any
+    proc.stdin = { write: vi.fn(), end: vi.fn(), writable: true }
+    proc.stdout = new EventEmitter()
+    proc.stderr = new EventEmitter()
+    proc.killed = false
+    proc.pid = 12345
+    proc.kill = vi.fn()
+    return proc
   }
+
+  beforeEach(() => {
+    mockProc = createMockProcess()
+  })
 
   function makeOpts(overrides: Partial<HullOpts> = {}): HullOpts {
     const mission = missionSvc.addMission({
@@ -149,22 +147,14 @@ describe('Hull Gate 2 — verify and lint', () => {
 
   // Helper: create worktree dir with a change so hasChanges=true
   // Sets up a bare remote so git push succeeds instantly.
-  // Uses the sector dir as the main repo and creates a proper worktree from it.
   function setupWorktreeWithChange() {
-    // Create bare remote
     mkdirSync(BARE_REMOTE_DIR, { recursive: true })
     execSync('git init --bare', { cwd: BARE_REMOTE_DIR })
-
-    // Add remote to sector dir and push
     execSync(`git remote add origin "${BARE_REMOTE_DIR}"`, { cwd: SECTOR_DIR })
     execSync('git push -u origin main', { cwd: SECTOR_DIR })
-
-    // Create worktree branch in sector and set up worktree dir
     execSync('git branch crew/test-branch main', { cwd: SECTOR_DIR })
     mkdirSync(join(TEST_DIR, 'worktrees', 'test-sb'), { recursive: true })
     execSync(`git worktree add "${WORKTREE_DIR}" crew/test-branch`, { cwd: SECTOR_DIR })
-
-    // Make a change in the worktree
     writeFileSync(join(WORKTREE_DIR, 'new-file.txt'), 'new content')
     execSync('git add -A && git commit -m "work"', { cwd: WORKTREE_DIR })
   }
@@ -172,11 +162,14 @@ describe('Hull Gate 2 — verify and lint', () => {
   it('verify command pass — continues to PR creation', { timeout: 60_000 }, async () => {
     setupWorktreeWithChange()
     const opts = makeOpts({ verifyCommand: 'echo "tests passed"' })
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-1')
-    pty.triggerExit('pane-1', 0)
+    await hull.start()
+    // Trigger exit on the mock process
+    mockProc.emit('exit', 0)
+
+    // Wait for cleanup to complete
+    await new Promise((r) => setTimeout(r, 500))
 
     // Verify result should be stored
     const row = db
@@ -194,11 +187,12 @@ describe('Hull Gate 2 — verify and lint', () => {
   it('verify command fail — sets failed-verification, no PR', { timeout: 60_000 }, async () => {
     setupWorktreeWithChange()
     const opts = makeOpts({ verifyCommand: 'exit 1' })
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-2')
-    pty.triggerExit('pane-2', 0)
+    await hull.start()
+    mockProc.emit('exit', 0)
+
+    await new Promise((r) => setTimeout(r, 500))
 
     const row = db
       .getDb()
@@ -225,17 +219,13 @@ describe('Hull Gate 2 — verify and lint', () => {
     { timeout: 60_000 },
     async () => {
       setupWorktreeWithChange()
-      // Use a command that sleeps longer than timeout; we set a very short timeout via the command itself
-      // Since we can't easily set a <1s timeout on execSync, we test the error shape instead.
-      // We'll use a command that fails with killed=true simulation.
-      // Actually, let's just use 'sleep 200' with the real 120s timeout — that's too slow.
-      // Instead, use a verify command that we know will fail and check the structure.
       const opts = makeOpts({ verifyCommand: 'false' }) // exits with code 1
-      const pty = createMockPtyManager()
       const hull = new Hull(opts)
 
-      await hull.start(pty as any, 'pane-timeout')
-      pty.triggerExit('pane-timeout', 0)
+      await hull.start()
+      mockProc.emit('exit', 0)
+
+      await new Promise((r) => setTimeout(r, 500))
 
       const row = db
         .getDb()
@@ -250,13 +240,13 @@ describe('Hull Gate 2 — verify and lint', () => {
 
   it('lint warnings — PR gets lint-warnings label in comms', { timeout: 60_000 }, async () => {
     setupWorktreeWithChange()
-    // lint command that exits non-zero (warnings)
     const opts = makeOpts({ lintCommand: 'echo "warning: unused var" && exit 1' })
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-lint')
-    pty.triggerExit('pane-lint', 0)
+    await hull.start()
+    mockProc.emit('exit', 0)
+
+    await new Promise((r) => setTimeout(r, 500))
 
     // Mission should NOT be failed-verification (lint is non-blocking)
     const row = db
@@ -279,11 +269,12 @@ describe('Hull Gate 2 — verify and lint', () => {
   it('no verify/lint commands — existing behavior unchanged', { timeout: 60_000 }, async () => {
     setupWorktreeWithChange()
     const opts = makeOpts() // no verifyCommand, no lintCommand
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-noop')
-    pty.triggerExit('pane-noop', 0)
+    await hull.start()
+    mockProc.emit('exit', 0)
+
+    await new Promise((r) => setTimeout(r, 500))
 
     const row = db
       .getDb()
@@ -301,11 +292,12 @@ describe('Hull Gate 2 — verify and lint', () => {
       verifyCommand: 'echo "ok"',
       lintCommand: 'echo "warn: something" && exit 1'
     })
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-both')
-    pty.triggerExit('pane-both', 0)
+    await hull.start()
+    mockProc.emit('exit', 0)
+
+    await new Promise((r) => setTimeout(r, 500))
 
     const row = db
       .getDb()
@@ -336,30 +328,20 @@ describe('Hull Gate 2 — verify and lint', () => {
  * and sets mission status to 'pending-review'. Also verifies other review modes don't trigger this.
  */
 describe('Hull Gate 3 — Admiral review', () => {
-  function createMockPtyManager() {
-    const handlers: Record<
-      string,
-      { onData?: (d: string) => void; onExit?: (code: number) => void }
-    > = {}
-    return {
-      create: vi.fn(({ paneId }: { paneId: string }) => {
-        handlers[paneId] = {}
-        return { pid: 12345 }
-      }),
-      onData: vi.fn((paneId: string, cb: (d: string) => void) => {
-        if (handlers[paneId]) handlers[paneId].onData = cb
-      }),
-      onExit: vi.fn((paneId: string, cb: (code: number) => void) => {
-        if (handlers[paneId]) handlers[paneId].onExit = cb
-      }),
-      has: vi.fn(() => false),
-      kill: vi.fn(),
-      protect: vi.fn(),
-      triggerExit: (paneId: string, code: number) => {
-        handlers[paneId]?.onExit?.(code)
-      }
-    }
+  function createMockProcess() {
+    const proc = new EventEmitter() as any
+    proc.stdin = { write: vi.fn(), end: vi.fn(), writable: true }
+    proc.stdout = new EventEmitter()
+    proc.stderr = new EventEmitter()
+    proc.killed = false
+    proc.pid = 12345
+    proc.kill = vi.fn()
+    return proc
   }
+
+  beforeEach(() => {
+    mockProc = createMockProcess()
+  })
 
   function makeOpts(overrides: Partial<HullOpts> = {}): HullOpts {
     const mission = missionSvc.addMission({
@@ -404,11 +386,12 @@ describe('Hull Gate 3 — Admiral review', () => {
     async () => {
       setupWorktreeWithChange()
       const opts = makeOpts({ reviewMode: 'admiral-review' })
-      const pty = createMockPtyManager()
       const hull = new Hull(opts)
 
-      await hull.start(pty as any, 'pane-review-1')
-      pty.triggerExit('pane-review-1', 0)
+      await hull.start()
+      mockProc.emit('exit', 0)
+
+      await new Promise((r) => setTimeout(r, 500))
 
       // gh pr create will fail (no real GitHub), so pr_review_request won't be sent
       // but the mission_complete comms should still be sent
@@ -432,11 +415,12 @@ describe('Hull Gate 3 — Admiral review', () => {
   it('verify-only mode — no pr_review_request comms sent', { timeout: 60_000 }, async () => {
     setupWorktreeWithChange()
     const opts = makeOpts({ reviewMode: 'verify-only' })
-    const pty = createMockPtyManager()
     const hull = new Hull(opts)
 
-    await hull.start(pty as any, 'pane-review-2')
-    pty.triggerExit('pane-review-2', 0)
+    await hull.start()
+    mockProc.emit('exit', 0)
+
+    await new Promise((r) => setTimeout(r, 500))
 
     // No pr_review_request comms should exist
     const reviewComms = db
@@ -459,11 +443,12 @@ describe('Hull Gate 3 — Admiral review', () => {
     async () => {
       setupWorktreeWithChange()
       const opts = makeOpts() // no reviewMode
-      const pty = createMockPtyManager()
       const hull = new Hull(opts)
 
-      await hull.start(pty as any, 'pane-review-3')
-      pty.triggerExit('pane-review-3', 0)
+      await hull.start()
+      mockProc.emit('exit', 0)
+
+      await new Promise((r) => setTimeout(r, 500))
 
       // No pr_review_request comms should exist
       const reviewComms = db

--- a/src/main/__tests__/socket-server.test.ts
+++ b/src/main/__tests__/socket-server.test.ts
@@ -64,9 +64,11 @@ function makeMockServices() {
 
   const crewService = {
     listCrew: vi.fn().mockReturnValue([]),
-    deployCrew: vi.fn().mockResolvedValue({ crewId: 'crew-1', tabId: 'tab-1', missionId: 1 }),
+    deployCrew: vi.fn().mockResolvedValue({ crewId: 'crew-1', missionId: 1 }),
     recallCrew: vi.fn(),
     observeCrew: vi.fn().mockReturnValue('some output'),
+    messageCrew: vi.fn().mockReturnValue(false),
+    getCrewStatus: vi.fn().mockReturnValue(null),
   };
 
   const cargoService = {
@@ -85,20 +87,11 @@ function makeMockServices() {
     set: vi.fn(),
   };
 
-  const ptyManager = {
-    create: vi.fn(),
-    kill: vi.fn(),
-    write: vi.fn(),
-    has: vi.fn().mockReturnValue(false),
-  };
-
   const shipsLog = {
     query: vi.fn().mockReturnValue([{ id: 1, event_type: 'deployed', created_at: '2026-01-01' }]),
     getRecent: vi.fn().mockReturnValue([]),
     log: vi.fn().mockReturnValue(1),
   };
-
-  const createTab = vi.fn().mockReturnValue('tab-uuid');
 
   return {
     sectorService,
@@ -108,9 +101,7 @@ function makeMockServices() {
     cargoService,
     supplyRouteService,
     configService,
-    ptyManager,
     shipsLog,
-    createTab,
   };
 }
 

--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -186,6 +186,9 @@ const COMMAND_MAP: Record<string, string> = {
   'crew.kill': 'crew.recall',
   'crew.stop': 'crew.recall',
   'crew.remove': 'crew.recall',
+  'crew.message': 'crew.message',
+  'crew.msg': 'crew.message',
+  'crew.send': 'crew.message',
 
   // Comms (CLI "inbox" maps to comms.list)
   'comms.inbox': 'comms.list',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -191,20 +191,7 @@ app.whenReady().then(async () => {
       PATH: fleetBinPath + ':' + (process.env.PATH ?? '')
     }
 
-    // Buffer crew PTY data until the renderer signals it's ready via PTY_ATTACH.
-    // Before attach: data accumulates in crewPtyBuffers.
-    // After attach: data flows via PTY_DATA IPC as normal.
-    const crewPtyBuffers = new Map<string, string[]>()
-    const crewPtyAttached = new Set<string>()
-
-    ipcMain.handle(IPC_CHANNELS.PTY_ATTACH, (_event, { paneId }: { paneId: string }) => {
-      const buffer = crewPtyBuffers.get(paneId)
-      const data = buffer ? buffer.join('') : ''
-      crewPtyBuffers.delete(paneId)
-      crewPtyAttached.add(paneId)
-      return { data }
-    })
-
+    // Crews are headless (stream-json, no PTY/tab). No PTY buffer wiring needed.
     crewService = new CrewService({
       db: starbaseDb.getDb(),
       starbaseId: starbaseDb.getStarbaseId(),
@@ -214,30 +201,6 @@ app.whenReady().then(async () => {
       worktreeManager,
       eventBus,
       crewEnv,
-      onPtyData: (paneId, data) => {
-        notificationDetector.scan(paneId, data)
-        if (crewPtyAttached.has(paneId)) {
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send(IPC_CHANNELS.PTY_DATA, { paneId, data })
-          }
-        } else {
-          let buf = crewPtyBuffers.get(paneId)
-          if (!buf) {
-            buf = []
-            crewPtyBuffers.set(paneId, buf)
-          }
-          buf.push(data)
-        }
-      },
-      onPtyExit: (paneId, exitCode) => {
-        cwdPoller.stopPolling(paneId)
-        crewPtyBuffers.delete(paneId)
-        crewPtyAttached.delete(paneId)
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send(IPC_CHANNELS.PTY_EXIT, { paneId, exitCode })
-        }
-        eventBus.emit('pty-exit', { type: 'pty-exit', paneId, exitCode })
-      },
     })
 
     // Phase 3 services
@@ -245,8 +208,9 @@ app.whenReady().then(async () => {
     const commsRateLimit = configService.get('comms_rate_limit_per_min') as number
     commsService.setRateLimit(commsRateLimit)
 
-    // Buffer create-tab messages until renderer signals it's ready to receive them.
-    // Prevents race where crew deploys via socket arrive before React mounts.
+    // TODO(#30): createTab and its buffering are no longer used by crew deploys — crews are
+    // now headless (stream-json, no terminal tab). This code remains for backwards compatibility
+    // and potential future use. Remove when crew tab UI is fully deprecated.
     const pendingCreateTabs: Array<{ tabId: string; label: string; cwd: string; avatarVariant?: string }> = []
     let rendererTabListenerReady = false
 
@@ -281,8 +245,6 @@ app.whenReady().then(async () => {
       cargoService: cargoService!,
       supplyRouteService: supplyRouteService!,
       configService: configService!,
-      ptyManager,
-      createTab,
       shipsLog,
     })
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -175,19 +175,15 @@ export function registerIpcHandlers(
   // Phase 2: Deploy/Recall/Crew/Missions handlers
   if (crewService && missionService) {
     ipcMain.handle(IPC_CHANNELS.STARBASE_DEPLOY, async (_e, req) => {
-      const createTab = (label: string, cwd: string, avatarVariant?: string): string => {
-        const tabId = crypto.randomUUID()
-        const w = getWindow()
-        if (w && !w.isDestroyed()) {
-          w.webContents.send('fleet:create-tab', { tabId, label, cwd, avatarVariant })
-        }
-        return tabId
-      }
-      return crewService.deployCrew(req, ptyManager, createTab)
+      return crewService.deployCrew(req)
     })
 
     ipcMain.handle(IPC_CHANNELS.STARBASE_RECALL, (_e, { crewId }) => {
-      crewService.recallCrew(crewId, ptyManager)
+      crewService.recallCrew(crewId)
+    })
+
+    ipcMain.handle(IPC_CHANNELS.STARBASE_MESSAGE_CREW, (_e, { crewId, message }) => {
+      return crewService.messageCrew(crewId, message)
     })
 
     ipcMain.handle(IPC_CHANNELS.STARBASE_CREW, (_e, filter?) => {

--- a/src/main/socket-command-handler.ts
+++ b/src/main/socket-command-handler.ts
@@ -227,28 +227,15 @@ export class FleetCommandHandler implements SocketCommandHandler {
       // Phase 2: Deploy/Recall/Crew/Missions
       case 'deploy': {
         if (!this.crewService) return { ok: false, error: 'Star Command Phase 2 not initialized' };
-        const createTab = (label: string, cwd: string): string => {
-          const tabId = randomUUID();
-          const leaf: PaneLeaf = { type: 'leaf', id: randomUUID(), cwd };
-          const tab: Tab = { id: tabId, label, labelIsCustom: false, cwd, splitRoot: leaf };
-          this.workspace.tabs.push(tab);
-          this.tabs.set(tabId, tab);
-
-          this.ptyManager.create({ paneId: leaf.id, cwd, cmd: cmd.cmd as string | undefined });
-          this.eventBus.emit('pane-created', { type: 'pane-created', paneId: leaf.id });
-          return tabId;
-        };
         const result = await this.crewService.deployCrew(
           { sectorId: cmd.sectorId as string, prompt: cmd.prompt as string, missionId: cmd.missionId as number | undefined },
-          this.ptyManager,
-          createTab,
         );
         return { ok: true, ...result };
       }
 
       case 'recall':
         if (!this.crewService) return { ok: false, error: 'Star Command Phase 2 not initialized' };
-        this.crewService.recallCrew(cmd.crewId as string, this.ptyManager);
+        this.crewService.recallCrew(cmd.crewId as string);
         return { ok: true };
 
       case 'crew':

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -9,7 +9,6 @@ import type { SectorService } from './starbase/sector-service';
 import type { CargoService } from './starbase/cargo-service';
 import type { SupplyRouteService } from './starbase/supply-route-service';
 import type { ConfigService } from './starbase/config-service';
-import type { PtyManager } from './pty-manager';
 import type { ShipsLog } from './starbase/ships-log';
 
 export interface ServiceRegistry {
@@ -20,8 +19,6 @@ export interface ServiceRegistry {
   cargoService: CargoService;
   supplyRouteService: SupplyRouteService;
   configService: ConfigService;
-  ptyManager: PtyManager;
-  createTab: (label: string, cwd: string, avatarVariant?: string) => string;
   shipsLog: ShipsLog;
 }
 
@@ -172,8 +169,6 @@ export class SocketServer extends EventEmitter {
       cargoService,
       supplyRouteService,
       configService,
-      ptyManager,
-      createTab,
       shipsLog,
     } = this.services;
 
@@ -234,22 +229,18 @@ export class SocketServer extends EventEmitter {
           }
         }
 
-        const result = await crewService.deployCrew(
-          {
-            sectorId: (args.sector ?? args.sectorId) as string,
-            prompt,
-            missionId,
-          },
-          ptyManager,
-          createTab,
-        );
+        const result = await crewService.deployCrew({
+          sectorId: (args.sector ?? args.sectorId) as string,
+          prompt,
+          missionId,
+        });
         this.emit('state-change', 'crew:changed', result);
         return result;
       }
 
       case 'crew.recall': {
         const crewId = (args.id ?? args.crewId) as string;
-        crewService.recallCrew(crewId, ptyManager);
+        crewService.recallCrew(crewId);
         this.emit('state-change', 'crew:changed', { crewId, status: 'recalled' });
         return null;
       }
@@ -263,6 +254,24 @@ export class SocketServer extends EventEmitter {
         const id = (args.id ?? args.crewId) as string;
         const raw = crewService.observeCrew(id);
         return stripAnsi(raw);
+      }
+
+      case 'crew.message': {
+        const crewId = (args.id ?? args.crewId) as string;
+        const message = (args.message ?? args.text) as string;
+        if (!crewId || !message) {
+          const err = new Error('crew.message requires id and message') as Error & { code: string };
+          err.code = 'BAD_REQUEST';
+          throw err;
+        }
+        const sent = crewService.messageCrew(crewId, message);
+        if (!sent) {
+          const err = new Error(`Crew not active: ${crewId}`) as Error & { code: string };
+          err.code = 'NOT_FOUND';
+          throw err;
+        }
+        this.emit('state-change', 'crew:changed', { crewId });
+        return { sent: true };
       }
 
       // ── Comms ─────────────────────────────────────────────────────────────────
@@ -279,14 +288,23 @@ export class SocketServer extends EventEmitter {
       }
 
       case 'comms.send': {
+        const to = args.to as string;
+        const payload = (args.message ?? args.payload ?? '') as string;
         const id = commsService.send({
           from: (args.from ?? 'admiral') as string,
-          to: args.to as string,
+          to,
           type: (args.type ?? 'directive') as string,
-          payload: (args.message ?? args.payload ?? '') as string,
+          payload,
         });
         this.emit('state-change', 'comms:changed', { id });
-        return { id };
+
+        // Auto-inject into active crew's Claude Code process if target is a live crew
+        let injected = false;
+        if (to && to !== 'admiral') {
+          injected = crewService.messageCrew(to, payload);
+        }
+
+        return { id, injected };
       }
 
       case 'comms.delete': {

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -6,7 +6,6 @@ import type { MissionService } from './mission-service';
 import type { ConfigService } from './config-service';
 import { WorktreeLimitError, type WorktreeManager } from './worktree-manager';
 import { Hull } from './hull';
-import type { PtyManager } from '../pty-manager';
 import type { EventBus } from '../event-bus';
 
 export class InsufficientMemoryError extends Error {
@@ -44,17 +43,12 @@ type CrewServiceDeps = {
   configService: ConfigService;
   worktreeManager: WorktreeManager;
   eventBus?: EventBus;
-  /** Enriched env for crew PTYs (PATH with claude binary). */
+  /** Enriched env for crew processes (PATH with claude binary). */
   crewEnv?: Record<string, string>;
-  /** Forward crew PTY data to renderer. */
-  onPtyData?: (paneId: string, data: string) => void;
-  /** Forward crew PTY exit to renderer. */
-  onPtyExit?: (paneId: string, exitCode: number) => void;
 };
 
 type DeployResult = {
   crewId: string;
-  tabId: string;
   missionId: number;
 };
 
@@ -71,13 +65,11 @@ export class CrewService {
   }
 
   /**
-   * Deploy a Crewmate. Returns { crewId, tabId, missionId }.
-   * Caller must provide a PtyManager and a way to create tabs.
+   * Deploy a Crewmate. Returns { crewId, missionId }.
+   * Crews are headless (no terminal tab) — they use stream-json for communication.
    */
   async deployCrew(
     opts: { sectorId: string; prompt: string; missionId?: number },
-    ptyManager: PtyManager,
-    createTab: (label: string, cwd: string, avatarVariant?: string) => string,
   ): Promise<DeployResult> {
     const { db, starbaseId, sectorService, missionService, configService, worktreeManager } = this.deps;
 
@@ -109,7 +101,7 @@ export class CrewService {
     // 4. Generate crew ID
     const crewId = this.generateCrewId(sector.id);
 
-    // 4. Create worktree
+    // 5. Create worktree
     let worktreeResult;
     try {
       worktreeResult = worktreeManager.create({
@@ -131,7 +123,7 @@ export class CrewService {
       throw err;
     }
 
-    // 5. Install dependencies
+    // 6. Install dependencies
     try {
       worktreeManager.installDependencies(worktreeResult.worktreePath);
     } catch (err) {
@@ -140,14 +132,10 @@ export class CrewService {
       throw err;
     }
 
-    // 6. Pick avatar variant
+    // 7. Pick avatar variant (stored in DB for UI display even without a tab)
     const avatar = AVATAR_VARIANTS[Math.floor(Math.random() * AVATAR_VARIANTS.length)];
 
-    // 7. Create tab
-    const tabLabel = opts.prompt.slice(0, 50);
-    const tabId = createTab(tabLabel, worktreeResult.worktreePath, avatar);
-
-    // 8. Create Hull
+    // 8. Create Hull (headless — no tab, no PtyManager)
     const timeoutMin = configService.get('default_mission_timeout_min') as number;
     const lifesignSec = configService.get('lifesign_interval_sec') as number;
 
@@ -164,14 +152,15 @@ export class CrewService {
       lifesignIntervalSec: lifesignSec,
       timeoutMin,
       mergeStrategy: sector.merge_strategy,
+      verifyCommand: sector.verify_command ?? undefined,
+      lintCommand: sector.lint_command ?? undefined,
+      reviewMode: sector.review_mode,
       model: sector.model ?? undefined,
       systemPrompt: sector.system_prompt ?? undefined,
       allowedTools: sector.allowed_tools ?? undefined,
       mcpConfig: sector.mcp_config ?? undefined,
-      onComplete: () => this.autoDeployNext(ptyManager, createTab),
+      onComplete: () => this.autoDeployNext(),
       env: this.deps.crewEnv,
-      onPtyData: this.deps.onPtyData,
-      onPtyExit: this.deps.onPtyExit,
     });
 
     // Update crew record with avatar
@@ -179,20 +168,30 @@ export class CrewService {
 
     this.hulls.set(crewId, hull);
 
-    // 9. Start the Hull
-    await hull.start(ptyManager, tabId);
+    // 9. Start the Hull (headless — no paneId)
+    await hull.start();
 
     this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' });
-    return { crewId, tabId, missionId };
+    return { crewId, missionId };
   }
 
-  recallCrew(crewId: string, ptyManager: PtyManager): void {
+  recallCrew(crewId: string): void {
     const hull = this.hulls.get(crewId);
     if (hull) {
-      hull.kill(ptyManager);
+      hull.kill();
       this.hulls.delete(crewId);
       this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' });
     }
+  }
+
+  /**
+   * Send a follow-up message to an active crew's Claude Code process.
+   * Returns true if the message was sent, false if the crew is not active.
+   */
+  messageCrew(crewId: string, message: string): boolean {
+    const hull = this.hulls.get(crewId);
+    if (!hull || hull.getStatus() !== 'active') return false;
+    return hull.sendMessage(message);
   }
 
   listCrew(filter?: { sectorId?: string }): CrewRow[] {
@@ -234,17 +233,12 @@ export class CrewService {
   }
 
   /** Auto-deploy next queued mission if worktree slots are available */
-  private autoDeployNext(
-    ptyManager: PtyManager,
-    createTab: (label: string, cwd: string, avatarVariant?: string) => string,
-  ): void {
+  private autoDeployNext(): void {
     const next = this.nextQueuedMission();
     if (!next) return;
 
     this.deployCrew(
       { sectorId: next.sector_id, prompt: next.prompt, missionId: next.id },
-      ptyManager,
-      createTab,
     ).then((result) => {
       // Notify Admiral of auto-deployment
       this.deps.db.prepare(

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -1,11 +1,33 @@
 import type Database from 'better-sqlite3'
-import { execSync, ExecSyncOptions } from 'child_process'
+import { spawn, ChildProcess, execSync, ExecSyncOptions } from 'child_process'
 import { writeFileSync, unlinkSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import type { PtyManager } from '../pty-manager'
 import { inferCommitType, deriveSummary, formatCommitMessage, formatCommitSubject } from './conventional-commits'
 import { generateSkillMd } from './workspace-templates'
+
+// Stream-JSON message types emitted by Claude Code on stdout
+type ClaudeInitMessage = {
+  type: 'system'
+  subtype: 'init'
+  session_id: string
+}
+
+type ClaudeAssistantMessage = {
+  type: 'assistant'
+  message: { role: 'assistant'; content: Array<{ type: string; text?: string }> }
+  session_id: string
+}
+
+type ClaudeResultMessage = {
+  type: 'result'
+  is_error: boolean
+  session_id: string
+  total_cost_usd?: number
+  result?: string
+}
+
+type ClaudeStreamMessage = ClaudeInitMessage | ClaudeAssistantMessage | ClaudeResultMessage | { type: string }
 
 export type HullOpts = {
   crewId: string
@@ -32,12 +54,8 @@ export type HullOpts = {
   /** Path to an MCP config JSON file */
   mcpConfig?: string
   onComplete?: () => void
-  /** Environment variables for the PTY (enriched PATH so `claude` is found). */
+  /** Environment variables for the subprocess (enriched PATH so `claude` is found). */
   env?: Record<string, string>
-  /** Called with PTY data — wire to renderer for live terminal output. */
-  onPtyData?: (paneId: string, data: string) => void
-  /** Called on PTY exit — wire to renderer for exit handling. */
-  onPtyExit?: (paneId: string, exitCode: number) => void
 }
 
 type HullStatus = 'pending' | 'active' | 'complete' | 'error' | 'timeout' | 'aborted'
@@ -49,33 +67,33 @@ export class Hull {
   private outputLines: string[] = []
   private lifesignTimer: ReturnType<typeof setInterval> | null = null
   private timeoutTimer: ReturnType<typeof setTimeout> | null = null
-  private paneId: string | null = null
+  private process: ChildProcess | null = null
   private promptFile: string | null = null
   private systemPromptFile: string | null = null
   private pid: number | null = null
+  private stdoutBuffer: string = ''
+  private sessionId: string | null = null
 
   private static ghAvailable: boolean | null = null
 
   constructor(private opts: HullOpts) {}
 
   /**
-   * Start the Hull lifecycle. Requires a PtyManager to spawn the agent.
-   * Returns the paneId of the created PTY.
+   * Start the Hull lifecycle. Spawns a headless Claude Code process
+   * using stream-json protocol for bidirectional communication.
    */
-  async start(ptyManager: PtyManager, paneId: string): Promise<void> {
-    this.paneId = paneId
+  async start(): Promise<void> {
     const { crewId, sectorId, missionId, prompt, worktreePath, worktreeBranch, db } = this.opts
     const lifesignSec = this.opts.lifesignIntervalSec ?? 10
     const timeoutMin = this.opts.timeoutMin ?? 15
 
-    // Insert crew record
+    // Insert crew record (tab_id is NULL — headless crew, no terminal tab)
     db.prepare(
       `INSERT INTO crew (id, tab_id, sector_id, mission_id, sector_path, worktree_path,
         worktree_branch, status, mission_summary, pid, deadline, last_lifesign)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, NULL, datetime('now', '+${timeoutMin} minutes'), datetime('now'))`
+       VALUES (?, NULL, ?, ?, ?, ?, ?, 'active', ?, NULL, datetime('now', '+${timeoutMin} minutes'), datetime('now'))`
     ).run(
       crewId,
-      paneId,
       sectorId,
       missionId,
       this.opts.sectorPath,
@@ -109,7 +127,7 @@ export class Hull {
     // Start timeout timer
     this.timeoutTimer = setTimeout(
       () => {
-        this.handleTimeout(ptyManager)
+        this.handleTimeout()
       },
       timeoutMin * 60 * 1000
     )
@@ -123,7 +141,7 @@ export class Hull {
       // Non-fatal — crew can still work without the skill
     }
 
-    // Spawn agent PTY
+    // Spawn headless Claude Code with stream-json protocol
     try {
       // Write prompt to a temp file to avoid shell escaping issues with complex prompts.
       // Claude Code reads the file via its Read tool on first turn.
@@ -134,41 +152,95 @@ export class Hull {
       this.promptFile = promptFile
 
       const model = this.opts.model || 'claude-sonnet-4-6'
-      const cmdParts = [
-        'claude',
+      const cmdArgs = [
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--input-format', 'stream-json',
         '--dangerously-skip-permissions',
-        `--model ${model}`
+        '--model', model
       ]
       if (this.opts.systemPrompt) {
-        // Append to default prompt so Claude Code retains its built-in tool instructions
         const spFile = join(promptDir, `${crewId}-system-prompt.md`)
         writeFileSync(spFile, this.opts.systemPrompt, 'utf-8')
         this.systemPromptFile = spFile
-        cmdParts.push(`--append-system-prompt-file "${spFile}"`)
+        cmdArgs.push('--append-system-prompt-file', spFile)
       }
       if (this.opts.allowedTools) {
-        cmdParts.push(`--allowedTools "${this.opts.allowedTools}"`)
+        cmdArgs.push('--allowedTools', this.opts.allowedTools)
       }
       if (this.opts.mcpConfig) {
-        cmdParts.push(`--mcp-config "${this.opts.mcpConfig}"`)
+        cmdArgs.push('--mcp-config', this.opts.mcpConfig)
       }
-      cmdParts.push(`-p "Read and execute the mission prompt in ${promptFile}. Delete the file when done."`)
 
-      const result = ptyManager.create({
-        paneId,
+      const mergedEnv: Record<string, string> = {
+        ...(this.opts.env ?? (process.env as Record<string, string>)),
+        FLEET_CREW_ID: crewId,
+        FLEET_SECTOR_ID: this.opts.sectorId,
+        FLEET_MISSION_ID: String(this.opts.missionId)
+      }
+
+      const proc = spawn('claude', cmdArgs, {
         cwd: worktreePath,
-        cmd: cmdParts.join(' '),
-        exitOnComplete: true,
-        env: {
-          ...this.opts.env,
-          FLEET_CREW_ID: crewId,
-          FLEET_SECTOR_ID: this.opts.sectorId,
-          FLEET_MISSION_ID: String(this.opts.missionId)
+        env: mergedEnv,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+
+      this.process = proc
+      this.pid = proc.pid ?? null
+      if (this.pid) {
+        db.prepare('UPDATE crew SET pid = ? WHERE id = ?').run(this.pid, crewId)
+      }
+
+      // Send initial user message via stream-json stdin
+      const initMsg = JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: `Read and execute the mission prompt in ${promptFile}. Delete the file when done.` },
+        parent_tool_use_id: null,
+        session_id: ''
+      }) + '\n'
+      proc.stdin!.write(initMsg)
+
+      // Parse NDJSON from stdout
+      proc.stdout!.on('data', (chunk: Buffer) => {
+        this.stdoutBuffer += chunk.toString()
+        const lines = this.stdoutBuffer.split('\n')
+        this.stdoutBuffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.trim()) continue
+          try {
+            const msg = JSON.parse(line) as ClaudeStreamMessage
+            this.handleStreamMessage(msg)
+          } catch {
+            // non-JSON line (e.g. claude startup noise) — ignore
+          }
         }
       })
-      this.pid = result.pid
-      ptyManager.protect(paneId)
-      db.prepare('UPDATE crew SET pid = ? WHERE id = ?').run(result.pid, crewId)
+
+      // Log stderr for diagnostics
+      proc.stderr!.on('data', (chunk: Buffer) => {
+        console.error(`[hull:${crewId}] stderr:`, chunk.toString().trim())
+      })
+
+      // Handle process exit → trigger cleanup
+      proc.on('exit', (code) => {
+        this.process = null
+        const status = code === 0 ? 'complete' : 'error'
+        this.cleanup(status, code === 0 ? 'Completed successfully' : `Exit code: ${code}`).catch(
+          (cleanupErr) => {
+            console.error('[hull] cleanup error:', cleanupErr)
+          }
+        )
+      })
+
+      proc.on('error', (err) => {
+        this.process = null
+        this.cleanup('error', `Spawn failed: ${err.message}`).catch(
+          (cleanupErr) => {
+            console.error('[hull] cleanup error:', cleanupErr)
+          }
+        )
+      })
     } catch (err) {
       this.cleanup('error', `Spawn failed: ${err instanceof Error ? err.message : 'unknown'}`).catch(
         (cleanupErr) => {
@@ -177,32 +249,38 @@ export class Hull {
       )
       return
     }
-
-    // Listen for output (also forward to renderer if callback provided)
-    ptyManager.onData(paneId, (data) => {
-      this.appendOutput(data)
-      this.opts.onPtyData?.(paneId, data)
-    })
-
-    // Listen for exit (also forward to renderer if callback provided)
-    ptyManager.onExit(paneId, (exitCode) => {
-      this.opts.onPtyExit?.(paneId, exitCode)
-      const status = exitCode === 0 ? 'complete' : 'error'
-      this.cleanup(status, exitCode === 0 ? 'Completed successfully' : `Exit code: ${exitCode}`).catch(
-        (cleanupErr) => {
-          console.error('[hull] cleanup error:', cleanupErr)
-        }
-      )
-    })
   }
 
-  kill(ptyManager: PtyManager): void {
-    if (this.paneId && ptyManager.has(this.paneId)) {
-      // Try graceful exit first, then force kill after 5s
-      ptyManager.write(this.paneId, '/exit\r')
+  /**
+   * Send a follow-up message to the crew's Claude Code process via stream-json stdin.
+   * Resets the timeout deadline.
+   */
+  sendMessage(message: string): boolean {
+    if (this.status !== 'active' || !this.process?.stdin?.writable) {
+      return false
+    }
+
+    const msg = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: message },
+      parent_tool_use_id: null,
+      session_id: this.sessionId ?? ''
+    }) + '\n'
+
+    this.process.stdin.write(msg)
+    this.resetTimeout()
+    return true
+  }
+
+  kill(): void {
+    if (this.process) {
+      // Graceful: close stdin so Claude finishes current turn then exits
+      try { this.process.stdin?.end() } catch { /* ignore */ }
+      // Force kill after 5s if still alive
+      const proc = this.process
       setTimeout(() => {
-        if (this.paneId && ptyManager.has(this.paneId)) {
-          ptyManager.kill(this.paneId)
+        if (proc && !proc.killed) {
+          proc.kill('SIGTERM')
         }
       }, 5000)
     }
@@ -231,18 +309,51 @@ export class Hull {
     return this.outputLines.join('\n')
   }
 
-  private handleTimeout(ptyManager: PtyManager): void {
-    if (this.paneId && ptyManager.has(this.paneId)) {
-      // Try graceful exit first
-      ptyManager.write(this.paneId, '/exit\r')
+  private handleStreamMessage(msg: ClaudeStreamMessage): void {
+    if (msg.type === 'system' && (msg as ClaudeInitMessage).subtype === 'init') {
+      this.sessionId = (msg as ClaudeInitMessage).session_id
+    } else if (msg.type === 'assistant') {
+      const am = msg as ClaudeAssistantMessage
+      const textParts = am.message.content
+        .filter(c => c.type === 'text' && c.text)
+        .map(c => c.text!)
+      if (textParts.length > 0) {
+        this.appendOutput(textParts.join('\n'))
+      }
+    }
+    // 'result' messages are informational — the process exit handler triggers cleanup
+  }
+
+  private resetTimeout(): void {
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer)
+    }
+    const timeoutMin = this.opts.timeoutMin ?? 15
+    this.timeoutTimer = setTimeout(
+      () => this.handleTimeout(),
+      timeoutMin * 60 * 1000
+    )
+    // Update DB deadline to match
+    try {
+      this.opts.db.prepare(
+        `UPDATE crew SET deadline = datetime('now', '+${timeoutMin} minutes') WHERE id = ?`
+      ).run(this.opts.crewId)
+    } catch { /* db might be closed */ }
+  }
+
+  private handleTimeout(): void {
+    if (this.process) {
+      // Graceful: close stdin
+      try { this.process.stdin?.end() } catch { /* ignore */ }
       // Force kill after 5s if still alive
+      const proc = this.process
       setTimeout(() => {
-        if (this.paneId && ptyManager.has(this.paneId)) {
-          ptyManager.kill(this.paneId)
+        if (proc && !proc.killed) {
+          proc.kill('SIGTERM')
         }
       }, 5000)
     }
-    // Cleanup will be called by the onExit handler, but if kill doesn't trigger exit:
+    // Cleanup will be called by the exit handler, but if kill doesn't trigger exit:
     setTimeout(() => {
       if (this.status === 'active') {
         this.cleanup('timeout', 'Mission deadline exceeded').catch((err) => {
@@ -318,6 +429,15 @@ export class Hull {
         db.prepare(
           "UPDATE missions SET status = 'failed', result = ?, completed_at = datetime('now') WHERE id = ?"
         ).run('No work produced', missionId)
+        // Send mission_complete comms so Admiral is notified of the failure
+        db.prepare(
+          "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES (?, 'admiral', 'mission_complete', ?)"
+        ).run(crewId, JSON.stringify({ missionId, status: 'failed', reason: 'No work produced' }))
+        // Log exit
+        db.prepare("INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'exited', ?)").run(
+          crewId,
+          JSON.stringify({ status: 'error', reason: 'No work produced' })
+        )
         overrideStatus = 'error'
         return
       }

--- a/src/main/starbase/workspace-templates.ts
+++ b/src/main/starbase/workspace-templates.ts
@@ -120,7 +120,8 @@ fleet crew list --sector <id>          # Filter by Sector
 fleet crew info <crew-id>              # Show details for a specific Crewmate
 fleet crew deploy --sector <id> --mission <id>  # Deploy a Crewmate to a Mission
 fleet crew recall <crew-id>            # Recall (terminate) a Crewmate
-fleet crew observe <crew-id>           # View recent terminal output from a Crewmate
+fleet crew observe <crew-id>           # View recent assistant output from a Crewmate
+fleet crew message <crew-id> --message "..."  # Send a follow-up message to an active Crewmate
 \`\`\`
 
 ### Missions
@@ -140,7 +141,7 @@ fleet missions show <id>               # Show full Mission details
 fleet comms inbox                      # List unread transmissions
 fleet comms inbox --all                # List all transmissions (including read)
 fleet comms check --quiet              # Check for unread comms (exit code 0 = none, 1 = unread)
-fleet comms send --to <crew-id> --message "..."  # Send a transmission (as Admiral)
+fleet comms send --to <crew-id> --message "..."  # Send directive (also injects into live process)
 fleet comms send --from <crew-id> --to admiral --message "..."  # Send as a Crewmate
 fleet comms resolve <id> --response "..."        # Reply and mark resolved
 fleet comms read-all                   # Mark all transmissions as read
@@ -188,6 +189,35 @@ When a user makes a request, decompose it into well-scoped Missions:
 
 **Bad Mission prompt:**
 > "Add a settings feature"
+
+## Follow-Up Workflow (Mid-Flight Messaging)
+
+Active Crewmates can receive follow-up messages while they are running. This enables
+the Admiral to provide clarification, corrections, or additional context without
+recalling and redeploying.
+
+**When to use:**
+- Crewmate has sent an \`awaiting_feedback\` comms and is waiting for a response
+- You need to correct the Crewmate's approach before they commit
+- Clarification is needed mid-mission without losing the working context
+
+**How it works:**
+1. Crewmate writes to comms: \`fleet comms send --from $FLEET_CREW_ID --to admiral --type awaiting_feedback --message "..."\`
+2. Admiral reads comms: \`fleet comms inbox\`
+3. Admiral responds: \`fleet comms send --to <crew-id> --message "..."\` (this also injects into the live process)
+   OR: \`fleet crew message <crew-id> --message "..."\` (direct injection only, no comms record)
+4. Crewmate receives the message as a new turn in its session
+5. Crewmate continues work and eventually completes the mission
+
+### \`awaiting_feedback\` comms type
+
+Use \`awaiting_feedback\` when you need the Admiral to provide input before you can continue:
+
+\`\`\`
+fleet comms send --from $FLEET_CREW_ID --to admiral --type awaiting_feedback --message "Need clarification on X before proceeding"
+\`\`\`
+
+The Admiral will respond by injecting a follow-up instruction into your session.
 
 ## Handling Comms
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -149,6 +149,8 @@ const fleetApi = {
       ipcRenderer.invoke(IPC_CHANNELS.STARBASE_UPDATE_SECTOR, { sectorId, fields })
   },
   ptyDrain: (paneId: string) => ipcRenderer.send(IPC_CHANNELS.PTY_DRAIN, { paneId }),
+  // TODO(#30): Crew tabs are no longer created — crews are now headless (stream-json).
+  // This bridge remains for backwards compatibility but will not fire for new deployments.
   onCreateTab: (callback: (payload: { tabId: string; label: string; cwd: string; avatarVariant?: string }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, payload: { tabId: string; label: string; cwd: string; avatarVariant?: string }) =>
       callback(payload)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -107,7 +107,9 @@ export function App() {
     return () => document.removeEventListener('fleet:toggle-git-changes', handler);
   }, []);
 
-  // Listen for crew tab creation from main process
+  // TODO(#30): Crew tabs are no longer created — crews are now headless (stream-json).
+  // This listener remains for backwards compatibility but will not fire for new deployments.
+  // Remove when crew tab UI is fully deprecated.
   useEffect(() => {
     const cleanup = window.fleet.onCreateTab(({ tabId, label, cwd, avatarVariant }) => {
       markPtyCreated(tabId);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -34,6 +34,7 @@ export const IPC_CHANNELS = {
   STARBASE_MISSIONS: 'starbase:missions',
   STARBASE_ADD_MISSION: 'starbase:add-mission',
   STARBASE_OBSERVE: 'starbase:observe',
+  STARBASE_MESSAGE_CREW: 'starbase:message-crew',
   STARBASE_STATUS_UPDATE: 'starbase:status-update',
   STARBASE_COMMS_UNREAD: 'starbase:comms-unread',
   STARBASE_LIST_SUPPLY_ROUTES: 'starbase:list-supply-routes',

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -115,8 +115,8 @@ export type DeployRequest = {
 
 export type DeployResponse = {
   crewId: string;
-  tabId: string;
   missionId: number;
+  // TODO(#30): tabId removed — crews are now headless (stream-json, no terminal tab)
 };
 
 export type RecallRequest = {


### PR DESCRIPTION
## Summary
- Switch crew agents from PTY-based fire-and-forget (`-p` flag) to headless `child_process.spawn` with Claude Code's stream-json protocol (`--input-format stream-json --output-format stream-json`)
- Enable bidirectional Admiral↔Crew communication: `fleet comms send --to <crew-id>` auto-injects messages into the live Claude process via NDJSON stdin
- Add `fleet crew message <crew-id> --message "..."` for direct messaging without comms record, timeout reset on each follow-up, and `awaiting_feedback` comms type for crews to signal they need input

## Changes

### Core (Hull refactor)
- `hull.ts`: Replace `PtyManager` with `child_process.spawn()`, NDJSON parser for stdout, `sendMessage()` + `resetTimeout()` methods, graceful shutdown via stdin close + SIGTERM fallback
- `crew-service.ts`: Remove `ptyManager`/`createTab` deps, add `messageCrew()`, simplify `autoDeployNext()`

### API layer
- `socket-server.ts`: Remove `ptyManager`/`createTab` from `ServiceRegistry`, add `crew.message` command, auto-inject on `comms.send`
- `socket-command-handler.ts`: Update `deploy`/`recall` to match new signatures
- `fleet-cli.ts`: Add `crew.message`/`crew.msg`/`crew.send` to `COMMAND_MAP`

### Wiring
- `index.ts`: Remove crew PTY buffer/attach wiring (crews are headless)
- `ipc-handlers.ts`: Simplify deploy/recall, add `STARBASE_MESSAGE_CREW` handler
- `constants.ts`: Add `STARBASE_MESSAGE_CREW` IPC channel
- `ipc-api.ts`: Remove `tabId` from `DeployResponse`

### Docs & UI
- `workspace-templates.ts`: Add follow-up workflow docs, `awaiting_feedback` comms type, `crew message` command reference
- `App.tsx`, `preload/index.ts`: Add `TODO(#30)` deprecation comments on dormant crew tab code

### Bugs fixed during review
- Missing `verifyCommand`/`lintCommand`/`reviewMode` in Hull constructor (would have silently skipped verification gates)
- "No work produced" path now sends `mission_complete` comms so Admiral is notified

## Test plan
- [x] All 396 tests pass
- [x] Zero TypeScript errors
- [ ] Deploy a crew and verify stream-json process spawns correctly
- [ ] Send follow-up via `fleet comms send --to <crew-id> --message "..."` and verify injection
- [ ] Send follow-up via `fleet crew message <crew-id> --message "..."` and verify injection
- [ ] Verify timeout resets on each `sendMessage()` call
- [ ] Verify `fleet crew observe <crew-id>` returns assistant text output
- [ ] Verify crew recall sends stdin EOF then SIGTERM after 5s
- [ ] Verify Admiral (PTY-based) is unaffected

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)