### PR TITLE
feat(star-command): add Comms and Crew sub-tabs to Star Command

### DIFF
--- a/src/renderer/src/components/star-command/CrewPanel.tsx
+++ b/src/renderer/src/components/star-command/CrewPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useStarCommandStore } from '../../store/star-command-store'
-import type { CrewStatus, MissionInfo, SectorInfo } from '../../store/star-command-store'
+import type { MissionInfo, SectorInfo } from '../../store/star-command-store'
 
 const STATUS_COLORS: Record<string, string> = {
   active: 'bg-green-400',
@@ -343,7 +343,7 @@ export function CrewPanel() {
       <section>
         <SectionHeader title="Active Crew" count={crewList.length} />
         <div className="space-y-2 mb-3">
-          {(crewList as FullCrewRow[]).map((c) => (
+          {(crewList as unknown as FullCrewRow[]).map((c) => (
             <CrewCard key={c.id} crew={c} onRefresh={refresh} />
           ))}
           {crewList.length === 0 && (


### PR DESCRIPTION
## Summary
- Add Comms sub-tab to Star Command with full inbox: unread/read sections, expand to see full payload, resolve with response, mark read, delete, bulk read-all and clear-all with confirmation
- Add Crew sub-tab showing all crew with status dots, expandable cards with observe/message/recall actions, deploy new crew section, and mission queue view
- Add Missions sub-tab (MissionsPanel) for viewing the mission queue
- Wire up all actions via existing IPC bridge (listComms, resolveComms, recallCrew, observeCrew, messageCrew, deployCrew, etc.)
- Add commsList state and setCommsList action to star-command-store

## Test plan
- [ ] Open Star Command and verify Admiral/Config tabs still work
- [ ] Click Comms tab — unread transmissions show with teal border, read ones with neutral border
- [ ] Expand a comm card to see full payload and resolve/delete actions
- [ ] Click Crew tab — active crew list with status dots, expand to observe output / send message / recall
- [ ] Test Deploy Crew section: select sector, enter prompt, click Deploy
- [ ] Test Missions section shows queued missions
- [ ] Unread badge on Comms button reflects actual unread count

🤖 Generated with [Claude Code](https://claude.com/claude-code)