### PR TITLE
fix(missions): transition approved missions to completed and send comm

### DIFF
--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -405,7 +405,22 @@ export class SocketServer extends EventEmitter {
         }
 
         missionService.setReviewVerdict(id, verdict, notes);
-        missionService.setStatus(id, verdict);
+        if (verdict === 'approved') {
+          missionService.setStatus(id, 'completed');
+          const mission = missionService.getMission(id);
+          commsService.send({
+            from: 'admiral',
+            to: 'admiral',
+            type: 'mission_approved',
+            payload: JSON.stringify({
+              missionId: id,
+              summary: mission?.summary ?? '',
+              pr_branch: mission?.pr_branch ?? null,
+            }),
+          });
+        } else {
+          missionService.setStatus(id, verdict);
+        }
         this.emit('state-change', 'mission:changed', { id });
         return missionService.getMission(id);
       }

--- a/src/main/starbase/sentinel.ts
+++ b/src/main/starbase/sentinel.ts
@@ -604,6 +604,24 @@ ${mission.review_notes ?? 'No specific notes provided'}
         console.error(`[sentinel] Fix crew deploy failed for mission ${mission.id}:`, err)
       }
     }
+
+    // Auto-approved missions — transition to completed and notify admiral
+    const autoApproved = db
+      .prepare(
+        `SELECT id, summary, pr_branch FROM missions
+         WHERE status = 'approved'`
+      )
+      .all() as { id: number; summary: string; pr_branch: string | null }[]
+
+    for (const mission of autoApproved) {
+      db.prepare(
+        "UPDATE missions SET status = 'completed', completed_at = datetime('now') WHERE id = ?"
+      ).run(mission.id)
+      db.prepare(
+        "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES ('admiral', 'admiral', 'mission_approved', ?)"
+      ).run(JSON.stringify({ missionId: mission.id, summary: mission.summary, pr_branch: mission.pr_branch }))
+      this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' })
+    }
   }
 
   private pingSocket(socketPath: string, timeoutMs: number): Promise<boolean> {


### PR DESCRIPTION
## Summary
- When a mission verdict of `approved` is set via the CLI, the mission now transitions to `completed` (instead of staying in `approved` forever) and a `mission_approved` comm is sent to the admiral with `missionId`, `summary`, and `pr_branch`
- Added a sentinel sweep that catches any missions stuck in `approved` status (e.g. auto-approved by the first officer without a CLI verdict command) and performs the same transition + comm

## Test plan
- [ ] Run `fleet missions verdict <id> --verdict approved` and verify mission status becomes `completed`
- [ ] Verify a `mission_approved` comm appears in `fleet comms`
- [ ] Seed a mission with `status = 'approved'` directly in the DB and confirm the sentinel sweep transitions it to `completed` on next tick
- [ ] Verify `changes-requested` and `escalated` verdicts still set the mission to their respective statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)