### PR TITLE
feat(editor): add FileEditorPane with CodeMirror 6 and full save workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,18 @@
       "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/language": "^6.12.2",
+        "@codemirror/search": "^6.6.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.40.0",
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@git-diff-view/react": "^0.1.2",
@@ -367,6 +379,182 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -2528,6 +2716,95 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
+      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -2605,6 +2882,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@npmcli/agent": {
       "version": "3.0.0",
@@ -6487,6 +6770,12 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -12793,6 +13082,12 @@
       "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -14741,6 +15036,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,18 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/language": "^6.12.2",
+    "@codemirror/search": "^6.6.0",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.40.0",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@git-diff-view/react": "^0.1.2",

--- a/src/renderer/src/components/FileEditorPane.tsx
+++ b/src/renderer/src/components/FileEditorPane.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { EditorState } from '@codemirror/state';
+import {
+  EditorView,
+  keymap,
+  lineNumbers,
+  highlightActiveLineGutter,
+  highlightSpecialChars,
+  drawSelection,
+  highlightActiveLine,
+} from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
+import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
+import { search, searchKeymap } from '@codemirror/search';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { javascript } from '@codemirror/lang-javascript';
+import { html } from '@codemirror/lang-html';
+import { css } from '@codemirror/lang-css';
+import { json } from '@codemirror/lang-json';
+import { markdown } from '@codemirror/lang-markdown';
+import { python } from '@codemirror/lang-python';
+import { useWorkspaceStore } from '../store/workspace-store';
+import { registerFileSave, unregisterFileSave } from '../lib/file-save-registry';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const AUTO_SAVE_DELAY = 3000; // 3 seconds
+const SAVED_FLASH_DURATION = 1500; // 1.5 seconds
+
+function getLanguageExtension(filePath: string) {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  switch (ext) {
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+      return javascript();
+    case 'ts':
+      return javascript({ typescript: true });
+    case 'tsx':
+      return javascript({ typescript: true, jsx: true });
+    case 'jsx':
+      return javascript({ jsx: true });
+    case 'html':
+    case 'htm':
+      return html();
+    case 'css':
+    case 'scss':
+    case 'less':
+      return css();
+    case 'json':
+      return json();
+    case 'md':
+    case 'markdown':
+      return markdown();
+    case 'py':
+      return python();
+    default:
+      return null;
+  }
+}
+
+type Props = {
+  paneId: string;
+  filePath: string;
+};
+
+export function FileEditorPane({ paneId, filePath }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tooLarge, setTooLarge] = useState(false);
+  const [fileSize, setFileSize] = useState(0);
+  const [isDirty, setIsDirty] = useState(false);
+  const [showSaved, setShowSaved] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const savedContentRef = useRef<string>('');
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const savedFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const initialContentRef = useRef<string | null>(null);
+
+  const setPaneDirty = useWorkspaceStore((s) => s.setPaneDirty);
+
+  const save = useCallback(async () => {
+    if (!viewRef.current) return;
+    const content = viewRef.current.state.doc.toString();
+    const result = await window.fleet.file.write(filePath, content);
+    if (result.success) {
+      savedContentRef.current = content;
+      setIsDirty(false);
+      setPaneDirty(paneId, false);
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+      if (savedFlashTimerRef.current) clearTimeout(savedFlashTimerRef.current);
+      setShowSaved(true);
+      savedFlashTimerRef.current = setTimeout(() => setShowSaved(false), SAVED_FLASH_DURATION);
+    }
+  }, [filePath, paneId, setPaneDirty]);
+
+  // Keep saveRef current so closures in EditorView always call the latest save
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  // Load file on mount
+  useEffect(() => {
+    window.fleet.file.read(filePath).then((result) => {
+      if (result.success && result.data) {
+        if (result.data.size > MAX_FILE_SIZE) {
+          setTooLarge(true);
+          setFileSize(result.data.size);
+        } else {
+          initialContentRef.current = result.data.content;
+        }
+      } else {
+        setError(result.error ?? 'Failed to read file');
+      }
+      setLoading(false);
+    });
+  }, [filePath]);
+
+  // Create editor once file is loaded
+  useEffect(() => {
+    if (loading || tooLarge || error !== null || initialContentRef.current === null) return;
+    if (!containerRef.current) return;
+
+    const content = initialContentRef.current;
+    savedContentRef.current = content;
+
+    const langExt = getLanguageExtension(filePath);
+
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: content,
+        extensions: [
+          lineNumbers(),
+          highlightActiveLineGutter(),
+          highlightSpecialChars(),
+          history(),
+          drawSelection(),
+          highlightActiveLine(),
+          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+          search(),
+          keymap.of([
+            { key: 'Mod-s', run: () => { saveRef.current(); return true; } },
+            indentWithTab,
+            ...defaultKeymap,
+            ...historyKeymap,
+            ...searchKeymap,
+          ]),
+          oneDark,
+          EditorView.updateListener.of((update) => {
+            if (!update.docChanged) return;
+            const current = update.state.doc.toString();
+            const dirty = current !== savedContentRef.current;
+            setIsDirty(dirty);
+            setPaneDirty(paneId, dirty);
+            if (dirty) {
+              if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+              autoSaveTimerRef.current = setTimeout(() => {
+                saveRef.current();
+              }, AUTO_SAVE_DELAY);
+            }
+          }),
+          EditorView.theme({
+            '&': { height: '100%' },
+            '.cm-scroller': { overflow: 'auto' },
+          }),
+          ...(langExt ? [langExt] : []),
+        ],
+      }),
+      parent: containerRef.current,
+    });
+
+    viewRef.current = view;
+
+    return () => {
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+      view.destroy();
+      viewRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, tooLarge, error]);
+
+  // Register save function so the close dialog can trigger it
+  useEffect(() => {
+    registerFileSave(paneId, () => saveRef.current());
+    return () => unregisterFileSave(paneId);
+  }, [paneId]);
+
+  // Cleanup dirty state on unmount
+  useEffect(() => {
+    return () => {
+      if (savedFlashTimerRef.current) clearTimeout(savedFlashTimerRef.current);
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+      setPaneDirty(paneId, false);
+    };
+  }, [paneId, setPaneDirty]);
+
+  if (loading) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-[#282c34] text-neutral-400 text-sm">
+        Loading…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-[#282c34] text-red-400 text-sm">
+        Error: {error}
+      </div>
+    );
+  }
+
+  if (tooLarge) {
+    return (
+      <div className="h-full w-full flex flex-col items-center justify-center bg-[#282c34] text-neutral-400 text-sm gap-2">
+        <div className="text-3xl text-neutral-500">⚠</div>
+        <div className="font-medium text-neutral-200">File too large to edit</div>
+        <div className="text-neutral-500">
+          {(fileSize / 1024 / 1024).toFixed(1)} MB — limit is 10 MB
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full relative flex flex-col overflow-hidden">
+      <div ref={containerRef} className="h-full w-full" />
+      {/* Saved flash indicator */}
+      {showSaved && (
+        <div className="absolute bottom-3 right-4 text-xs text-neutral-400 bg-neutral-800 border border-neutral-700 px-2 py-1 rounded pointer-events-none">
+          Saved
+        </div>
+      )}
+      {/* Dirty dot (only when not showing Saved) */}
+      {isDirty && !showSaved && (
+        <div
+          className="absolute bottom-3 right-4 w-2 h-2 rounded-full bg-amber-400 pointer-events-none"
+          title="Unsaved changes"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/components/PaneGrid.tsx
+++ b/src/renderer/src/components/PaneGrid.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 import type { PaneNode } from '../../../shared/types';
 import { TerminalPane } from './TerminalPane';
 import { ImageViewerPane } from './ImageViewerPane';
+import { FileEditorPane } from './FileEditorPane';
 import { useWorkspaceStore } from '../store/workspace-store';
 
 type PaneActions = {
@@ -52,9 +53,10 @@ function PaneNodeRenderer({ node, path, activePaneId, onPaneFocus, serializedPan
   if (node.type === 'leaf') {
     if (node.paneType === 'file') {
       return (
-        <div className="h-full w-full flex items-center justify-center bg-neutral-900 text-neutral-400 text-sm">
-          File Editor: {node.filePath}
-        </div>
+        <FileEditorPane
+          paneId={node.id}
+          filePath={node.filePath ?? ''}
+        />
       );
     }
     if (node.paneType === 'image') {

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
+import * as Dialog from '@radix-ui/react-dialog';
 import { Settings, Terminal, FileCode2, ImageIcon } from 'lucide-react';
 import { TabItem } from './TabItem';
 import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from '../store/workspace-store';
@@ -8,7 +9,24 @@ import { useCwdStore } from '../store/cwd-store';
 import { clearCreatedPty, serializePane } from '../hooks/use-terminal';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
 import { Avatar } from './star-command/Avatar';
-import type { Workspace } from '../../../shared/types';
+import { getFileSave } from '../lib/file-save-registry';
+import type { Workspace, PaneLeaf, Tab } from '../../../shared/types';
+
+function getFirstDirtyPaneId(tab: Tab): string | null {
+  function check(node: Tab['splitRoot']): string | null {
+    if (node.type === 'leaf') return node.isDirty ? node.id : null;
+    return check(node.children[0]) ?? check(node.children[1]);
+  }
+  return check(tab.splitRoot);
+}
+
+function getFirstLeaf(tab: Tab): PaneLeaf | null {
+  function find(node: Tab['splitRoot']): PaneLeaf | null {
+    if (node.type === 'leaf') return node;
+    return find(node.children[0]) ?? find(node.children[1]);
+  }
+  return find(tab.splitRoot);
+}
 
 const AUTO_SAVE_DEBOUNCE_MS = 2000;
 
@@ -250,10 +268,17 @@ export function Sidebar({ updateReady, onCollapse }: { updateReady?: boolean; on
     setDeleteConfirmId(null);
   }, []);
 
-  const handleCloseTab = useCallback((tabId: string) => {
+  // --- File close confirmation ---
+  const [fileCloseConfirm, setFileCloseConfirm] = useState<{
+    tabId: string;
+    label: string;
+    paneId: string;
+  } | null>(null);
+  const [fileSaving, setFileSaving] = useState(false);
+
+  const doCloseTab = useCallback((tabId: string) => {
     const tab = workspace.tabs.find((t) => t.id === tabId);
     if (!tab) return;
-    // Serialize terminal content before React unmounts the components
     const serializedPanes = new Map<string, string>();
     for (const paneId of collectPaneIds(tab.splitRoot)) {
       const content = serializePane(paneId);
@@ -261,6 +286,22 @@ export function Sidebar({ updateReady, onCollapse }: { updateReady?: boolean; on
     }
     closeTab(tabId, serializedPanes);
   }, [workspace.tabs, closeTab]);
+
+  const handleCloseTab = useCallback((tabId: string) => {
+    const tab = workspace.tabs.find((t) => t.id === tabId);
+    if (!tab) return;
+    // File tabs: check for dirty panes before closing
+    if (tab.type === 'file') {
+      const dirtyPaneId = getFirstDirtyPaneId(tab);
+      if (dirtyPaneId) {
+        const leaf = getFirstLeaf(tab);
+        const filename = leaf?.filePath?.split('/').pop() ?? tab.label;
+        setFileCloseConfirm({ tabId, label: filename, paneId: dirtyPaneId });
+        return;
+      }
+    }
+    doCloseTab(tabId);
+  }, [workspace.tabs, doCloseTab]);
 
   return (
     <div className="flex flex-col h-full w-56 bg-neutral-900 border-r border-neutral-800">
@@ -636,6 +677,56 @@ export function Sidebar({ updateReady, onCollapse }: { updateReady?: boolean; on
           )}
         </button>
       </div>
+
+      {/* File close confirmation dialog */}
+      <Dialog.Root
+        open={!!fileCloseConfirm}
+        onOpenChange={(open) => { if (!open && !fileSaving) setFileCloseConfirm(null); }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/60 z-50" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl p-5 w-80 text-sm">
+            <Dialog.Title className="text-base font-semibold text-white mb-1">
+              Save changes to &ldquo;{fileCloseConfirm?.label}&rdquo;?
+            </Dialog.Title>
+            <Dialog.Description className="text-neutral-400 mb-5 text-xs">
+              Your changes will be lost if you don&apos;t save.
+            </Dialog.Description>
+            <div className="flex justify-end gap-2">
+              <button
+                className="px-3 py-1.5 text-xs text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 rounded transition-colors"
+                onClick={() => {
+                  if (fileCloseConfirm) doCloseTab(fileCloseConfirm.tabId);
+                  setFileCloseConfirm(null);
+                }}
+              >
+                Don&apos;t Save
+              </button>
+              <button
+                className="px-3 py-1.5 text-xs text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 rounded transition-colors"
+                onClick={() => setFileCloseConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                disabled={fileSaving}
+                className="px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition-colors font-medium"
+                onClick={async () => {
+                  if (!fileCloseConfirm) return;
+                  setFileSaving(true);
+                  const saveFn = getFileSave(fileCloseConfirm.paneId);
+                  if (saveFn) await saveFn();
+                  setFileSaving(false);
+                  doCloseTab(fileCloseConfirm.tabId);
+                  setFileCloseConfirm(null);
+                }}
+              >
+                {fileSaving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/src/renderer/src/lib/file-save-registry.ts
+++ b/src/renderer/src/lib/file-save-registry.ts
@@ -1,0 +1,17 @@
+/**
+ * Registry of save functions for open file editor panes.
+ * Allows Sidebar's close confirmation dialog to trigger saves.
+ */
+const registry = new Map<string, () => Promise<void>>();
+
+export function registerFileSave(paneId: string, fn: () => Promise<void>): void {
+  registry.set(paneId, fn);
+}
+
+export function unregisterFileSave(paneId: string): void {
+  registry.delete(paneId);
+}
+
+export function getFileSave(paneId: string): (() => Promise<void>) | undefined {
+  return registry.get(paneId);
+}

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -84,6 +84,7 @@ type WorkspaceStore = {
   openFile: (filePath: string) => string;
   addRecentFile: (filePath: string) => void;
   setFileDirty: (paneId: string, isDirty: boolean) => void;
+  setPaneDirty: (paneId: string, dirty: boolean) => void;
 
   // Helpers
   findTab: (tabId: string) => Tab | undefined;
@@ -371,6 +372,18 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   },
 
   markClean: () => set({ isDirty: false }),
+
+  setPaneDirty: (paneId, dirty) => {
+    set((state) => ({
+      workspace: {
+        ...state.workspace,
+        tabs: state.workspace.tabs.map((tab) => ({
+          ...tab,
+          splitRoot: updateLeafInTree(tab.splitRoot, paneId, (leaf) => ({ ...leaf, isDirty: dirty })),
+        })),
+      },
+    }));
+  },
 
   openFile: (filePath) => {
     const ext = getFileExt(filePath);


### PR DESCRIPTION
## Summary
- Replaces the placeholder file pane from Mission 1 with a full CodeMirror 6 editor supporting JS/TS/JSX/TSX/HTML/CSS/JSON/Markdown/Python syntax highlighting and one-dark theme
- Implements complete save workflow: explicit Cmd+S, 3-second auto-save, "Saved" flash indicator, asterisk+bold dirty tab label, and close confirmation dialog (Don't Save / Cancel / Save) for unsaved changes
- Adds a 10 MB file guard showing a size warning instead of loading into the editor; undo/redo (Cmd+Z/Shift+Z) and search (Cmd+F) work via CodeMirror built-in keymaps

## Test plan
- [ ] Open a .ts/.js/.json/.md/.py/.html/.css file — syntax-highlighted editor appears
- [ ] Edit a file — tab label becomes `* filename` in bold
- [ ] Cmd+S saves and clears dirty indicator with brief "Saved" flash
- [ ] Leave dirty for 3+ seconds — auto-save triggers and clears indicator
- [ ] Close a dirty tab — dialog appears with Don't Save / Cancel / Save buttons; each behaves correctly
- [ ] Open a file >10 MB — size warning shown, no editor loaded
- [ ] Cmd+Z / Cmd+Shift+Z undo/redo works; Cmd+F opens search panel
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)