### PR TITLE
feat(missions): add review mission preamble and default tool restrictions

### DIFF
--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -185,7 +185,11 @@ export class CrewService {
       model: sector.model ?? undefined,
       systemPrompt: sector.system_prompt ?? undefined,
       // Research crews default to read-only tools unless sector explicitly overrides
-      allowedTools: sector.allowed_tools ?? (missionType === 'research' ? 'Read,Glob,Grep,WebSearch,WebFetch' : undefined),
+      allowedTools: sector.allowed_tools ?? (
+        missionType === 'research' ? 'Read,Glob,Grep,WebSearch,WebFetch' :
+        missionType === 'review'   ? 'Read,Glob,Grep,Bash,WebFetch' :
+        undefined
+      ),
       mcpConfig: sector.mcp_config ?? undefined,
       onComplete: () => this.autoDeployNext(),
       env: this.deps.crewEnv,

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -245,7 +245,25 @@ You are a research crew deployed on a research mission (FLEET_MISSION_TYPE=resea
 `
         : null
 
-      const combinedSystemPrompt = [researchPreamble, this.opts.systemPrompt]
+      const reviewPreamble = this.opts.missionType === 'review'
+        ? `# Review Mission Instructions
+
+You are a review crew deployed on a PR review mission (FLEET_MISSION_TYPE=review).
+
+## Output Format
+You MUST end your response with:
+
+VERDICT: APPROVE | REQUEST_CHANGES | ESCALATE
+NOTES: <specific file:line references for any issues found>
+
+## Constraints
+- Do NOT make code changes. This is a review mission.
+- Do NOT commit or push. Any changes will be discarded.
+- Use the gh CLI to read the PR diff: gh pr diff <branch>
+- Only report issues you are >=80% confident about.`
+        : null
+
+      const combinedSystemPrompt = [researchPreamble, reviewPreamble, this.opts.systemPrompt]
         .filter(Boolean)
         .join('\n\n')
 


### PR DESCRIPTION
## Summary
- Adds a system prompt preamble for review crews instructing them to output a structured `VERDICT`/`NOTES` block and constraining them to read-only inspection (no code changes, no commits)
- Defaults review crews to `Read,Glob,Grep,Bash,WebFetch` tools — Bash is needed for `gh pr diff`/`gh pr view`; Write/Edit are excluded to prevent mutations
- Research crew tool restrictions (`Read,Glob,Grep,WebSearch,WebFetch`) and code crew behavior are unchanged

## Test plan
- [ ] `fleet missions add --type review` creates a mission whose crew receives the review preamble in its system prompt
- [ ] Review crews default to `Read,Glob,Grep,Bash,WebFetch` when sector has no `allowed_tools` override
- [ ] Research crew tool restriction is unchanged
- [ ] Code crew has no default tool restriction
- [ ] `tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)