### PR TITLE
fix(starbase): clean up errored crew records and orphaned worktrees

### DIFF
--- a/src/main/__tests__/crew-service.test.ts
+++ b/src/main/__tests__/crew-service.test.ts
@@ -62,6 +62,26 @@ describe('CrewService', () => {
     expect(crewSvc.listCrew()).toHaveLength(0);
   });
 
+  it('should dismiss a terminal crew record when no hull is in memory (post-restart recall)', () => {
+    const rawDb = db.getDb();
+    rawDb.prepare('INSERT INTO crew (id, sector_id, status) VALUES (?, ?, ?)').run('fleet-crew-old', 'api', 'error');
+
+    crewSvc.recallCrew('fleet-crew-old');
+
+    const row = rawDb.prepare('SELECT status FROM crew WHERE id = ?').get('fleet-crew-old') as { status: string };
+    expect(row.status).toBe('dismissed');
+  });
+
+  it('should mark active crew with no hull as lost when recalled post-restart', () => {
+    const rawDb = db.getDb();
+    rawDb.prepare('INSERT INTO crew (id, sector_id, status) VALUES (?, ?, ?)').run('fleet-crew-active', 'api', 'active');
+
+    crewSvc.recallCrew('fleet-crew-active');
+
+    const row = rawDb.prepare('SELECT status FROM crew WHERE id = ?').get('fleet-crew-active') as { status: string };
+    expect(row.status).toBe('lost');
+  });
+
   it('should throw InsufficientMemoryError and queue mission when free RAM is below threshold', async () => {
     // Set an impossibly high threshold so any real machine will fail the check
     const configSvc = crewSvc['deps'].configService;

--- a/src/main/__tests__/reconciliation.test.ts
+++ b/src/main/__tests__/reconciliation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { StarbaseDB } from '../starbase/db';
 import { runReconciliation } from '../starbase/reconciliation';
-import { rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -166,5 +166,47 @@ describe('runReconciliation', () => {
     expect(summary.lostCrew).not.toContain('crew-done');
     const crew = getDb().prepare('SELECT status FROM crew WHERE id = ?').get('crew-done') as { status: string };
     expect(crew.status).toBe('complete');
+  });
+
+  it('should remove a lingering worktree for errored crew without a push-pending mission', async () => {
+    const sectorDir = join(TEST_DIR, 'workspace', 'api');
+    insertSector('api', sectorDir);
+
+    const worktreeDir = join(TEST_DIR, 'worktrees', starbaseDb.getStarbaseId(), 'crew-errored');
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(join(worktreeDir, 'leftover.ts'), '// orphan');
+
+    insertCrew({ id: 'crew-errored', sectorId: 'api', status: 'error', worktreePath: worktreeDir });
+    insertMission({ sectorId: 'api', status: 'failed', crewId: 'crew-errored' });
+
+    const summary = await runReconciliation({
+      db: getDb(),
+      starbaseId: starbaseDb.getStarbaseId(),
+      worktreeBasePath: join(TEST_DIR, 'worktrees'),
+    });
+
+    expect(summary.cleanedErroredCrew).toContain('crew-errored');
+    expect(existsSync(worktreeDir)).toBe(false);
+  });
+
+  it('should NOT remove a worktree for errored crew with a push-pending mission', async () => {
+    const sectorDir = join(TEST_DIR, 'workspace', 'api');
+    insertSector('api', sectorDir);
+
+    const worktreeDir = join(TEST_DIR, 'worktrees', starbaseDb.getStarbaseId(), 'crew-push-pending');
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(join(worktreeDir, 'leftover.ts'), '// needs push');
+
+    insertCrew({ id: 'crew-push-pending', sectorId: 'api', status: 'error', worktreePath: worktreeDir });
+    insertMission({ sectorId: 'api', status: 'push-pending', crewId: 'crew-push-pending' });
+
+    const summary = await runReconciliation({
+      db: getDb(),
+      starbaseId: starbaseDb.getStarbaseId(),
+      worktreeBasePath: join(TEST_DIR, 'worktrees'),
+    });
+
+    expect(summary.cleanedErroredCrew).not.toContain('crew-push-pending');
+    expect(existsSync(worktreeDir)).toBe(true);
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ let sentinel: Sentinel | null = null
 let lockfile: Lockfile | null = null
 let socketServer: SocketServer | null = null
 let admiralProcess: AdmiralProcess | null = null
+let crewServiceRef: CrewService | null = null
 const ptyManager = new PtyManager()
 const layoutStore = new LayoutStore()
 const eventBus = new EventBus()
@@ -192,7 +193,7 @@ app.whenReady().then(async () => {
     }
 
     // Crews are headless (stream-json, no PTY/tab). No PTY buffer wiring needed.
-    crewService = new CrewService({
+    crewServiceRef = crewService = new CrewService({
       db: starbaseDb.getDb(),
       starbaseId: starbaseDb.getStarbaseId(),
       sectorService,
@@ -685,7 +686,8 @@ app.whenReady().then(async () => {
   })
 })
 
-app.on('window-all-closed', () => {
+function shutdownAll(): void {
+  crewServiceRef?.shutdown()
   ptyManager.killAll()
   cwdPoller.stopAll()
   socketApi.stop()
@@ -695,8 +697,15 @@ app.on('window-all-closed', () => {
   jsonlWatcher.stop()
   if (sentinel) sentinel.stop()
   if (lockfile) lockfile.release()
-  // starbaseDb is scoped inside whenReady — close is handled by process exit
+}
+
+app.on('window-all-closed', () => {
+  shutdownAll()
   if (process.platform !== 'darwin') {
     app.quit()
   }
 })
+
+// Ensure child processes are cleaned up on unexpected termination
+process.on('SIGTERM', () => { shutdownAll(); process.exit(0) })
+process.on('SIGINT', () => { shutdownAll(); process.exit(0) })

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -181,7 +181,27 @@ export class CrewService {
       hull.kill();
       this.hulls.delete(crewId);
       this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' });
+      return;
     }
+
+    // Hull not in memory (post-restart recall): update DB record directly.
+    const TERMINAL_STATUSES = ['error', 'complete', 'timeout', 'lost', 'aborted', 'dismissed'];
+    const row = this.deps.db.prepare('SELECT status FROM crew WHERE id = ?').get(crewId) as
+      | { status: string }
+      | undefined;
+    if (!row) return;
+
+    if (TERMINAL_STATUSES.includes(row.status)) {
+      this.deps.db
+        .prepare("UPDATE crew SET status = 'dismissed', updated_at = datetime('now') WHERE id = ?")
+        .run(crewId);
+    } else {
+      // Active crew with no hull is an inconsistent state — mark as lost
+      this.deps.db
+        .prepare("UPDATE crew SET status = 'lost', updated_at = datetime('now') WHERE id = ?")
+        .run(crewId);
+    }
+    this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' });
   }
 
   /**
@@ -230,6 +250,18 @@ export class CrewService {
          LIMIT 1`,
       )
       .get() as { id: number; sector_id: string; prompt: string; summary: string } | undefined;
+  }
+
+  /** Immediately kill all active Hull processes (app shutdown). */
+  shutdown(): void {
+    for (const [crewId, hull] of this.hulls) {
+      try {
+        hull.forceKill();
+      } catch {
+        // Best-effort during shutdown
+      }
+      this.hulls.delete(crewId);
+    }
   }
 
   /** Auto-deploy next queued mission if worktree slots are available */

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -276,17 +276,37 @@ export class Hull {
     if (this.process) {
       // Graceful: close stdin so Claude finishes current turn then exits
       try { this.process.stdin?.end() } catch { /* ignore */ }
-      // Force kill after 5s if still alive
+      // Force kill after 5s if still alive, escalate to SIGKILL after 10s
       const proc = this.process
-      setTimeout(() => {
-        if (proc && !proc.killed) {
-          proc.kill('SIGTERM')
+      const sigterm = setTimeout(() => {
+        if (!proc.killed) {
+          try { proc.kill('SIGTERM') } catch { /* already dead */ }
         }
       }, 5000)
+      const sigkill = setTimeout(() => {
+        if (!proc.killed) {
+          try { proc.kill('SIGKILL') } catch { /* already dead */ }
+        }
+      }, 10000)
+      proc.once('exit', () => {
+        clearTimeout(sigterm)
+        clearTimeout(sigkill)
+      })
     }
     this.cleanup('aborted', 'Recalled by Star Command').catch((err) => {
       console.error('[hull] cleanup error:', err)
     })
+  }
+
+  /** Immediately kill the process (app shutdown — no graceful wait). */
+  forceKill(): void {
+    if (this.lifesignTimer) clearInterval(this.lifesignTimer)
+    if (this.timeoutTimer) clearTimeout(this.timeoutTimer)
+    if (this.process && !this.process.killed) {
+      try { this.process.kill('SIGKILL') } catch { /* already dead */ }
+    }
+    this.process = null
+    this.status = 'aborted'
   }
 
   getStatus(): HullStatus {

--- a/src/main/starbase/migrations.ts
+++ b/src/main/starbase/migrations.ts
@@ -169,6 +169,7 @@ export const CONFIG_DEFAULTS: Record<string, unknown> = {
   comms_retention_days: 30,
   cargo_retention_days: 14,
   ships_log_retention_days: 30,
+  crew_retention_days: 7,
   forward_failed_cargo: false,
   min_deploy_free_memory_gb: 1.5
 }

--- a/src/main/starbase/reconciliation.ts
+++ b/src/main/starbase/reconciliation.ts
@@ -17,6 +17,7 @@ type ReconciliationSummary = {
   orphanedWorktrees: string[];
   retriedPushes: number[];
   requeuedMissions: number[];
+  cleanedErroredCrew: string[];
 };
 
 type CrewRow = {
@@ -37,6 +38,7 @@ export async function runReconciliation(deps: ReconciliationDeps): Promise<Recon
     orphanedWorktrees: [],
     retriedPushes: [],
     requeuedMissions: [],
+    cleanedErroredCrew: [],
   };
 
   // 1. Query all active crew
@@ -142,7 +144,36 @@ export async function runReconciliation(deps: ReconciliationDeps): Promise<Recon
     }
   }
 
-  // 9. Return summary
+  // 9. Clean up errored crew whose worktrees are still on disk but mission is not push-pending
+  const erroredCrew = db
+    .prepare(
+      `SELECT c.id, c.worktree_path, c.sector_id
+       FROM crew c
+       WHERE c.status IN ('error', 'timeout')
+         AND c.worktree_path IS NOT NULL`,
+    )
+    .all() as { id: string; worktree_path: string; sector_id: string }[];
+
+  for (const crew of erroredCrew) {
+    if (!existsSync(crew.worktree_path)) continue;
+
+    // Skip if there is a push-pending mission — worktree needed for push retry
+    const hasPushPending = db
+      .prepare(
+        "SELECT 1 FROM missions WHERE crew_id = ? AND status = 'push-pending' LIMIT 1",
+      )
+      .get(crew.id);
+    if (hasPushPending) continue;
+
+    try {
+      rmSync(crew.worktree_path, { recursive: true, force: true });
+      summary.cleanedErroredCrew.push(crew.id);
+    } catch {
+      console.error(`[reconciliation] Failed to remove errored crew worktree: ${crew.worktree_path}`);
+    }
+  }
+
+  // 10. Return summary
   return summary;
 }
 

--- a/src/main/starbase/retention-service.ts
+++ b/src/main/starbase/retention-service.ts
@@ -20,11 +20,12 @@ export class RetentionService {
     private dbPath: string
   ) {}
 
-  cleanup(): { comms: number; cargo: number; shipsLog: number } {
+  cleanup(): { comms: number; cargo: number; shipsLog: number; crew: number } {
     const commsRetentionDays = (this.configService.get('comms_retention_days') as number) ?? 30
     const cargoRetentionDays = (this.configService.get('cargo_retention_days') as number) ?? 14
     const shipsLogRetentionDays =
       (this.configService.get('ships_log_retention_days') as number) ?? 30
+    const crewRetentionDays = (this.configService.get('crew_retention_days') as number) ?? 7
 
     const commsResult = this.db
       .prepare(`DELETE FROM comms WHERE created_at < datetime('now', '-' || ? || ' days')`)
@@ -38,10 +39,19 @@ export class RetentionService {
       .prepare(`DELETE FROM ships_log WHERE created_at < datetime('now', '-' || ? || ' days')`)
       .run(shipsLogRetentionDays)
 
+    const crewResult = this.db
+      .prepare(
+        `DELETE FROM crew
+         WHERE status IN ('error', 'complete', 'timeout', 'lost', 'aborted', 'dismissed')
+         AND updated_at < datetime('now', '-' || ? || ' days')`
+      )
+      .run(crewRetentionDays)
+
     return {
       comms: commsResult.changes,
       cargo: cargoResult.changes,
-      shipsLog: shipsLogResult.changes
+      shipsLog: shipsLogResult.changes,
+      crew: crewResult.changes
     }
   }
 


### PR DESCRIPTION
## Summary
- **recallCrew post-restart no-op fixed**: when no Hull is in memory, terminal-status crew are updated to `dismissed` and orphaned active crew are marked `lost`, both emitting `starbase-changed`
- **Crew record retention added**: `RetentionService.cleanup()` now purges crew in terminal states older than `crew_retention_days` (default 7 days); new config key added to defaults
- **Reconciliation handles errored crew**: startup reconciliation now removes lingering worktree directories for `error`/`timeout` crew without `push-pending` missions; push-pending worktrees are preserved for retry

Also wires `CrewService.shutdown()` into the app quit path and adds `Hull.forceKill()` for clean process teardown on exit.

## Test plan
- [ ] `fleet crew recall <errored-crew-id>` after app restart updates DB status to `dismissed`
- [ ] Active crew with no hull in memory is marked `lost` on recall
- [ ] `RetentionService.cleanup()` returns `crew` count and deletes old terminal records
- [ ] Reconciliation removes lingering worktrees for errored crew (not push-pending)
- [ ] Push-pending worktrees are untouched by reconciliation
- [ ] All 350 tests pass (`npx vitest run src/main/__tests__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)