### PR TITLE
perf(worktree): convert sync shell ops to async to unblock event loop

### DIFF
--- a/src/main/__tests__/worktree-manager.test.ts
+++ b/src/main/__tests__/worktree-manager.test.ts
@@ -25,9 +25,9 @@ afterEach(() => {
 });
 
 describe('WorktreeManager', () => {
-  it('should create a worktree', () => {
+  it('should create a worktree', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'api-crew-a1b2',
       sectorPath: REPO_DIR,
@@ -39,17 +39,17 @@ describe('WorktreeManager', () => {
     expect(existsSync(join(result.worktreePath, 'README.md'))).toBe(true);
   });
 
-  it('should handle branch name collision with numeric suffix', () => {
+  it('should handle branch name collision with numeric suffix', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
     // Create first worktree
-    mgr.create({
+    await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'api-crew-a1b2',
       sectorPath: REPO_DIR,
       baseBranch: 'main',
     });
     // Create second with same crewId — should get suffix
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'api-crew-a1b2-2',
       sectorPath: REPO_DIR,
@@ -58,9 +58,9 @@ describe('WorktreeManager', () => {
     expect(result.worktreeBranch).toBe('crew/api-crew-a1b2-2');
   });
 
-  it('should remove a worktree', () => {
+  it('should remove a worktree', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'rm-crew',
       sectorPath: REPO_DIR,
@@ -70,9 +70,9 @@ describe('WorktreeManager', () => {
     expect(existsSync(result.worktreePath)).toBe(false);
   });
 
-  it('should detect lockfile type for dependency install', () => {
+  it('should detect lockfile type for dependency install', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'dep-crew',
       sectorPath: REPO_DIR,
@@ -100,7 +100,7 @@ describe('WorktreeManager with concurrency limits', () => {
     starbaseDb.close();
   });
 
-  it('should throw WorktreeLimitError when at max concurrent', () => {
+  it('should throw WorktreeLimitError when at max concurrent', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
     mgr.configure(starbaseDb.getDb(), 1);
 
@@ -109,21 +109,21 @@ describe('WorktreeManager with concurrency limits', () => {
       .prepare("INSERT INTO crew (id, sector_id, status, worktree_path) VALUES ('existing', 'api', 'active', '/some/path')")
       .run();
 
-    expect(() =>
+    await expect(
       mgr.create({
         starbaseId: 'test-sb',
         crewId: 'new-crew',
         sectorPath: REPO_DIR,
         baseBranch: 'main',
       }),
-    ).toThrow(WorktreeLimitError);
+    ).rejects.toThrow(WorktreeLimitError);
   });
 
-  it('should allow creation when below limit', () => {
+  it('should allow creation when below limit', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
     mgr.configure(starbaseDb.getDb(), 5);
 
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'allowed-crew',
       sectorPath: REPO_DIR,
@@ -132,12 +132,12 @@ describe('WorktreeManager with concurrency limits', () => {
     expect(existsSync(result.worktreePath)).toBe(true);
   });
 
-  it('should mark a worktree as pooled and retrieve it', () => {
+  it('should mark a worktree as pooled and retrieve it', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
     mgr.configure(starbaseDb.getDb(), 5);
 
     // Create crew with worktree
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'pool-crew',
       sectorPath: REPO_DIR,
@@ -157,11 +157,11 @@ describe('WorktreeManager with concurrency limits', () => {
     expect(pooled).toBe(result.worktreePath);
   });
 
-  it('should evict stale pooled worktrees', () => {
+  it('should evict stale pooled worktrees', async () => {
     const mgr = new WorktreeManager(WORKTREE_BASE);
     mgr.configure(starbaseDb.getDb(), 5);
 
-    const result = mgr.create({
+    const result = await mgr.create({
       starbaseId: 'test-sb',
       crewId: 'evict-crew',
       sectorPath: REPO_DIR,

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -104,7 +104,7 @@ export class CrewService {
     // 5. Create worktree
     let worktreeResult;
     try {
-      worktreeResult = worktreeManager.create({
+      worktreeResult = await worktreeManager.create({
         starbaseId,
         crewId,
         sectorPath: sector.root_path,
@@ -125,7 +125,7 @@ export class CrewService {
 
     // 6. Install dependencies
     try {
-      worktreeManager.installDependencies(worktreeResult.worktreePath);
+      await worktreeManager.installDependencies(worktreeResult.worktreePath);
     } catch (err) {
       worktreeManager.remove(worktreeResult.worktreePath, sector.root_path);
       missionService.failMission(missionId, `Dependency install failed: ${err instanceof Error ? err.message : 'unknown'}`);

--- a/src/main/starbase/worktree-manager.ts
+++ b/src/main/starbase/worktree-manager.ts
@@ -1,7 +1,10 @@
 import type Database from 'better-sqlite3';
-import { execSync, ExecSyncOptions } from 'child_process';
+import { exec, execSync } from 'node:child_process';
+import { promisify } from 'node:util';
 import { existsSync, mkdirSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+
+const execAsync = promisify(exec);
 
 export class WorktreeLimitError extends Error {
   constructor(message: string) {
@@ -34,9 +37,9 @@ export class WorktreeManager {
     this.maxConcurrent = maxConcurrent;
   }
 
-  create(opts: CreateOpts): CreateResult {
+  async create(opts: CreateOpts): Promise<CreateResult> {
     const { starbaseId, crewId, sectorPath, baseBranch } = opts;
-    const execOpts: ExecSyncOptions = { cwd: sectorPath, stdio: 'pipe' };
+    const execOpts = { cwd: sectorPath };
 
     // Check concurrency limit
     if (this.db && this.maxConcurrent < Infinity) {
@@ -57,7 +60,7 @@ export class WorktreeManager {
       const pooled = this.getPooled(starbaseId);
       if (pooled) {
         try {
-          const recycled = this.recycle(pooled, baseBranch, crewId);
+          const recycled = await this.recycle(pooled, baseBranch, crewId);
           if (recycled) return recycled;
         } catch {
           // Recycle failed — fall through to create new
@@ -67,7 +70,7 @@ export class WorktreeManager {
 
     // Pre-flight: verify git repo
     try {
-      execSync('git rev-parse --git-dir', execOpts);
+      await execAsync('git rev-parse --git-dir', execOpts);
     } catch {
       throw new Error(`Not a git repository: ${sectorPath}`);
     }
@@ -81,16 +84,14 @@ export class WorktreeManager {
 
     // Check if branch exists locally
     try {
-      const localBranches = execSync(`git branch --list "${branchName}"`, execOpts)
-        .toString()
-        .trim();
-      if (localBranches) {
+      const { stdout: localBranches } = await execAsync(`git branch --list "${branchName}"`, execOpts);
+      if (localBranches.trim()) {
         // Branch exists — append suffix
         let suffix = 2;
         while (true) {
           const candidate = `crew/${crewId}-${suffix}`;
-          const check = execSync(`git branch --list "${candidate}"`, execOpts).toString().trim();
-          if (!check) {
+          const { stdout: check } = await execAsync(`git branch --list "${candidate}"`, execOpts);
+          if (!check.trim()) {
             branchName = candidate;
             break;
           }
@@ -102,13 +103,13 @@ export class WorktreeManager {
     }
 
     // Create worktree
-    execSync(`git worktree add "${worktreePath}" -b "${branchName}" "${baseBranch}"`, execOpts);
+    await execAsync(`git worktree add "${worktreePath}" -b "${branchName}" "${baseBranch}"`, execOpts);
 
     return { worktreePath, worktreeBranch: branchName };
   }
 
   remove(worktreePath: string, sectorPath: string): void {
-    const execOpts: ExecSyncOptions = { cwd: sectorPath, stdio: 'pipe' };
+    const execOpts = { cwd: sectorPath, stdio: 'pipe' as const };
     try {
       execSync(`git worktree remove "${worktreePath}"`, execOpts);
     } catch {
@@ -128,22 +129,20 @@ export class WorktreeManager {
     }
   }
 
-  installDependencies(worktreePath: string, timeoutMs = 120_000): void {
+  async installDependencies(worktreePath: string, timeoutMs = 120_000): Promise<void> {
     const cmd = this.detectInstallCommand(worktreePath);
     if (!cmd) return;
 
     try {
-      execSync(cmd, {
+      await execAsync(cmd, {
         cwd: worktreePath,
-        stdio: 'pipe',
         timeout: timeoutMs,
       });
     } catch {
       // Retry once
       try {
-        execSync(cmd, {
+        await execAsync(cmd, {
           cwd: worktreePath,
-          stdio: 'pipe',
           timeout: timeoutMs,
         });
       } catch (retryErr) {
@@ -199,16 +198,16 @@ export class WorktreeManager {
   }
 
   /** Recycle a pooled worktree: reset to base branch and create new branch */
-  recycle(worktreePath: string, baseBranch: string, newCrewId: string): CreateResult | null {
+  async recycle(worktreePath: string, baseBranch: string, newCrewId: string): Promise<CreateResult | null> {
     if (!existsSync(worktreePath)) return null;
-    const execOpts: ExecSyncOptions = { cwd: worktreePath, stdio: 'pipe' };
+    const execOpts = { cwd: worktreePath };
 
     try {
-      execSync(`git checkout "${baseBranch}"`, execOpts);
-      execSync('git pull', execOpts);
-      execSync('git clean -fd', execOpts);
+      await execAsync(`git checkout "${baseBranch}"`, execOpts);
+      await execAsync('git pull', execOpts);
+      await execAsync('git clean -fd', execOpts);
       const branchName = `crew/${newCrewId}`;
-      execSync(`git checkout -b "${branchName}"`, execOpts);
+      await execAsync(`git checkout -b "${branchName}"`, execOpts);
 
       // Clear pool status for the old crew entry
       if (this.db) {


### PR DESCRIPTION
## Summary
- Replace all `execSync` calls in `WorktreeManager.create()`, `installDependencies()`, and `recycle()` with `execAsync` (promisified `exec`)
- Await the now-async methods in `crew-service.ts` `deployCrew()`
- Update tests to use `async/await` and `.rejects.toThrow()` for async error assertions

## Why
`execSync` blocks the Node.js event loop for the full duration of git operations and `pnpm install` (up to 240s), freezing IPC, PTY forwarding, and all UI updates during `fleet crew deploy`.

## Test plan
- [ ] Worktree creation completes successfully (4 basic WorktreeManager tests pass)
- [ ] `fleet crew deploy` no longer freezes the renderer/UI
- [ ] Active terminal sessions continue receiving data during deploy
- [ ] Other CLI commands remain responsive during deploy
- [ ] TypeScript compiles cleanly (`pnpm tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)