### PR TITLE
feat(crew): include mission type in crew names

### DIFF
--- a/src/main/__tests__/crew-service.test.ts
+++ b/src/main/__tests__/crew-service.test.ts
@@ -55,7 +55,12 @@ afterEach(() => {
 describe('CrewService', () => {
   it('should generate a crew ID with sector slug and random hex', () => {
     const id = crewSvc.generateCrewId('api');
-    expect(id).toMatch(/^api-crew-[a-f0-9]{4}$/);
+    expect(id).toMatch(/^api-code-[a-f0-9]{4}$/);
+  });
+
+  it('should generate a crew ID with the specified mission type', () => {
+    const id = crewSvc.generateCrewId('fleet', 'research');
+    expect(id).toMatch(/^fleet-research-[a-f0-9]{4}$/);
   });
 
   it('should list crew (empty initially)', () => {

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -59,9 +59,9 @@ export class CrewService {
 
   constructor(private deps: CrewServiceDeps) {}
 
-  generateCrewId(sectorSlug: string): string {
+  generateCrewId(sectorSlug: string, missionType: string = 'code'): string {
     const hex = randomBytes(2).toString('hex');
-    return `${sectorSlug}-crew-${hex}`;
+    return `${sectorSlug}-${missionType}-${hex}`;
   }
 
   /**
@@ -106,7 +106,7 @@ export class CrewService {
     }
 
     // 4. Generate crew ID
-    const crewId = this.generateCrewId(sector.id);
+    const crewId = this.generateCrewId(sector.id, missionType);
 
     // 5. Create worktree
     let worktreeResult;


### PR DESCRIPTION
## Summary
- Updated `generateCrewId` to accept a `missionType` parameter (default: `'code'`)
- Crew names now follow the format `{sector}-{type}-{hex}` (e.g., `fleet-research-9da3`, `fleet-code-b3c4`) instead of `fleet-crew-XXXX`
- Pass mission type through at the `deployCrew` call site and updated tests to match

## Test plan
- [x] `generateCrewId('api')` produces `api-code-XXXX` (default)
- [x] `generateCrewId('fleet', 'research')` produces `fleet-research-XXXX`
- [x] Existing crew service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)