### PR TITLE
fix(star-command): keep admiral terminal mounted when memo panel opens

### DIFF
--- a/src/renderer/src/components/StarCommandTab.tsx
+++ b/src/renderer/src/components/StarCommandTab.tsx
@@ -278,9 +278,7 @@ export function StarCommandTab() {
               </div>
             </div>
 
-            {showMemos ? (
-              <MemoPanel onClose={() => setShowMemos(false)} />
-            ) : view === 'config' ? (
+            {view === 'config' ? (
               <StarCommandConfig />
             ) : view === 'comms' ? (
               <CommsPanel />
@@ -349,6 +347,12 @@ export function StarCommandTab() {
                   </div>
                 )}
 
+                {/* Memo overlay — rendered on top of AdmiralTerminal so the terminal stays mounted */}
+                {showMemos && (
+                  <div className="absolute inset-0 z-10">
+                    <MemoPanel onClose={() => setShowMemos(false)} />
+                  </div>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- Opening the First Officer memo panel no longer unmounts the Admiral terminal
- `MemoPanel` is now rendered as an `absolute inset-0 z-10` overlay within the terminal container, keeping `AdmiralTerminal` mounted at all times
- Closing the memo (via its Close button) still works by setting `showMemos = false` to hide the overlay

## Test plan
- [ ] Open Fleet and start the Admiral terminal
- [ ] Click the First Officer memo button to open the memo panel
- [ ] Verify the memo panel appears as an overlay
- [ ] Close the memo panel — Admiral terminal should still be running without reconnecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)