### PR TITLE
fix(cli): detect node from nvm, fnm, volta, and homebrew in shell wrapper

### DIFF
--- a/src/main/install-fleet-cli.ts
+++ b/src/main/install-fleet-cli.ts
@@ -31,6 +31,53 @@ export async function installFleetCLI(): Promise<string> {
   let cliEntrypoint: string
   let wrapperContent: string
 
+  // Shell wrapper with node path detection for common version managers.
+  // Non-interactive shells (e.g. Claude Code) don't source ~/.zshrc or nvm.sh,
+  // so `node` may not be on PATH. This wrapper probes nvm, fnm, volta, and
+  // Homebrew before falling back to a helpful error message.
+  const nodeResolverScript = `
+# ── Node.js path resolution ───────────────────────────────────────────────────
+# Only run if node isn't already accessible — don't override a working setup.
+if ! command -v node >/dev/null 2>&1; then
+  # nvm: use the default alias if available, otherwise pick the latest installed
+  if [ -s "$HOME/.nvm/alias/default" ]; then
+    NVM_DEFAULT="$(cat "$HOME/.nvm/alias/default")"
+    NVM_BIN="$HOME/.nvm/versions/node/$NVM_DEFAULT/bin"
+    [ -d "$NVM_BIN" ] && export PATH="$NVM_BIN:$PATH"
+  fi
+  if ! command -v node >/dev/null 2>&1 && [ -d "$HOME/.nvm/versions/node" ]; then
+    NVM_LATEST="$(ls -1 "$HOME/.nvm/versions/node" | sort -V | tail -1)"
+    [ -n "$NVM_LATEST" ] && export PATH="$HOME/.nvm/versions/node/$NVM_LATEST/bin:$PATH"
+  fi
+  # fnm: default alias (respects $FNM_DIR override)
+  if ! command -v node >/dev/null 2>&1; then
+    FNM_DIR_RESOLVED="\${FNM_DIR:-$HOME/.local/share/fnm}"
+    FNM_BIN="$FNM_DIR_RESOLVED/aliases/default/bin"
+    [ -d "$FNM_BIN" ] && export PATH="$FNM_BIN:$PATH"
+  fi
+  # volta
+  if ! command -v node >/dev/null 2>&1 && [ -d "$HOME/.volta/bin" ]; then
+    export PATH="$HOME/.volta/bin:$PATH"
+  fi
+  # Homebrew — Apple Silicon first, then Intel/Linux
+  if ! command -v node >/dev/null 2>&1 && [ -d "/opt/homebrew/bin" ]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+  fi
+  if ! command -v node >/dev/null 2>&1 && [ -d "/usr/local/bin" ]; then
+    export PATH="/usr/local/bin:$PATH"
+  fi
+fi
+
+# If node still can't be found, print a clear error and exit
+if ! command -v node >/dev/null 2>&1; then
+  echo "fleet: error: 'node' not found on PATH." >&2
+  echo "       Fleet requires Node.js to run the CLI." >&2
+  echo "       Install it via https://nodejs.org, nvm, fnm, or volta," >&2
+  echo "       then restart Fleet so it can pick up the new installation." >&2
+  exit 1
+fi
+`
+
   if (isPackaged) {
     // Production: use the compiled output bundled alongside the app
     const compiledPath = existsSync(join(dirname(fileURLToPath(import.meta.url)), 'fleet-cli.mjs'))
@@ -45,6 +92,7 @@ export async function installFleetCLI(): Promise<string> {
 
     wrapperContent = `#!/bin/bash
 # Fleet CLI — connects to running Fleet app via Unix socket
+${nodeResolverScript}
 FLEET_DIR="$(dirname "$(dirname "$0")")"
 exec node "$FLEET_DIR/lib/fleet-cli.js" "$@"
 `
@@ -80,6 +128,7 @@ process.exit(result.status ?? 1);
 
     wrapperContent = `#!/bin/bash
 # Fleet CLI — connects to running Fleet app via Unix socket
+${nodeResolverScript}
 FLEET_DIR="$(dirname "$(dirname "$0")")"
 exec node "$FLEET_DIR/lib/fleet-cli.js" "$@"
 `


### PR DESCRIPTION
## Summary
- The fleet shell wrapper now probes nvm, fnm, volta, and Homebrew for `node` when it isn't already on PATH
- Non-interactive shells (Claude Code, cron, etc.) don't source `~/.zshrc` or `nvm.sh`, so this was silently failing for users with node version managers
- Existing setups where `node` is already on PATH are not affected; a clear error is shown if node still can't be found after all probes

## Test plan
- [ ] With nvm and no `node` on PATH, `fleet` correctly resolves node via `~/.nvm/alias/default`
- [ ] Falls back to latest nvm version if default alias isn't set
- [ ] With fnm, resolves node via `~/.local/share/fnm/aliases/default/bin`
- [ ] With volta, resolves node via `~/.volta/bin`
- [ ] With Homebrew, resolves node via `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel)
- [ ] When node is already on PATH, wrapper runs as before without modification
- [ ] If node cannot be found, prints a helpful error message and exits with code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)