### PR TITLE
fix(build): add fleet-cli.ts as separate rollup input for packaged mode

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   main: {
     build: {
       rollupOptions: {
+        input: { index: 'src/main/index.ts', 'fleet-cli': 'src/main/fleet-cli.ts' },
         output: { format: 'es' }
       }
     }

--- a/src/renderer/src/components/StarCommandTab.tsx
+++ b/src/renderer/src/components/StarCommandTab.tsx
@@ -52,7 +52,7 @@ export function StarCommandTab() {
   const [view, setView] = useState<'terminal' | 'config' | 'comms' | 'crew' | 'missions'>('terminal')
   const [talkFrame, setTalkFrame] = useState(false)
   const [resetConfirm, setResetConfirm] = useState(false)
-  const [isRestarting, setIsRestarting] = useState(false)
+  const [_isRestarting, setIsRestarting] = useState(false)
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Auto-dismiss reset confirmation after 5s (Baymard: time-limited destructive states)


### PR DESCRIPTION
## Summary

- Adds `fleet-cli.ts` as a separate Rollup input in `electron.vite.config.ts`, producing `out/main/fleet-cli.mjs` alongside `index.mjs`
- This fixes `install-fleet-cli.ts`'s `isPackaged` detection, which checks for `fleet-cli.mjs` next to `index.mjs` — without this entry the check always failed, embedding dev-mode asar-internal paths that regular node cannot read
- Also fixes a pre-existing unused variable type error in `StarCommandTab.tsx` that was blocking the build

## Test plan

- [x] Build succeeds: `npm run build`
- [x] `out/main/fleet-cli.mjs` is produced
- [x] No type errors: `npm run typecheck`
- [ ] Install Fleet app, run `fleet` command — should connect via socket instead of exiting 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)