### PR TITLE
feat(missions): wire --depends-on flag through CLI and IPC to mission creation

### DIFF
--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -197,6 +197,7 @@ export class SocketServer extends EventEmitter {
           sectorId: (args.sector ?? args.sectorId) as string,
           summary: args.summary as string,
           prompt: args.prompt as string,
+          dependsOnMissionId: args['depends-on'] ? Number(args['depends-on']) : undefined,
         });
         this.emit('state-change', 'mission:changed', { mission });
         return mission;

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -133,6 +133,7 @@ export type AddMissionRequest = {
   summary: string;
   prompt: string;
   priority?: number;
+  dependsOnMissionId?: number;
 };
 
 export type AdmiralStateDetailPayload = {


### PR DESCRIPTION
## Summary
- Added `dependsOnMissionId` to `AddMissionRequest` type in `ipc-api.ts` so the renderer/IPC path can pass dependency information
- Wired `args['depends-on']` through to `missionService.addMission()` in the socket server's `mission.create` handler
- The IPC handler already passes the full request object through, so it picks up `dependsOnMissionId` automatically

## Test plan
- [ ] `fleet missions add --sector fleet --summary 'test' --prompt 'test' --depends-on 1` creates a mission with `depends_on_mission_id=1`
- [ ] `fleet missions show <id>` displays the dependency
- [ ] Creating a mission without `--depends-on` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)