### PR TITLE
feat(ui): improve file/image viewer UX with status bars and unified tabs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
-import { Terminal, FileCode2, ImageIcon } from 'lucide-react';
+import { Terminal, ImageIcon } from 'lucide-react';
+import { getFileIcon } from './lib/file-icons';
 import { Sidebar } from './components/Sidebar';
 import { PaneGrid } from './components/PaneGrid';
-import { useWorkspaceStore, collectPaneIds } from './store/workspace-store';
+import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from './store/workspace-store';
 import { usePaneNavigation } from './hooks/use-pane-navigation';
 import { useNotifications } from './hooks/use-notifications';
 import { useNotificationStore } from './store/notification-store';
@@ -295,7 +296,7 @@ export function App() {
                 {tab.type === 'crew' ? (
                   <Avatar type="crew" variant={tab.avatarVariant} size={20} />
                 ) : tab.type === 'file' ? (
-                  <FileCode2 size={16} className={isActive ? 'text-white' : 'text-neutral-500'} />
+                  <span className={isActive ? 'text-white' : 'text-neutral-500'}>{getFileIcon(collectPaneLeafs(tab.splitRoot)[0]?.filePath?.split('/').pop() ?? tab.label, 16)}</span>
                 ) : tab.type === 'image' ? (
                   <ImageIcon size={16} className={isActive ? 'text-white' : 'text-neutral-500'} />
                 ) : (

--- a/src/renderer/src/components/FileEditorPane.tsx
+++ b/src/renderer/src/components/FileEditorPane.tsx
@@ -24,7 +24,6 @@ import { registerFileSave, unregisterFileSave } from '../lib/file-save-registry'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const AUTO_SAVE_DELAY = 3000; // 3 seconds
-const SAVED_FLASH_DURATION = 1500; // 1.5 seconds
 
 function getLanguageExtension(filePath: string) {
   const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
@@ -58,6 +57,24 @@ function getLanguageExtension(filePath: string) {
   }
 }
 
+function getLanguageName(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  switch (ext) {
+    case 'js': case 'mjs': case 'cjs': return 'JavaScript';
+    case 'ts': return 'TypeScript';
+    case 'tsx': return 'TSX';
+    case 'jsx': return 'JSX';
+    case 'html': case 'htm': return 'HTML';
+    case 'css': return 'CSS';
+    case 'scss': return 'SCSS';
+    case 'less': return 'Less';
+    case 'json': return 'JSON';
+    case 'md': case 'markdown': return 'Markdown';
+    case 'py': return 'Python';
+    default: return 'Plain Text';
+  }
+}
+
 type Props = {
   paneId: string;
   filePath: string;
@@ -69,32 +86,36 @@ export function FileEditorPane({ paneId, filePath }: Props) {
   const [tooLarge, setTooLarge] = useState(false);
   const [fileSize, setFileSize] = useState(0);
   const [isDirty, setIsDirty] = useState(false);
-  const [showSaved, setShowSaved] = useState(false);
+  const [cursorPos, setCursorPos] = useState({ line: 1, col: 1 });
+  const [isSaving, setIsSaving] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const savedContentRef = useRef<string>('');
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const savedFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const initialContentRef = useRef<string | null>(null);
 
   const setPaneDirty = useWorkspaceStore((s) => s.setPaneDirty);
 
   const save = useCallback(async () => {
     if (!viewRef.current) return;
+    setIsSaving(true);
     const content = viewRef.current.state.doc.toString();
     const result = await window.fleet.file.write(filePath, content);
+    setIsSaving(false);
     if (result.success) {
       savedContentRef.current = content;
-      setIsDirty(false);
-      setPaneDirty(paneId, false);
-      if (autoSaveTimerRef.current) {
-        clearTimeout(autoSaveTimerRef.current);
-        autoSaveTimerRef.current = null;
+      // Re-check if editor content changed during the async write
+      const currentContent = viewRef.current?.state.doc.toString();
+      const stillDirty = currentContent !== undefined && currentContent !== content;
+      if (!stillDirty) {
+        setIsDirty(false);
+        setPaneDirty(paneId, false);
+        if (autoSaveTimerRef.current) {
+          clearTimeout(autoSaveTimerRef.current);
+          autoSaveTimerRef.current = null;
+        }
       }
-      if (savedFlashTimerRef.current) clearTimeout(savedFlashTimerRef.current);
-      setShowSaved(true);
-      savedFlashTimerRef.current = setTimeout(() => setShowSaved(false), SAVED_FLASH_DURATION);
     }
   }, [filePath, paneId, setPaneDirty]);
 
@@ -162,6 +183,13 @@ export function FileEditorPane({ paneId, filePath }: Props) {
               }, AUTO_SAVE_DELAY);
             }
           }),
+          EditorView.updateListener.of((update) => {
+            if (update.selectionSet || update.docChanged) {
+              const head = update.state.selection.main.head;
+              const line = update.state.doc.lineAt(head);
+              setCursorPos({ line: line.number, col: head - line.from + 1 });
+            }
+          }),
           EditorView.theme({
             '&': { height: '100%' },
             '.cm-scroller': { overflow: 'auto' },
@@ -191,7 +219,6 @@ export function FileEditorPane({ paneId, filePath }: Props) {
   // Cleanup dirty state on unmount
   useEffect(() => {
     return () => {
-      if (savedFlashTimerRef.current) clearTimeout(savedFlashTimerRef.current);
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
       setPaneDirty(paneId, false);
     };
@@ -225,22 +252,26 @@ export function FileEditorPane({ paneId, filePath }: Props) {
     );
   }
 
+  const langLabel = getLanguageName(filePath);
+  const saveStatus = isSaving
+    ? { label: 'Saving...', className: 'text-neutral-500' }
+    : isDirty
+    ? { label: 'Modified', className: 'text-amber-400' }
+    : { label: 'Saved', className: 'text-emerald-500' };
+
   return (
-    <div className="h-full w-full relative flex flex-col overflow-hidden">
-      <div ref={containerRef} className="h-full w-full" />
-      {/* Saved flash indicator */}
-      {showSaved && (
-        <div className="absolute bottom-3 right-4 text-xs text-neutral-400 bg-neutral-800 border border-neutral-700 px-2 py-1 rounded pointer-events-none">
-          Saved
-        </div>
-      )}
-      {/* Dirty dot (only when not showing Saved) */}
-      {isDirty && !showSaved && (
-        <div
-          className="absolute bottom-3 right-4 w-2 h-2 rounded-full bg-amber-400 pointer-events-none"
-          title="Unsaved changes"
-        />
-      )}
+    <div className="h-full w-full flex flex-col overflow-hidden">
+      <div ref={containerRef} className="flex-1 min-h-0" />
+      <div className="flex-shrink-0 flex items-center gap-3 px-3 h-7 bg-neutral-950/80 border-t border-neutral-800 text-xs text-neutral-400">
+        <span className="text-neutral-300">{langLabel}</span>
+        <span className="text-neutral-500">Ln {cursorPos.line}, Col {cursorPos.col}</span>
+        <span className={`ml-auto flex items-center gap-1.5 ${saveStatus.className}`}>
+          {saveStatus.label === 'Modified' && (
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400" />
+          )}
+          {saveStatus.label}
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/renderer/src/components/ImageViewerPane.tsx
+++ b/src/renderer/src/components/ImageViewerPane.tsx
@@ -29,7 +29,6 @@ export function ImageViewerPane({ filePath }: ImageViewerPaneProps) {
   const [zoom, setZoom] = useState(1);
   const [isFit, setIsFit] = useState(true);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
-  const [isHovered, setIsHovered] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
   const dragAnchor = useRef({ x: 0, y: 0 });
@@ -176,27 +175,23 @@ export function ImageViewerPane({ filePath }: ImageViewerPaneProps) {
     return () => observer.disconnect();
   }, [applyFit]);
 
-  // Keyboard shortcuts (active when pane is hovered)
+  // Keyboard shortcuts (always active unless focused on an input)
   useEffect(() => {
-    if (!isHovered) return;
     const onKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       if (e.key === '0') applyFit();
       else if (e.key === '+' || e.key === '=') adjustZoom(ZOOM_STEP);
       else if (e.key === '-') adjustZoom(-ZOOM_STEP);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [isHovered, applyFit, adjustZoom]);
+  }, [applyFit, adjustZoom]);
 
   const zoomPercent = Math.round(zoom * 100);
   const cursor = isFit ? 'default' : isDragging ? 'grabbing' : 'grab';
 
   return (
-    <div
-      className="flex flex-col h-full w-full bg-neutral-900 select-none"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
+    <div className="flex flex-col h-full w-full bg-neutral-900 select-none">
       {/* Image viewport */}
       <div
         ref={containerRef}
@@ -241,28 +236,6 @@ export function ImageViewerPane({ filePath }: ImageViewerPaneProps) {
           />
         )}
 
-        {/* Zoom indicator */}
-        {imageSrc && (
-          <div className="absolute bottom-2 right-2 bg-black/60 text-white text-xs px-2 py-0.5 rounded pointer-events-none font-mono">
-            {zoomPercent}%
-          </div>
-        )}
-
-        {/* Floating toolbar */}
-        {isHovered && imageSrc && (
-          <div className="absolute top-2 right-2 flex items-center gap-0.5 bg-black/70 backdrop-blur-sm border border-white/10 rounded px-1.5 py-1">
-            <ToolbarButton onClick={() => adjustZoom(ZOOM_STEP)} title="Zoom In (+)">+</ToolbarButton>
-            <ToolbarButton onClick={() => adjustZoom(-ZOOM_STEP)} title="Zoom Out (−)">−</ToolbarButton>
-            <div className="w-px h-3.5 bg-neutral-600 mx-0.5" />
-            <ToolbarButton onClick={applyFit} title="Fit to Window (0)">Fit</ToolbarButton>
-            <ToolbarButton
-              onClick={() => { setZoom(1); setOffset({ x: 0, y: 0 }); setIsFit(false); }}
-              title="Actual Size (1:1)"
-            >
-              1:1
-            </ToolbarButton>
-          </div>
-        )}
       </div>
 
       {/* Status bar */}
@@ -273,6 +246,27 @@ export function ImageViewerPane({ filePath }: ImageViewerPaneProps) {
         )}
         {fileSize !== null && (
           <span className="text-neutral-500">{formatSize(fileSize)}</span>
+        )}
+        {imageSrc && (
+          <div className="ml-auto flex items-center gap-0.5">
+            <ToolbarButton onClick={() => adjustZoom(-ZOOM_STEP)} title="Zoom Out (−)">−</ToolbarButton>
+            <span
+              className="font-mono w-10 text-center text-neutral-400 hover:text-white cursor-pointer"
+              onClick={applyFit}
+              title="Click to fit"
+            >
+              {zoomPercent}%
+            </span>
+            <ToolbarButton onClick={() => adjustZoom(ZOOM_STEP)} title="Zoom In (+)">+</ToolbarButton>
+            <div className="w-px h-3.5 bg-neutral-700 mx-1" />
+            <ToolbarButton onClick={applyFit} title="Fit to Window (0)">Fit</ToolbarButton>
+            <ToolbarButton
+              onClick={() => { setZoom(1); setOffset({ x: 0, y: 0 }); setIsFit(false); }}
+              title="Actual Size"
+            >
+              1:1
+            </ToolbarButton>
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/src/components/QuickOpenOverlay.tsx
+++ b/src/renderer/src/components/QuickOpenOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWorkspaceStore } from '../store/workspace-store';
 import { fuzzyMatch } from '../lib/commands';
+import { getFileIcon } from '../lib/file-icons';
 
 type FileEntry = {
   path: string;
@@ -54,6 +55,7 @@ export function QuickOpenOverlay({ isOpen, onClose, rootDir }: QuickOpenOverlayP
   useEffect(() => {
     if (!isOpen || !rootDir) return;
     setIsLoading(true);
+    setAllFiles([]);
     window.fleet.file.list(rootDir).then((result) => {
       if (result.success) {
         setAllFiles(result.files);
@@ -169,29 +171,18 @@ export function QuickOpenOverlay({ isOpen, onClose, rootDir }: QuickOpenOverlayP
                 onMouseEnter={() => setSelectedIndex(i)}
                 onClick={() => handleSelect(file)}
               >
-                {/* File icon */}
-                <svg
-                  className="text-neutral-500 shrink-0"
-                  width="13"
-                  height="13"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M9 2H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6L9 2z" />
-                  <polyline points="9 2 9 6 13 6" />
-                </svg>
-                {/* Filename + path */}
+                <span className="text-neutral-500 shrink-0">
+                  {getFileIcon(file.name)}
+                </span>
                 <div className="flex flex-col min-w-0">
                   <span className="truncate font-medium">
                     <HighlightedText text={file.name} query={query} />
                   </span>
                   {file.relativePath !== file.name && (
-                    <span className="truncate text-xs text-neutral-500">
-                      {file.relativePath}
+                    <span className="truncate text-xs text-neutral-600">
+                      {file.relativePath.includes('/')
+                        ? file.relativePath.split('/').slice(0, -1).join('/')
+                        : file.relativePath}
                     </span>
                   )}
                 </div>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Settings, Terminal, FileCode2, ImageIcon } from 'lucide-react';
+import { Settings, Terminal, ImageIcon } from 'lucide-react';
+import { getFileIcon } from '../lib/file-icons';
 import { TabItem } from './TabItem';
 import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from '../store/workspace-store';
 import { useNotificationStore } from '../store/notification-store';
@@ -444,84 +445,77 @@ export function Sidebar({ updateReady, onCollapse }: { updateReady?: boolean; on
         {workspace.tabs.filter((t) => t.type === 'crew').length > 0 && (
           <div className="h-px bg-neutral-800 mx-1 my-1" />
         )}
-        {workspace.tabs.filter((t) => t.type !== 'star-command' && t.type !== 'crew' && t.type !== 'file' && t.type !== 'image').map((tab, index) => {
-          const paneIds = collectPaneIds(tab.splitRoot);
-          // Active pane within this tab drives the displayed CWD
-          const drivingPane = (tab.id === activeTabId && activePaneId && paneIds.includes(activePaneId))
-            ? activePaneId
-            : paneIds[0];
-          const liveCwd = (drivingPane ? cwds.get(drivingPane) : undefined) ?? tab.cwd;
+        {workspace.tabs
+          .filter((t) => t.type !== 'star-command' && t.type !== 'crew')
+          .map((tab, index) => {
+            const paneIds = collectPaneIds(tab.splitRoot);
+            const isFile = tab.type === 'file' || tab.type === 'image';
 
-          return (
-            <TabItem
-              key={tab.id}
-              id={tab.id}
-              label={tab.label}
-              labelIsCustom={tab.labelIsCustom ?? false}
-              cwd={liveCwd}
-              isActive={tab.id === activeTabId}
-              badge={getTabBadge(paneIds)}
-              icon={<Terminal size={14} />}
-              index={index}
-              onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
-              onDrop={handleDrop}
-              isDragOver={
-                dropTarget?.index === index
-                  ? dropTarget.position
-                  : null
-              }
-              onClick={() => {
-                setActiveTab(tab.id);
-                for (const paneId of paneIds) {
-                  useNotificationStore.getState().clearPane(paneId);
-                  window.fleet.notifications.paneFocused({ paneId });
+            // Derive CWD to display in TabItem
+            let displayCwd: string;
+            if (isFile) {
+              const leafs = collectPaneLeafs(tab.splitRoot);
+              const filePath = leafs[0]?.filePath ?? '';
+              displayCwd = filePath
+                ? filePath.split('/').slice(0, -1).join('/') || '/'
+                : '/';
+            } else {
+              const drivingPane =
+                tab.id === activeTabId && activePaneId && paneIds.includes(activePaneId)
+                  ? activePaneId
+                  : paneIds[0];
+              displayCwd = (drivingPane ? cwds.get(drivingPane) : undefined) ?? tab.cwd;
+            }
+
+            // Dirty label for file tabs
+            const isFileDirty = isFile && collectPaneLeafs(tab.splitRoot).some((l) => l.isDirty === true);
+            const displayLabel = isFile && isFileDirty ? tab.label + ' *' : tab.label;
+
+            // Icon — use filePath basename for file tabs (label may be renamed)
+            let icon: React.ReactNode;
+            if (isFile) {
+              const leafs2 = collectPaneLeafs(tab.splitRoot);
+              const fileBasename = leafs2[0]?.filePath?.split('/').pop() ?? tab.label;
+              icon = tab.type === 'image'
+                ? <ImageIcon size={14} />
+                : getFileIcon(fileBasename, 14);
+            } else {
+              icon = <Terminal size={14} />;
+            }
+
+            return (
+              <TabItem
+                key={tab.id}
+                id={tab.id}
+                label={displayLabel}
+                labelIsCustom={tab.labelIsCustom ?? false}
+                cwd={displayCwd}
+                isActive={tab.id === activeTabId}
+                badge={getTabBadge(paneIds)}
+                icon={icon}
+                disableReset={isFile}
+                index={index}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+                isDragOver={
+                  dropTarget?.index === index ? dropTarget.position : null
                 }
-              }}
-              onClose={() => handleCloseTab(tab.id)}
-              onRename={(newLabel) => renameTab(tab.id, newLabel)}
-              onResetLabel={() => resetTabLabel(tab.id, liveCwd)}
-            />
-          );
-        })}
-        {/* File and image tabs */}
-        {workspace.tabs.filter((t) => t.type === 'file' || t.type === 'image').map((tab) => {
-          const leafs = collectPaneLeafs(tab.splitRoot);
-          const filePath = leafs[0]?.filePath;
-          const isFileDirty = leafs.some(l => l.isDirty === true);
-          const isActive = tab.id === activeTabId;
-          const Icon = tab.type === 'image' ? ImageIcon : FileCode2;
-          return (
-            <div
-              key={tab.id}
-              data-tab-id={tab.id}
-              className={`
-                group flex items-center gap-2 px-3 py-1.5 cursor-pointer rounded-md text-sm min-h-[44px] transition-colors
-                ${isActive
-                  ? 'bg-neutral-700 text-white border-l-2 border-blue-400'
-                  : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 border-l-2 border-transparent'}
-              `}
-              onClick={() => setActiveTab(tab.id)}
-              title={filePath ?? tab.label}
-            >
-              <span className={`flex-shrink-0 ${isActive ? 'text-neutral-400' : 'text-neutral-600'}`}>
-                <Icon size={14} />
-              </span>
-              <div className="flex-1 min-w-0">
-                <div className={`truncate text-sm leading-tight ${isFileDirty ? 'font-semibold' : ''}`}>
-                  {tab.label}{isFileDirty ? ' *' : ''}
-                </div>
-              </div>
-              <button
-                className="opacity-0 group-hover:opacity-100 text-neutral-500 hover:text-red-400 transition-opacity flex-shrink-0"
-                onClick={(e) => { e.stopPropagation(); handleCloseTab(tab.id); }}
-                title="Close"
-              >
-                ×
-              </button>
-            </div>
-          );
-        })}
+                onClick={() => {
+                  setActiveTab(tab.id);
+                  if (!isFile) {
+                    for (const paneId of paneIds) {
+                      useNotificationStore.getState().clearPane(paneId);
+                      window.fleet.notifications.paneFocused({ paneId });
+                    }
+                  }
+                }}
+                onClose={() => handleCloseTab(tab.id)}
+                onRename={(newLabel) => renameTab(tab.id, newLabel)}
+                onResetLabel={() => resetTabLabel(tab.id, displayCwd)}
+              />
+            );
+          })}
       </div>
       {/* Scroll overflow shadow indicator */}
       {hasScrollOverflow && (

--- a/src/renderer/src/components/TabItem.tsx
+++ b/src/renderer/src/components/TabItem.tsx
@@ -26,6 +26,7 @@ type TabItemProps = {
   onClose: () => void;
   onRename: (newLabel: string) => void;
   onResetLabel: () => void;
+  disableReset?: boolean;
   // Drag-and-drop
   index: number;
   onDragStart: (index: number) => void;
@@ -55,6 +56,7 @@ export function TabItem({
   onClose,
   onRename,
   onResetLabel,
+  disableReset,
   index,
   onDragStart,
   onDragOver,
@@ -206,7 +208,7 @@ export function TabItem({
           >
             Rename
           </ContextMenu.Item>
-          {labelIsCustom && (
+          {!disableReset && labelIsCustom && (
             <ContextMenu.Item
               className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-neutral-700 hover:bg-neutral-700"
               onSelect={onResetLabel}

--- a/src/renderer/src/lib/file-icons.tsx
+++ b/src/renderer/src/lib/file-icons.tsx
@@ -1,0 +1,63 @@
+import {
+  FileCode2,
+  FileImage,
+  FileJson,
+  FileText,
+  File,
+  type LucideIcon,
+} from 'lucide-react';
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  // Code
+  '.js': FileCode2,
+  '.jsx': FileCode2,
+  '.mjs': FileCode2,
+  '.cjs': FileCode2,
+  '.ts': FileCode2,
+  '.tsx': FileCode2,
+  '.py': FileCode2,
+  '.go': FileCode2,
+  '.rs': FileCode2,
+  '.c': FileCode2,
+  '.cpp': FileCode2,
+  '.java': FileCode2,
+  '.rb': FileCode2,
+  '.sh': FileCode2,
+  // Web
+  '.html': FileCode2,
+  '.htm': FileCode2,
+  '.css': FileCode2,
+  '.scss': FileCode2,
+  '.less': FileCode2,
+  // Data
+  '.json': FileJson,
+  '.jsonc': FileJson,
+  // Markup / docs
+  '.md': FileText,
+  '.mdx': FileText,
+  '.txt': FileText,
+  '.rst': FileText,
+  // Config
+  '.yaml': FileText,
+  '.yml': FileText,
+  '.toml': FileText,
+  '.env': FileText,
+  '.ini': FileText,
+  // Images
+  '.png': FileImage,
+  '.jpg': FileImage,
+  '.jpeg': FileImage,
+  '.gif': FileImage,
+  '.webp': FileImage,
+  '.svg': FileImage,
+  '.ico': FileImage,
+  '.bmp': FileImage,
+};
+
+/** Returns a sized lucide icon for a given filename. */
+export function getFileIcon(filename: string, size = 13): React.ReactNode {
+  const dot = filename.lastIndexOf('.');
+  const ext = dot >= 0 ? filename.slice(dot).toLowerCase() : '';
+  const Icon = ICON_MAP[ext] ?? File;
+  return <Icon size={size} />;
+}


### PR DESCRIPTION
## Summary
- **Quick Open (Cmd+P):** File-type icons (code, image, JSON, text, config) replace generic SVG; directory-only path display in dimmer color; stale file list cleared on reopen
- **Image Viewer:** Hover-only floating toolbar replaced with always-visible bottom status bar containing zoom controls (−, %, +, Fit, 1:1) — per NNG research on control discoverability
- **File Editor:** New permanent status bar showing language mode, cursor position (Ln/Col), and save status (Saved/Modified/Saving...) replacing tiny floating indicators
- **Tab unification:** File and image tabs now use the same `TabItem` component as terminal tabs, gaining drag-and-drop reorder, inline rename, and right-click context menu
- **Bug fix:** Save race condition where typing during an in-flight auto-save could incorrectly clear dirty state

## Test plan
- [ ] Open a file via Cmd+P — verify file-type icons appear and directory paths show correctly
- [ ] Open an image — verify zoom controls are always visible in the bottom status bar
- [ ] Open a code file — verify status bar shows language, Ln/Col updates on cursor move, save status transitions correctly
- [ ] Verify file/image tabs in sidebar support drag-to-reorder, double-click rename, and right-click context menu
- [ ] Close a dirty file tab — verify unsaved changes dialog still works
- [ ] Type while auto-save is in progress — verify dirty indicator stays visible until save completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)