### PR TITLE
fix(missions): fix missions update command and add deploy dependency guard

### DIFF
--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -172,7 +172,7 @@ const COMMAND_MAP: Record<string, string> = {
   'missions.list': 'mission.list',
   'missions.add': 'mission.create',
   'missions.create': 'mission.create',
-  'missions.update': 'mission.status',
+  'missions.update': 'mission.update',
   'missions.show': 'mission.status',
   'missions.status': 'mission.status',
   'missions.cancel': 'mission.cancel',

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -208,6 +208,15 @@ export class SocketServer extends EventEmitter {
       case 'mission.status':
         return missionService.getMission((args.id ?? args.missionId) as number);
 
+      case 'mission.update': {
+        const id = (args.id ?? args.missionId) as number;
+        if (args.status) {
+          missionService.setStatus(id, args.status as string);
+          this.emit('state-change', 'mission:changed', { id });
+        }
+        return missionService.getMission(id);
+      }
+
       case 'mission.cancel':
         missionService.abortMission((args.id ?? args.missionId) as number);
         this.emit('state-change', 'mission:changed', { id: args.id ?? args.missionId });
@@ -226,6 +235,16 @@ export class SocketServer extends EventEmitter {
           const mission = missionService.getMission(missionId);
           if (mission) {
             prompt = mission.prompt ?? mission.summary ?? '';
+          }
+        }
+
+        if (missionId) {
+          const mission = missionService.getMission(missionId);
+          if (mission?.depends_on_mission_id) {
+            const dep = missionService.getMission(mission.depends_on_mission_id);
+            if (dep && dep.status !== 'completed') {
+              throw new Error(`Cannot deploy: mission ${missionId} depends on mission ${mission.depends_on_mission_id} which is not completed (status: ${dep.status})`);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- Fix `fleet missions update` command: was mapping to read-only `mission.status`, now maps to new `mission.update` handler that actually calls `setStatus()`
- Add `mission.update` socket handler that updates mission status and emits `state-change`
- Add dependency guard in `crew.deploy`: blocks deploy if the mission's dependency is not yet completed, with a clear error message

## Test plan
- [ ] `fleet missions update 1 --status done` updates the mission status
- [ ] `fleet missions update 1 --status failed` updates the mission status
- [ ] `fleet missions show 1` still works (maps to `mission.status`)
- [ ] Deploying a crew to a mission with an unmet dependency throws a clear error
- [ ] Deploying a crew to a mission with a completed dependency succeeds
- [ ] Deploying a crew to a mission with no dependency succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)