### PR TITLE
feat(system-checker): add fleet.sock connectivity check

### DIFF
--- a/src/main/system-checker.ts
+++ b/src/main/system-checker.ts
@@ -3,13 +3,83 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import * as net from 'net'
 import type { SystemDepResult } from '../shared/ipc-api'
+import { SOCKET_PATH } from '../shared/constants'
 
 const execAsync = promisify(exec)
 
 const FLEET_BIN = join(homedir(), '.fleet', 'bin', 'fleet')
 
-const CHECKS = [
+type CmdCheck = {
+  name: string
+  cmd: string
+  installHint: string
+  preCheck?: () => boolean
+  fn?: never
+}
+
+type FnCheck = {
+  name: string
+  fn: () => Promise<SystemDepResult>
+  cmd?: never
+  preCheck?: never
+  installHint?: never
+}
+
+type Check = CmdCheck | FnCheck
+
+async function checkFleetSock(): Promise<SystemDepResult> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection(SOCKET_PATH)
+    let responded = false
+
+    const fail = () => {
+      if (responded) return
+      responded = true
+      socket.destroy()
+      resolve({
+        name: 'fleet.sock',
+        found: false,
+        installHint:
+          'Fleet socket is not running. The app may still be starting up — try clicking Retry in a moment.'
+      })
+    }
+
+    socket.setTimeout(3000)
+    socket.on('timeout', fail)
+    socket.on('error', fail)
+
+    socket.on('connect', () => {
+      socket.write(JSON.stringify({ command: 'ping' }) + '\n')
+    })
+
+    let buf = ''
+    socket.on('data', (data) => {
+      if (responded) return
+      buf += data.toString()
+      const line = buf.split('\n')[0]
+      try {
+        const msg = JSON.parse(line)
+        if (msg.ok === true && msg.data?.pong === true) {
+          responded = true
+          socket.destroy()
+          const uptime = msg.data.uptime
+          const version = uptime !== undefined ? `uptime: ${Math.round(uptime)}s` : undefined
+          resolve({ name: 'fleet.sock', found: true, version })
+        }
+      } catch {
+        // keep buffering
+      }
+    })
+
+    socket.on('close', () => {
+      if (!responded) fail()
+    })
+  })
+}
+
+const CHECKS: Check[] = [
   {
     name: 'node',
     cmd: 'node --version',
@@ -36,6 +106,10 @@ const CHECKS = [
     installHint: 'Fleet CLI should be auto-installed. Try restarting Fleet.',
     // Check binary exists before exec to avoid slow timeout
     preCheck: () => process.platform === 'win32' || existsSync(FLEET_BIN)
+  },
+  {
+    name: 'fleet.sock',
+    fn: checkFleetSock
   }
 ]
 
@@ -43,6 +117,11 @@ export async function checkSystemDeps(): Promise<SystemDepResult[]> {
   const results: SystemDepResult[] = []
 
   for (const check of CHECKS) {
+    if (check.fn) {
+      results.push(await check.fn())
+      continue
+    }
+
     if (check.preCheck && !check.preCheck()) {
       results.push({ name: check.name, found: false, installHint: check.installHint })
       continue

--- a/src/renderer/src/components/AppPreChecks.tsx
+++ b/src/renderer/src/components/AppPreChecks.tsx
@@ -5,7 +5,7 @@ interface Props {
   onDismiss: () => void
 }
 
-const DEP_NAMES = ['node', 'claude', 'git', 'gh', 'fleet']
+const DEP_NAMES = ['node', 'claude', 'git', 'gh', 'fleet', 'fleet.sock']
 
 export function AppPreChecks({ onDismiss }: Props) {
   const [status, setStatus] = useState<'checking' | 'passed' | 'failed'>('checking')


### PR DESCRIPTION
## Summary
- Adds a new `fleet.sock` pre-start check that connects to the Fleet Unix socket, sends a ping command, and verifies a pong response within a 3-second timeout
- Refactors `system-checker.ts` CHECKS array to support both shell-command checks and async function checks via a discriminated union type
- Adds `fleet.sock` to the `DEP_NAMES` placeholder list in `AppPreChecks.tsx` so it appears in the UI while checks run

## Test plan
- [ ] With the Fleet socket running, open the app and verify `fleet.sock` shows as "found" with an uptime value
- [ ] With the Fleet socket not running, verify `fleet.sock` shows as "missing" with the hint about retrying
- [ ] Verify existing checks (node, claude, git, gh, fleet) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)