### PR TITLE
refactor: convert blocking sync operations to async in main process

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,6 +1,5 @@
 import { ipcMain, BrowserWindow, dialog } from 'electron'
 import { readFile, writeFile, stat, readdir } from 'fs/promises'
-import { readFileSync } from 'fs'
 import { extname, join, relative, resolve } from 'path'
 import { exec } from 'child_process'
 import { promisify } from 'util'
@@ -344,14 +343,14 @@ export function registerIpcHandlers(
       memoService!.dismiss(id)
     })
 
-    ipcMain.handle(IPC_CHANNELS.MEMO_CONTENT, (_e, filePath: string) => {
+    ipcMain.handle(IPC_CHANNELS.MEMO_CONTENT, async (_e, filePath: string) => {
       const allowedBase = join(process.env.HOME ?? '~', '.fleet', 'starbases')
       const resolved = resolve(filePath)
       if (!resolved.startsWith(allowedBase) || !resolved.includes('first-officer/memos/')) {
         return null
       }
       try {
-        return readFileSync(resolved, 'utf-8')
+        return await readFile(resolved, 'utf-8')
       } catch {
         return null
       }

--- a/src/main/starbase/admiral-process.ts
+++ b/src/main/starbase/admiral-process.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs'
+import * as fsp from 'fs/promises'
 import * as path from 'path'
-import { execSync, exec } from 'child_process'
+import { exec } from 'child_process'
 import { promisify } from 'util'
 import type { PtyManager } from '../pty-manager'
 
@@ -106,20 +106,30 @@ export class AdmiralProcess {
     ]
 
     for (const dir of dirsToCreate) {
-      fs.mkdirSync(dir, { recursive: true })
+      await fsp.mkdir(dir, { recursive: true })
     }
 
     // 2. git init if no .git/
     const gitDir = path.join(this.workspace, '.git')
-    if (!fs.existsSync(gitDir)) {
-      execSync('git init', { cwd: this.workspace, stdio: 'ignore' })
+    try {
+      await fsp.access(gitDir)
+    } catch {
+      await execAsync('git init', { cwd: this.workspace })
     }
 
     // 3. Handle CLAUDE.md
     const claudeMdPath = path.join(this.workspace, 'CLAUDE.md')
-    if (fs.existsSync(claudeMdPath)) {
+    let claudeMdExists = false
+    try {
+      await fsp.access(claudeMdPath)
+      claudeMdExists = true
+    } catch {
+      // does not exist
+    }
+
+    if (claudeMdExists) {
       // Read existing content and update sectors auto-section only
-      const existing = fs.readFileSync(claudeMdPath, 'utf-8')
+      const existing = await fsp.readFile(claudeMdPath, 'utf-8')
       const sectorLines =
         this.sectors.length > 0
           ? this.sectors
@@ -131,20 +141,20 @@ export class AdmiralProcess {
               .join('\n')
           : '_No sectors registered._'
       const updated = updateAutoSection(existing, 'sectors', sectorLines)
-      fs.writeFileSync(claudeMdPath, updated, 'utf-8')
+      await fsp.writeFile(claudeMdPath, updated, 'utf-8')
     } else {
       // Write full generated content
       const content = generateClaudeMd({ starbaseName: this.starbaseName, sectors: this.sectors })
-      fs.writeFileSync(claudeMdPath, content, 'utf-8')
+      await fsp.writeFile(claudeMdPath, content, 'utf-8')
     }
 
     // 4. Always overwrite skill file
     const skillPath = path.join(this.workspace, '.claude', 'skills', 'fleet', 'SKILL.md')
-    fs.writeFileSync(skillPath, generateSkillMd(), 'utf-8')
+    await fsp.writeFile(skillPath, generateSkillMd(), 'utf-8')
 
     // 5. Always overwrite settings (include fleet bin path so Claude can find the CLI)
     const settingsPath = path.join(this.workspace, '.claude', 'settings.json')
-    fs.writeFileSync(settingsPath, generateSettings(this.fleetBinPath), 'utf-8')
+    await fsp.writeFile(settingsPath, generateSettings(this.fleetBinPath), 'utf-8')
   }
 
   async start(): Promise<string> {
@@ -217,7 +227,7 @@ export class AdmiralProcess {
    */
   async reset(): Promise<string> {
     await this.stop()
-    fs.rmSync(this.workspace, { recursive: true, force: true })
+    await fsp.rm(this.workspace, { recursive: true, force: true })
     return this.start()
   }
 }

--- a/src/main/starbase/sentinel.ts
+++ b/src/main/starbase/sentinel.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import { existsSync } from 'fs';
+import { access } from 'fs/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { createConnection } from 'node:net';
@@ -44,6 +44,7 @@ type SectorRow = {
 export class Sentinel {
   private interval: ReturnType<typeof setInterval> | null = null;
   private sweepCount = 0;
+  private sweepInProgress = false;
   private consecutivePingFailures = 0;
   private diskCacheBytes: number | null = null;
   private diskCacheTime = 0;
@@ -70,6 +71,16 @@ export class Sentinel {
   }
 
   async runSweep(): Promise<void> {
+    if (this.sweepInProgress) return;
+    this.sweepInProgress = true;
+    try {
+      await this._runSweep();
+    } finally {
+      this.sweepInProgress = false;
+    }
+  }
+
+  private async _runSweep(): Promise<void> {
     this.sweepCount++;
     const { db, configService } = this.deps;
 
@@ -124,7 +135,13 @@ export class Sentinel {
     // 3. Sector path validation
     const sectors = db.prepare('SELECT id, root_path FROM sectors').all() as SectorRow[];
     for (const sector of sectors) {
-      if (!existsSync(sector.root_path)) {
+      let pathExists = true;
+      try {
+        await access(sector.root_path);
+      } catch {
+        pathExists = false;
+      }
+      if (!pathExists) {
         // Mark all crew in this sector as lost
         db.prepare(
           "UPDATE crew SET status = 'lost', updated_at = datetime('now') WHERE sector_id = ? AND status = 'active'",
@@ -201,7 +218,11 @@ export class Sentinel {
     try {
       const homePath = process.env.HOME ?? '~';
       const worktreePath = `${homePath}/.fleet/worktrees`;
-      if (!existsSync(worktreePath)) return 0;
+      try {
+        await access(worktreePath);
+      } catch {
+        return 0;
+      }
 
       const { stdout } = await execFileAsync('du', ['-sk', worktreePath], { timeout: 10_000 });
       const match = stdout.match(/^(\d+)/);


### PR DESCRIPTION
## Summary
- Convert `AdmiralProcess.ensureWorkspace()` from sync FS/`execSync` to async `fs/promises`/`execAsync` — eliminates the hardest event loop block (`execSync('git init')`)
- Convert sentinel `existsSync` calls to async `access()` in sector path validation (step 3) and disk usage check (step 5), plus add a `sweepInProgress` guard to prevent overlapping sweeps
- Convert `MEMO_CONTENT` IPC handler from `readFileSync` to async `readFile`

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] Test suite results unchanged (17 pre-existing failures from `better-sqlite3` Node version mismatch, unrelated)
- [ ] Manual: start Admiral, verify workspace creation works
- [ ] Manual: reset Admiral, verify workspace is deleted and recreated
- [ ] Manual: verify sentinel sweeps run without errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)