### PR TITLE
fix(socket-server): sync crew deploy terminal status check with authoritative list

### DIFF
--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -503,7 +503,7 @@ export class SocketServer extends EventEmitter {
 
         // Check all dependencies via junction table
         const blockedDeps = missionService.getDependencies(missionId).filter(
-          dep => !['completed', 'failed', 'aborted'].includes(dep.status)
+          dep => !['completed', 'done', 'failed', 'aborted', 'failed-verification', 'escalated', 'approved'].includes(dep.status)
         )
         if (blockedDeps.length > 0) {
           const depList = blockedDeps.map(d => `#${d.id} (${d.status})`).join(', ')


### PR DESCRIPTION
## Summary
- The `fleet crew deploy` dependency pre-check only recognized 3 terminal statuses (`completed`, `failed`, `aborted`) while `TERMINAL_MISSION_STATUSES` in `crew-service.ts` defines 7
- Missions with status `done`, `failed-verification`, `escalated`, or `approved` were incorrectly blocked from deploying
- Updated the filter to match the full authoritative list from `crew-service.ts` and `hull.ts`

## Test plan
- [ ] `fleet crew deploy` succeeds when all dependencies have status: `done`, `completed`, `failed`, `aborted`, `failed-verification`, `escalated`, or `approved`
- [ ] `fleet crew deploy` still blocks when dependencies have non-terminal status: `queued`, `active`, `deploying`, `pending-review`, `reviewing`, `changes-requested`, `push-pending`
- [ ] `tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)