### PR TITLE
fix(hull): skip failure logic on intentional recall with no changes

### DIFF
--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -446,20 +446,27 @@ export class Hull {
       }
 
       if (!hasChanges) {
-        // No work produced
-        db.prepare(
-          "UPDATE missions SET status = 'failed', result = ?, completed_at = datetime('now') WHERE id = ?"
-        ).run('No work produced', missionId)
-        // Send mission_complete comms so Admiral is notified of the failure
-        db.prepare(
-          "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES (?, 'admiral', 'mission_complete', ?)"
-        ).run(crewId, JSON.stringify({ missionId, status: 'failed', reason: 'No work produced' }))
-        // Log exit
-        db.prepare("INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'exited', ?)").run(
-          crewId,
-          JSON.stringify({ status: 'error', reason: 'No work produced' })
-        )
-        overrideStatus = 'error'
+        if (status !== 'aborted') {
+          // Genuine failure: no work produced
+          db.prepare(
+            "UPDATE missions SET status = 'failed', result = ?, completed_at = datetime('now') WHERE id = ?"
+          ).run('No work produced', missionId)
+          // Send mission_complete comms so Admiral is notified of the failure
+          db.prepare(
+            "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES (?, 'admiral', 'mission_complete', ?)"
+          ).run(crewId, JSON.stringify({ missionId, status: 'failed', reason: 'No work produced' }))
+          // Log exit
+          db.prepare("INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'exited', ?)").run(
+            crewId,
+            JSON.stringify({ status: 'error', reason: 'No work produced' })
+          )
+          overrideStatus = 'error'
+        } else {
+          // Intentional recall with no changes: mark mission as aborted
+          db.prepare(
+            "UPDATE missions SET status = 'aborted', completed_at = datetime('now') WHERE id = ?"
+          ).run(missionId)
+        }
         return
       }
 


### PR DESCRIPTION
## Summary
- Fixes `fleet crew recall` causing crew to end up in `ERROR` state and missions showing as `failed` with "No work produced"
- Gates the failure-recording block in `cleanup()` on `status !== 'aborted'` — recalls with no changes now correctly set both crew and mission to `aborted`
- Genuine no-output failures (non-recall exits) are unaffected and still produce `error`/`failed` status

## Test plan
- [ ] Recall a crew that has made no changes: crew status = `aborted`, mission status = `aborted`
- [ ] Recall a crew that has made changes: existing behavior preserved (mission gets `aborted` status via the hasChanges path)
- [ ] A crew that genuinely exits with no output (not recalled): mission = `failed`, crew = `error`
- [ ] No spurious `mission_complete` comms sent to Admiral on intentional recall
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)