### PR TITLE
feat(missions): add review as a valid mission type

### DIFF
--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -320,24 +320,26 @@ function validateCommand(command: string, args: Record<string, unknown>): string
 
     // ── Missions ──────────────────────────────────────────────────────────
     case 'mission.create': {
-      const usage = 'Usage: fleet missions add --sector <id> --type <code|research> --summary "short title" --prompt "detailed instructions"';
+      const usage = 'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"';
       if (!args.sector && !args.sectorId)
         return `Error: missions add requires --sector <id>.\n\n${usage}`;
       if (!args.type) {
         return (
-          'Error: missions add requires --type <code|research>.\n\n' +
+          'Error: missions add requires --type <code|research|review>.\n\n' +
           'Mission types:\n' +
           '  code     — produces git commits (code changes, bug fixes, features)\n' +
-          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n\n' +
+          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+          '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n\n' +
           usage
         );
       }
-      if (args.type !== 'code' && args.type !== 'research') {
+      if (args.type !== 'code' && args.type !== 'research' && args.type !== 'review') {
         return (
-          `Error: invalid mission type "${args.type}". Must be "code" or "research".\n\n` +
+          `Error: invalid mission type "${args.type}". Must be "code", "research", or "review".\n\n` +
           'Mission types:\n' +
           '  code     — produces git commits (code changes, bug fixes, features)\n' +
-          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n\n' +
+          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+          '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n\n' +
           usage
         );
       }

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -244,7 +244,8 @@ export class SocketServer extends EventEmitter {
         const summary = args.summary as string | undefined;
         const prompt = args.prompt as string | undefined;
         const type = args.type as string | undefined;
-        const VALID_MISSION_TYPES = ['code', 'research'];
+        const VALID_MISSION_TYPES = ['code', 'research', 'review'];
+        const prBranch = args['pr-branch'] as string | undefined;
 
         if (!sectorId) {
           const err = new Error('mission.create requires --sector <id>') as Error & { code: string };
@@ -253,21 +254,23 @@ export class SocketServer extends EventEmitter {
         }
         if (!type) {
           const err = new Error(
-            'mission.create requires --type <code|research>.\n' +
+            'mission.create requires --type <code|research|review>.\n' +
             'Mission types:\n' +
             '  code     — produces git commits (code changes, bug fixes, features)\n' +
             '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
-            'Usage: fleet missions add --sector <id> --type <code|research> --summary "short title" --prompt "detailed instructions"'
+            '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
+            'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"'
           ) as Error & { code: string };
           err.code = 'BAD_REQUEST';
           throw err;
         }
         if (!VALID_MISSION_TYPES.includes(type)) {
           const err = new Error(
-            `Invalid mission type "${type}". Must be "code" or "research".\n` +
+            `Invalid mission type "${type}". Must be "code", "research", or "review".\n` +
             'Mission types:\n' +
             '  code     — produces git commits (code changes, bug fixes, features)\n' +
-            '  research — produces documentation artifacts (investigation, analysis, no git changes expected)'
+            '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+            '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)'
           ) as Error & { code: string };
           err.code = 'BAD_REQUEST';
           throw err;
@@ -275,7 +278,7 @@ export class SocketServer extends EventEmitter {
         if (!prompt || prompt.trim().length === 0) {
           const err = new Error(
             'mission.create requires a non-empty --prompt.\n' +
-            'Usage: fleet missions add --sector <id> --type <code|research> --summary "short title" --prompt "detailed instructions"'
+            'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"'
           ) as Error & { code: string };
           err.code = 'BAD_REQUEST';
           throw err;
@@ -283,7 +286,7 @@ export class SocketServer extends EventEmitter {
         if (!summary || summary.trim().length === 0) {
           const err = new Error(
             'mission.create requires a non-empty --summary.\n' +
-            'Usage: fleet missions add --sector <id> --type <code|research> --summary "short title" --prompt "detailed instructions"'
+            'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"'
           ) as Error & { code: string };
           err.code = 'BAD_REQUEST';
           throw err;
@@ -295,6 +298,7 @@ export class SocketServer extends EventEmitter {
           prompt,
           dependsOnMissionId: args['depends-on'] ? Number(args['depends-on']) : undefined,
           type,
+          prBranch,
         });
         this.emit('state-change', 'mission:changed', { mission });
         return mission;
@@ -491,6 +495,7 @@ export class SocketServer extends EventEmitter {
           prompt,
           missionId,
           type: args.type as string | undefined,
+          prBranch: mission.pr_branch ?? undefined,
         });
         this.emit('state-change', 'crew:changed', result);
         return result;

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -53,7 +53,7 @@ export type HullOpts = {
   allowedTools?: string
   /** Path to an MCP config JSON file */
   mcpConfig?: string
-  /** Mission type: 'code' (default) or 'research' */
+  /** Mission type: 'code' (default), 'research', or 'review' */
   missionType?: string
   /** PR branch name for review/fix crews working on an existing PR */
   prBranch?: string
@@ -332,7 +332,7 @@ export class Hull {
   appendOutput(data: string): void {
     const lines = data.split('\n')
     this.outputLines.push(...lines)
-    const maxLines = this.opts.missionType === 'research' ? 2000 : MAX_OUTPUT_LINES
+    const maxLines = (this.opts.missionType === 'research' || this.opts.missionType === 'review') ? 2000 : MAX_OUTPUT_LINES
     if (this.outputLines.length > maxLines) {
       this.outputLines = this.outputLines.slice(-maxLines)
     }

--- a/src/main/starbase/mission-service.ts
+++ b/src/main/starbase/mission-service.ts
@@ -31,6 +31,7 @@ type AddMissionOpts = {
   priority?: number
   dependsOnMissionId?: number
   type?: string
+  prBranch?: string
 }
 
 type ListMissionsFilter = {
@@ -47,8 +48,8 @@ export class MissionService {
   addMission(opts: AddMissionOpts): MissionRow {
     const result = this.db
       .prepare(
-        `INSERT INTO missions (sector_id, summary, prompt, acceptance_criteria, priority, depends_on_mission_id, type)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO missions (sector_id, summary, prompt, acceptance_criteria, priority, depends_on_mission_id, type, pr_branch)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         opts.sectorId,
@@ -57,7 +58,8 @@ export class MissionService {
         opts.acceptanceCriteria ?? null,
         opts.priority ?? 0,
         opts.dependsOnMissionId ?? null,
-        opts.type ?? 'code'
+        opts.type ?? 'code',
+        opts.prBranch ?? null
       )
 
     const mission = this.getMission(result.lastInsertRowid as number)!


### PR DESCRIPTION
## Summary
- Unlocks `review` as a valid mission type alongside `code` and `research` in fleet-cli.ts and socket-server.ts validation gates
- Adds `--pr-branch` flag to `fleet missions add`, stored in `pr_branch` column and passed through to `deployCrew` so review crews check out the right branch
- Expands hull.ts output buffer to 2000 lines for review missions so the full output is available to parse the VERDICT

## Test plan
- [ ] `fleet missions add --sector <id> --type review --summary "..." --prompt "..."` succeeds
- [ ] `fleet missions add --sector <id> --type review --pr-branch my-branch --summary "..." --prompt "..."` stores `pr_branch` on the mission
- [ ] `fleet crew deploy --sector <id> --mission <id>` for a review mission passes `pr_branch` to the Hull
- [ ] Invalid type still returns error listing code/research/review
- [ ] Existing code and research missions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)