### PR TITLE
fix(fleet): fix missing preload APIs and broken protocols CLI

### DIFF
--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -308,10 +308,15 @@ const COMMAND_MAP: Record<string, string> = {
   'protocols.show': 'protocol.show',
   'protocol.show': 'protocol.show',
   'protocols.enable': 'protocol.enable',
+  'protocol.enable': 'protocol.enable',
   'protocols.disable': 'protocol.disable',
+  'protocol.disable': 'protocol.disable',
   'protocols.executions.list': 'execution.list',
   'protocols.executions.show': 'execution.show',
   'protocols.executions.update': 'execution.update',
+  'protocol.executions.list': 'execution.list',
+  'protocol.executions.show': 'execution.show',
+  'protocol.executions.update': 'execution.update',
 }
 
 function mapCommand(group: string, action: string): string {
@@ -492,6 +497,33 @@ export function validateCommand(command: string, args: Record<string, unknown>):
         return 'Error: cargo produce requires --path <path>.\n\nUsage: fleet cargo produce --sector <sector-id> --type <type> --path <path>';
       return null;
 
+    // ── Protocols ──────────────────────────────────────────────────────────
+    case 'protocol.show':
+      if (!args.id && !args.slug)
+        return 'Error: protocols show requires a protocol slug.\n\nUsage: fleet protocols show <slug>\nList protocols: fleet protocols list';
+      return null;
+
+    case 'protocol.enable':
+      if (!args.id && !args.slug)
+        return 'Error: protocols enable requires a protocol slug.\n\nUsage: fleet protocols enable <slug>\nList protocols: fleet protocols list';
+      return null;
+
+    case 'protocol.disable':
+      if (!args.id && !args.slug)
+        return 'Error: protocols disable requires a protocol slug.\n\nUsage: fleet protocols disable <slug>\nList protocols: fleet protocols list';
+      return null;
+
+    // ── Executions ────────────────────────────────────────────────────────
+    case 'execution.show':
+      if (!args.id)
+        return 'Error: executions show requires an execution ID.\n\nUsage: fleet protocols executions show <execution-id>\nList executions: fleet protocols executions list';
+      return null;
+
+    case 'execution.update':
+      if (!args.id)
+        return 'Error: executions update requires an execution ID.\n\nUsage: fleet protocols executions update <execution-id> --status <status>';
+      return null;
+
     // ── Config ────────────────────────────────────────────────────────────
     case 'config.get':
       if (!args.key)
@@ -593,8 +625,19 @@ export async function runCLI(argv: string[], sockPath: string, opts?: { retry?: 
     }
   }
 
-  // Map CLI commands (plural groups, user-friendly actions) to server commands
-  const command = mapCommand(group, action);
+  // Map CLI commands — check for 3-part commands first (e.g. protocols executions list)
+  let command: string;
+  if (cleanRest.length > 0 && !cleanRest[0].startsWith('--')) {
+    const threePartKey = `${group}.${action}.${cleanRest[0]}`;
+    if (COMMAND_MAP[threePartKey]) {
+      command = COMMAND_MAP[threePartKey];
+      cleanRest = cleanRest.slice(1);
+    } else {
+      command = mapCommand(group, action);
+    }
+  } else {
+    command = mapCommand(group, action);
+  }
   const args = parseArgs(cleanRest);
 
   // ── Client-side validation ──────────────────────────────────────────────
@@ -651,8 +694,10 @@ export async function runCLI(argv: string[], sockPath: string, opts?: { retry?: 
     if (inner.description) lines.push(inner.description + '\n');
     if (inner.help_text) lines.push(inner.help_text + '\n');
     if (inner.trigger_examples) {
-      const examples = JSON.parse(inner.trigger_examples) as string[];
-      if (examples.length) { lines.push('Examples:'); examples.forEach(e => lines.push(`  • "${e}"`)); lines.push(''); }
+      try {
+        const examples = JSON.parse(inner.trigger_examples) as string[];
+        if (examples.length) { lines.push('Examples:'); examples.forEach(e => lines.push(`  • "${e}"`)); lines.push(''); }
+      } catch { /* ignore malformed JSON */ }
     }
     lines.push('Steps:');
     for (const s of inner.steps) lines.push(`  ${s.step_order}. [${s.type}] ${s.description ?? ''}`);

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -893,9 +893,10 @@ export class SocketServer extends EventEmitter {
         return protocolService.listProtocols();
 
       case 'protocol.show': {
-        const p = protocolService.getProtocolBySlug(args.slug as string);
+        const slug = (args.id ?? args.slug) as string;
+        const p = protocolService.getProtocolBySlug(slug);
         if (!p) {
-          const err = new Error(`Protocol not found: ${args.slug}`) as Error & { code: string };
+          const err = new Error(`Protocol not found: ${slug}`) as Error & { code: string };
           err.code = 'NOT_FOUND';
           throw err;
         }
@@ -904,13 +905,15 @@ export class SocketServer extends EventEmitter {
       }
 
       case 'protocol.enable': {
-        protocolService.setProtocolEnabled(args.slug as string, true);
-        return { slug: args.slug, enabled: true };
+        const slug = (args.id ?? args.slug) as string;
+        protocolService.setProtocolEnabled(slug, true);
+        return { slug, enabled: true };
       }
 
       case 'protocol.disable': {
-        protocolService.setProtocolEnabled(args.slug as string, false);
-        return { slug: args.slug, enabled: false };
+        const slug = (args.id ?? args.slug) as string;
+        protocolService.setProtocolEnabled(slug, false);
+        return { slug, enabled: false };
       }
 
       // ── Executions ────────────────────────────────────────────────────────────

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -93,6 +93,7 @@ const fleetApi = {
       ipcRenderer.invoke(IPC_CHANNELS.GIT_STATUS, cwd)
   },
   admiral: {
+    checkDependencies: (): Promise<unknown> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_CHECK_DEPENDENCIES),
     getPaneId: (): Promise<string | null> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_PANE_ID),
     ensureStarted: (): Promise<string | null> => ipcRenderer.invoke('admiral:ensure-started'),
     restart: (): Promise<string> => ipcRenderer.invoke(IPC_CHANNELS.ADMIRAL_RESTART),
@@ -194,6 +195,16 @@ const fleetApi = {
     // Signal to main that the renderer is ready to receive create-tab messages
     ipcRenderer.send('fleet:create-tab-ready')
     return () => ipcRenderer.removeListener('fleet:create-tab', handler)
+  },
+  file: {
+    openDialog: (opts: { defaultPath?: string } = {}): Promise<string[]> =>
+      ipcRenderer.invoke(IPC_CHANNELS.FILE_OPEN_DIALOG, opts),
+    onOpenInTab: (callback: (payload: { files: string[] }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: { files: string[] }) =>
+        callback(payload)
+      ipcRenderer.on(IPC_CHANNELS.FILE_OPEN_IN_TAB, handler)
+      return () => ipcRenderer.removeListener(IPC_CHANNELS.FILE_OPEN_IN_TAB, handler)
+    },
   },
   updates: {
     checkForUpdates: (): Promise<void> => ipcRenderer.invoke('fleet:update-check'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,7 +8,7 @@ import { usePaneNavigation } from './hooks/use-pane-navigation';
 import { useNotifications } from './hooks/use-notifications';
 import { useNotificationStore } from './store/notification-store';
 import { clearCreatedPty, markPtyCreated, serializePane } from './hooks/use-terminal';
-import { initCwdListener } from './store/cwd-store';
+import { initCwdListener, useCwdStore } from './store/cwd-store';
 import { useSettingsStore } from './store/settings-store';
 import { injectLiveCwd } from './lib/workspace-utils';
 import { VisualizerPanel } from './components/visualizer/VisualizerPanel';


### PR DESCRIPTION
## Summary
- Fix renderer crash: missing `useCwdStore` import, missing `file` namespace and `admiral.checkDependencies` in preload bridge
- Fix protocols CLI: `protocol.show/enable/disable` used `args.slug` instead of `args.id` (positional arg), 3-part commands like `fleet protocols executions list` weren't parsed
- Add client-side validation for all protocol/execution commands so missing args give helpful usage hints instead of "not found: undefined"
- Add singular COMMAND_MAP aliases and wrap `trigger_examples` JSON.parse in try/catch

## Test plan
- [ ] `fleet protocols list` — shows protocol list
- [ ] `fleet protocols show research-and-deploy` — shows protocol details (was: "Protocol not found: undefined")
- [ ] `fleet protocols enable <slug>` / `fleet protocols disable <slug>` — toggles protocol
- [ ] `fleet protocols executions list` — shows executions (was: "Unknown command")
- [ ] `fleet protocols show` (no arg) — shows usage hint (was: confusing error)
- [ ] App renders without crash on startup (useCwdStore, file.onOpenInTab, admiral.checkDependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)