### PR TITLE
feat(ui): add native folder picker for Sector path selection

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from 'electron'
+import { ipcMain, BrowserWindow, dialog } from 'electron'
 import { IPC_CHANNELS } from '../shared/constants'
 import type {
   PtyCreateRequest,
@@ -285,4 +285,13 @@ export function registerIpcHandlers(
       retentionService.vacuum()
     })
   }
+
+  // Folder picker
+  ipcMain.handle(IPC_CHANNELS.SHOW_FOLDER_PICKER, async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const result = await dialog.showOpenDialog(win!, {
+      properties: ['openDirectory']
+    })
+    return result.canceled ? null : result.filePaths[0]
+  })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -148,6 +148,8 @@ const fleetApi = {
     updateSector: (sectorId: string, fields: unknown): Promise<void> =>
       ipcRenderer.invoke(IPC_CHANNELS.STARBASE_UPDATE_SECTOR, { sectorId, fields })
   },
+  showFolderPicker: (): Promise<string | null> =>
+    ipcRenderer.invoke(IPC_CHANNELS.SHOW_FOLDER_PICKER),
   ptyDrain: (paneId: string) => ipcRenderer.send(IPC_CHANNELS.PTY_DRAIN, { paneId }),
   // TODO(#30): Crew tabs are no longer created — crews are now headless (stream-json).
   // This bridge remains for backwards compatibility but will not fire for new deployments.

--- a/src/renderer/src/components/StarCommandConfig.tsx
+++ b/src/renderer/src/components/StarCommandConfig.tsx
@@ -435,6 +435,15 @@ function SectorsSection() {
             placeholder="Path to project directory"
             className="flex-1 bg-neutral-900 text-neutral-300 text-xs rounded px-2 py-1.5 border border-neutral-600 focus:border-blue-500 focus:outline-none font-mono"
           />
+          <button
+            onClick={async () => {
+              const path = await window.fleet.showFolderPicker()
+              if (path) setAddPath(path)
+            }}
+            className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 text-neutral-300 text-xs font-medium rounded transition-colors"
+          >
+            Browse
+          </button>
           <input
             type="text"
             value={addName}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -52,6 +52,7 @@ export const IPC_CHANNELS = {
   ADMIRAL_PANE_ID: 'admiral:pane-id',
   PTY_DRAIN: 'fleet:pty-drain',
   PTY_ATTACH: 'pty:attach',
+  SHOW_FOLDER_PICKER: 'show-folder-picker',
 } as const
 
 export const DEFAULT_SCROLLBACK = 10_000


### PR DESCRIPTION
## Summary
- Adds a **Browse** button next to the Sector path input in Star Command's config tab
- Opens a native OS folder picker dialog (`dialog.showOpenDialog`) for selecting directories
- Follows existing IPC patterns: new channel constant, main process handler, preload bridge, and renderer button

## Files changed
- `src/shared/constants.ts` — `SHOW_FOLDER_PICKER` channel constant
- `src/main/ipc-handlers.ts` — folder picker IPC handler using Electron's `dialog.showOpenDialog`
- `src/preload/index.ts` — `showFolderPicker()` exposed via preload bridge
- `src/renderer/src/components/StarCommandConfig.tsx` — Browse button in `SectorsSection`

## Test plan
- [ ] Open Star Command config tab
- [ ] Click Browse button next to the Sector path input
- [ ] Verify native OS folder picker dialog opens
- [ ] Select a folder — path input should populate
- [ ] Cancel the dialog — no error, no change
- [ ] Manual path entry still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)