### PR TITLE
fix(fleet): prevent crews from committing to wrong branch

### DIFF
--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -192,9 +192,10 @@ export class Hull {
       }
 
       // Send initial user message via stream-json stdin
+      const worktreeWarning = `IMPORTANT: You are in a git worktree. Your current directory is already the correct working directory for this mission (branch: ${worktreeBranch}). Do NOT cd to any other path. All file edits and git operations must happen in the current directory.\n\n`
       const initMsg = JSON.stringify({
         type: 'user',
-        message: { role: 'user', content: `Read and execute the mission prompt in ${promptFile}. Delete the file when done.` },
+        message: { role: 'user', content: `${worktreeWarning}Read and execute the mission prompt in ${promptFile}. Delete the file when done.` },
         parent_tool_use_id: null,
         session_id: ''
       }) + '\n'

--- a/src/main/starbase/workspace-templates.ts
+++ b/src/main/starbase/workspace-templates.ts
@@ -62,6 +62,8 @@ The following Sectors are registered with this Starbase:
 ${sectorLines}
 <!-- fleet:auto-end:sectors -->
 
+> **Note:** Crew are deployed into isolated git worktrees, NOT the sector root paths listed above. Never include sector root paths in mission prompts — crews already have the correct working directory.
+
 ## Rules
 
 1. **Check comms first.** Before taking any action, run \`fleet comms inbox\` to check for unread transmissions from Crew.


### PR DESCRIPTION
Adds worktree-awareness to crew init message and updates Admiral context to not expose sector root paths in mission prompts.