### PR TITLE
feat(missions): add architect mission type

### DIFF
--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -420,26 +420,28 @@ export function validateCommand(command: string, args: Record<string, unknown>):
     // ── Missions ──────────────────────────────────────────────────────────
     case 'mission.create': {
       const usage =
-        'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"';
+        'Usage: fleet missions add --sector <id> --type <code|research|review|architect> --summary "short title" --prompt "detailed instructions"';
       if (!args.sector && !args.sectorId)
         return `Error: missions add requires --sector <id>.\n\n${usage}`;
       if (!args.type) {
         return (
-          'Error: missions add requires --type <code|research|review>.\n\n' +
+          'Error: missions add requires --type <code|research|review|architect>.\n\n' +
           'Mission types:\n' +
-          '  code     — produces git commits (code changes, bug fixes, features)\n' +
-          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
-          '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n\n' +
+          '  code      — produces git commits (code changes, bug fixes, features)\n' +
+          '  research  — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+          '  review    — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
+          '  architect — analyzes the codebase and produces an implementation blueprint (no git changes)\n\n' +
           usage
         );
       }
-      if (args.type !== 'code' && args.type !== 'research' && args.type !== 'review') {
+      if (args.type !== 'code' && args.type !== 'research' && args.type !== 'review' && args.type !== 'architect') {
         return (
-          `Error: invalid mission type "${toStr(args.type)}". Must be "code", "research", or "review".\n\n` +
+          `Error: invalid mission type "${toStr(args.type)}". Must be "code", "research", "review", or "architect".\n\n` +
           'Mission types:\n' +
-          '  code     — produces git commits (code changes, bug fixes, features)\n' +
-          '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
-          '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n\n' +
+          '  code      — produces git commits (code changes, bug fixes, features)\n' +
+          '  research  — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+          '  review    — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
+          '  architect — analyzes the codebase and produces an implementation blueprint (no git changes)\n\n' +
           usage
         );
       }

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -353,7 +353,7 @@ export class SocketServer extends EventEmitter {
         const summary = typeof args.summary === 'string' ? args.summary : undefined;
         const prompt = typeof args.prompt === 'string' ? args.prompt : undefined;
         const type = typeof args.type === 'string' ? args.type : undefined;
-        const VALID_MISSION_TYPES = ['code', 'research', 'review'];
+        const VALID_MISSION_TYPES = ['code', 'research', 'review', 'architect'];
         const rawPrBranch = args['pr-branch'];
         const prBranch = typeof rawPrBranch === 'string' ? rawPrBranch : undefined;
 
@@ -362,36 +362,38 @@ export class SocketServer extends EventEmitter {
         }
         if (!type) {
           throw new CodedError(
-            'mission.create requires --type <code|research|review>.\n' +
+            'mission.create requires --type <code|research|review|architect>.\n' +
               'Mission types:\n' +
-              '  code     — produces git commits (code changes, bug fixes, features)\n' +
-              '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
-              '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
-              'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"',
+              '  code      — produces git commits (code changes, bug fixes, features)\n' +
+              '  research  — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+              '  review    — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
+              '  architect — analyzes the codebase and produces an implementation blueprint (no git changes)\n' +
+              'Usage: fleet missions add --sector <id> --type <code|research|review|architect> --summary "short title" --prompt "detailed instructions"',
             'BAD_REQUEST'
           );
         }
         if (!VALID_MISSION_TYPES.includes(type)) {
           throw new CodedError(
-            `Invalid mission type "${type}". Must be "code", "research", or "review".\n` +
+            `Invalid mission type "${type}". Must be "code", "research", "review", or "architect".\n` +
               'Mission types:\n' +
-              '  code     — produces git commits (code changes, bug fixes, features)\n' +
-              '  research — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
-              '  review   — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)',
+              '  code      — produces git commits (code changes, bug fixes, features)\n' +
+              '  research  — produces documentation artifacts (investigation, analysis, no git changes expected)\n' +
+              '  review    — reviews a PR branch and produces a VERDICT (approved, changes-requested, escalated)\n' +
+              '  architect — analyzes the codebase and produces an implementation blueprint (no git changes)',
             'BAD_REQUEST'
           );
         }
         if (!prompt || prompt.trim().length === 0) {
           throw new CodedError(
             'mission.create requires a non-empty --prompt.\n' +
-              'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"',
+              'Usage: fleet missions add --sector <id> --type <code|research|review|architect> --summary "short title" --prompt "detailed instructions"',
             'BAD_REQUEST'
           );
         }
         if (!summary || summary.trim().length === 0) {
           throw new CodedError(
             'mission.create requires a non-empty --summary.\n' +
-              'Usage: fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions"',
+              'Usage: fleet missions add --sector <id> --type <code|research|review|architect> --summary "short title" --prompt "detailed instructions"',
             'BAD_REQUEST'
           );
         }

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -180,8 +180,8 @@ export class CrewService {
       throw err;
     }
 
-    // 6. Install dependencies (skip for review crews — they only read code)
-    if (missionType !== 'review') {
+    // 6. Install dependencies (skip for review/architect crews — they only read code)
+    if (missionType !== 'review' && missionType !== 'architect') {
       try {
         await worktreeManager.installDependencies(worktreeResult.worktreePath);
       } catch (err) {
@@ -226,7 +226,9 @@ export class CrewService {
           ? 'Read,Glob,Grep,WebSearch,WebFetch'
           : missionType === 'review'
             ? 'Read,Glob,Grep,Bash,WebFetch'
-            : undefined),
+            : missionType === 'architect'
+              ? 'Read,Glob,Grep,Bash,WebFetch'
+              : undefined),
       mcpConfig: sector.mcp_config ?? undefined,
       onComplete: () => this.autoDeployNext(),
       env: this.deps.crewEnv,

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -270,7 +270,23 @@ export class Hull {
         this.opts.missionType === 'research'
           ? `# Research Mission Instructions
 
-You are a research crew deployed on a research mission (FLEET_MISSION_TYPE=research).
+You are an expert code analyst deployed on a research mission (FLEET_MISSION_TYPE=research). Your mission is to provide a complete understanding of how a specific feature or system works by tracing its implementation from entry points to data storage, through all abstraction layers.
+
+## Analysis Approach
+- **Feature Discovery**: Find entry points (APIs, UI components, CLI commands), locate core implementation files, map feature boundaries and configuration.
+- **Code Flow Tracing**: Follow call chains from entry to output, trace data transformations at each step, identify all dependencies and integrations, document state changes and side effects.
+- **Architecture Analysis**: Map abstraction layers (presentation → business logic → data), identify design patterns and architectural decisions, document interfaces between components, note cross-cutting concerns.
+- **Implementation Details**: Key algorithms and data structures, error handling and edge cases, performance considerations, technical debt or improvement areas.
+
+## Output Format
+Provide a comprehensive analysis that helps developers understand the feature deeply enough to modify or extend it. Include:
+- Entry points with file:line references
+- Step-by-step execution flow with data transformations
+- Key components and their responsibilities
+- Architecture insights: patterns, layers, design decisions
+- Dependencies (external and internal)
+- Observations about strengths, issues, or opportunities
+- List of files that are absolutely essential to understand the topic
 
 ## Cargo Workflow
 - Output your findings as printed text in your responses — do NOT write findings to files in the worktree.
@@ -280,7 +296,6 @@ You are a research crew deployed on a research mission (FLEET_MISSION_TYPE=resea
 ## Constraints
 - Do NOT push code or create pull requests. This is a research mission, not a code mission.
 - Do NOT commit changes. Any git changes you make will be discarded at the end of the mission.
-- Focus on investigation, analysis, and producing written findings.
 
 ## Environment
 - FLEET_MISSION_TYPE=research (available in your environment)
@@ -291,7 +306,18 @@ You are a research crew deployed on a research mission (FLEET_MISSION_TYPE=resea
         this.opts.missionType === 'review'
           ? `# Review Mission Instructions
 
-You are a review crew deployed on a PR review mission (FLEET_MISSION_TYPE=review).
+You are an expert code reviewer deployed on a PR review mission (FLEET_MISSION_TYPE=review). Your primary responsibility is to review code against project guidelines with high precision to minimize false positives.
+
+## Review Scope
+Review the PR diff using: gh pr diff <branch>
+
+## Core Review Responsibilities
+- **Project Guidelines Compliance**: Verify adherence to explicit project rules (CLAUDE.md) including import patterns, framework conventions, naming conventions, error handling, testing practices.
+- **Bug Detection**: Identify actual bugs — logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, performance problems.
+- **Code Quality**: Evaluate significant issues like code duplication, missing critical error handling, and inadequate test coverage.
+
+## Confidence Scoring
+Rate each potential issue 0–100. Only report issues with confidence ≥ 80. Focus on issues that truly matter — quality over quantity.
 
 ## Output Format
 You MUST end your response with:
@@ -299,14 +325,50 @@ You MUST end your response with:
 VERDICT: APPROVE | REQUEST_CHANGES | ESCALATE
 NOTES: <specific file:line references for any issues found>
 
+For each high-confidence issue provide: description with confidence score, file path and line number, specific guideline reference or bug explanation, and a concrete fix suggestion.
+
 ## Constraints
 - Do NOT make code changes. This is a review mission.
 - Do NOT commit or push. Any changes will be discarded.
-- Use the gh CLI to read the PR diff: gh pr diff <branch>
 - Only report issues you are >=80% confident about.`
           : null;
 
-      const combinedSystemPrompt = [researchPreamble, reviewPreamble, this.opts.systemPrompt]
+      const architectPreamble =
+        this.opts.missionType === 'architect'
+          ? `# Architect Mission Instructions
+
+You are a senior software architect deployed on an architecture design mission (FLEET_MISSION_TYPE=architect).
+
+## Core Process
+- Analyze existing codebase patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and CLAUDE.md guidelines. Find similar features to understand established approaches.
+- Design the complete feature architecture based on patterns found. Make decisive choices — pick one approach and commit. Ensure seamless integration with existing code.
+- Produce a comprehensive implementation blueprint: every file to create or modify, component responsibilities, integration points, and data flow. Break implementation into clear phases with specific tasks.
+
+## Output Format
+Deliver a decisive, complete architecture blueprint. Include:
+- **Patterns & Conventions Found**: Existing patterns with file:line references, similar features, key abstractions
+- **Architecture Decision**: Your chosen approach with rationale and trade-offs
+- **Component Design**: Each component with file path, responsibilities, dependencies, and interfaces
+- **Implementation Map**: Specific files to create/modify with detailed change descriptions
+- **Data Flow**: Complete flow from entry points through transformations to outputs
+- **Build Sequence**: Phased implementation steps as a checklist
+
+## Cargo Workflow
+- Output your blueprint as printed text in your responses — do NOT write designs to files in the worktree.
+- The Fleet system captures your full output as cargo automatically.
+- Use Read, Glob, Grep, Bash, and WebFetch to explore the codebase before designing.
+
+## Constraints
+- Do NOT write code or create pull requests. This is a design mission, not a code mission.
+- Do NOT commit changes. Any git changes you make will be discarded at the end of the mission.
+- Focus on analyzing existing patterns, then producing an implementation blueprint.
+
+## Environment
+- FLEET_MISSION_TYPE=architect (available in your environment)
+`
+          : null;
+
+      const combinedSystemPrompt = [researchPreamble, reviewPreamble, architectPreamble, this.opts.systemPrompt]
         .filter(Boolean)
         .join('\n\n');
 
@@ -349,6 +411,10 @@ NOTES: <specific file:line references for any issues found>
         this.opts.missionType === 'research'
           ? `RESEARCH MISSION GUIDANCE: Your research findings will be captured as cargo from your terminal output. Print your findings to stdout using console.log, echo, or similar output commands. Do NOT write files to disk — any files you create or modify will be discarded by the git safety guard. Do NOT create pull requests or commit changes. Your mission is to investigate and report findings through your terminal output only.\n\n`
           : '';
+      const architectGuidance =
+        this.opts.missionType === 'architect'
+          ? `ARCHITECT MISSION GUIDANCE: Your architecture blueprint will be captured as cargo from your terminal output. Print your design to stdout. Do NOT write files to disk — any files you create or modify will be discarded by the git safety guard. Do NOT write code or create pull requests. Your mission is to analyze the codebase and produce an implementation blueprint through your terminal output only.\n\n`
+          : '';
       const cargoHeader =
         this.opts.missionType === 'code' || this.opts.missionType == null
           ? buildCargoHeader(db, missionId)
@@ -358,7 +424,7 @@ NOTES: <specific file:line references for any issues found>
           type: 'user',
           message: {
             role: 'user',
-            content: `${cargoHeader}${worktreeWarning}${researchGuidance}Read and execute the mission prompt in ${promptFile}. Delete the file when done.`
+            content: `${cargoHeader}${worktreeWarning}${researchGuidance}${architectGuidance}Read and execute the mission prompt in ${promptFile}. Delete the file when done.`
           },
           parent_tool_use_id: null,
           session_id: ''
@@ -504,7 +570,7 @@ NOTES: <specific file:line references for any issues found>
     const lines = data.split('\n');
     this.outputLines.push(...lines);
     const maxLines =
-      this.opts.missionType === 'research' || this.opts.missionType === 'review'
+      this.opts.missionType === 'research' || this.opts.missionType === 'review' || this.opts.missionType === 'architect'
         ? 2000
         : MAX_OUTPUT_LINES;
     if (this.outputLines.length > maxLines) {
@@ -773,8 +839,8 @@ NOTES: <specific file:line references for any issues found>
 
         // EXISTING code continues: if (status !== 'aborted') { ...
         if (status !== 'aborted') {
-          if (this.opts.missionType === 'research' && status !== 'error') {
-            // Research mission completed — produce cargo instead of failing
+          if ((this.opts.missionType === 'research' || this.opts.missionType === 'architect') && status !== 'error') {
+            // Research/architect mission completed — produce cargo instead of failing
             overrideStatus = 'complete';
 
             // Write cargo files to starbase directory
@@ -871,8 +937,8 @@ NOTES: <specific file:line references for any issues found>
         return;
       }
 
-      // Safety guard: research crews should never push code — discard changes and produce cargo
-      if (this.opts.missionType === 'research') {
+      // Safety guard: research/architect crews should never push code — discard changes and produce cargo
+      if (this.opts.missionType === 'research' || this.opts.missionType === 'architect') {
         // Capture what will be discarded before cleaning, for ships_log warning
         let discardedFiles: string[] = [];
         try {
@@ -908,11 +974,11 @@ NOTES: <specific file:line references for any issues found>
           ).run(
             crewId,
             JSON.stringify({
-              warning: 'Research safety guard discarded file changes',
+              warning: `${this.opts.missionType} safety guard discarded file changes`,
               filesDiscarded: discardedFiles.length,
               paths: discardedFiles.slice(0, 20),
               recommendation:
-                'Research crews should print findings to stdout — do not write files to disk. Cargo is captured from terminal output.'
+                'Research/architect crews should print findings to stdout — do not write files to disk. Cargo is captured from terminal output.'
             })
           );
         }
@@ -920,12 +986,12 @@ NOTES: <specific file:line references for any issues found>
         if (status === 'error') {
           db.prepare(
             "UPDATE missions SET status = 'failed', result = ?, completed_at = datetime('now') WHERE id = ?"
-          ).run('Research crew error', missionId);
+          ).run(`${this.opts.missionType} crew error`, missionId);
           db.prepare(
             "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES (?, 'admiral', 'mission_complete', ?)"
           ).run(
             crewId,
-            JSON.stringify({ missionId, status: 'failed', reason: 'Research crew error' })
+            JSON.stringify({ missionId, status: 'failed', reason: `${this.opts.missionType} crew error` })
           );
           db.prepare(
             "INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'exited', ?)"
@@ -933,7 +999,7 @@ NOTES: <specific file:line references for any issues found>
             crewId,
             JSON.stringify({
               status: 'error',
-              reason: 'Research crew error (git changes discarded)'
+              reason: `${this.opts.missionType} crew error (git changes discarded)`
             })
           );
           overrideStatus = 'error';
@@ -954,9 +1020,10 @@ NOTES: <specific file:line references for any issues found>
         const fullOutput = this.outputLines.join('\n');
         const summary = this.resultText ?? this.outputLines.slice(-20).join('\n');
         const hasOutput = fullOutput.trim().length > 0;
+        const missionLabel = this.opts.missionType === 'architect' ? 'Architect' : 'Research';
         const resultMsg = hasOutput
-          ? 'Research completed'
-          : 'Research completed (no output captured)';
+          ? `${missionLabel} completed`
+          : `${missionLabel} completed (no output captured)`;
 
         let fullManifest: string;
         let summaryManifest: string;

--- a/src/main/starbase/workspace-templates.ts
+++ b/src/main/starbase/workspace-templates.ts
@@ -48,7 +48,7 @@ Never send a Crewmate an open-ended or vague prompt. Refine requests into precis
 
 \`\`\`bash
 # 1. Create the mission (note the returned mission ID)
-fleet missions add --sector <id> --type <code|research|review> --summary "short title" --prompt "detailed instructions..."
+fleet missions add --sector <id> --type <code|research|review|architect> --summary "short title" --prompt "detailed instructions..."
 
 # 2. Deploy crew to execute it
 fleet crew deploy --sector <id> --mission <mission-id>
@@ -58,6 +58,7 @@ fleet crew deploy --sector <id> --mission <mission-id>
 - \`code\` — produces git commits (code changes, bug fixes, features)
 - \`research\` — produces documentation artifacts (investigation, analysis, no git changes expected)
 - \`review\` — performs PR code review, produces a VERDICT (approve/request-changes/escalate)
+- \`architect\` — analyzes the codebase and produces an implementation blueprint (no git changes)
 
 ### Research-First Workflow (recommended for non-trivial code missions)
 
@@ -214,7 +215,7 @@ fleet crew message <crew-id> --message "..."  # Send a follow-up message to an a
 fleet missions list                    # List all Missions
 fleet missions list --sector <id>      # Filter by Sector
 fleet missions list --status queued    # Filter by status
-fleet missions add --sector <id> --type <code|research|review> --summary "..." --prompt "..."  # Create a Mission
+fleet missions add --sector <id> --type <code|research|review|architect> --summary "..." --prompt "..."  # Create a Mission
 fleet missions add ... --depends-on <research-id>   # Link a research dependency (can repeat for multiple)
 fleet missions update <id> --status done    # Update Mission status
 fleet missions show <id>               # Show full Mission details
@@ -283,7 +284,7 @@ fleet protocols executions show <id>              # Show execution detail
 1. **Identify concerns** — Does the request touch multiple files, features, or Sectors?
 2. **Break into Missions** — Each Mission gets a precise prompt with acceptance criteria
 3. **Confirm with user** — Show the plan before deploying
-4. **Create Missions** — \`fleet missions add --sector <id> --type <code|research|review> --summary "..." --prompt "..."\`
+4. **Create Missions** — \`fleet missions add --sector <id> --type <code|research|review|architect> --summary "..." --prompt "..."\`
 5. **Deploy Crew** — \`fleet crew deploy --sector <id> --mission <mission-id>\`
 
 ### Example:
@@ -453,7 +454,7 @@ When \`FLEET_MISSION_TYPE=research\`, your findings are captured as **cargo** fr
 
 **Checking your mission type:**
 \`\`\`bash
-echo $FLEET_MISSION_TYPE   # 'research', 'code', or 'review'
+echo $FLEET_MISSION_TYPE   # 'research', 'code', 'review', or 'architect'
 \`\`\`
 
 When a research mission completes, its summary cargo path is referenced in the initial message of any code missions that depend on it. The code crew can Read the file on demand if the task requires the findings.
@@ -465,7 +466,7 @@ When a Crewmate is deployed, the following environment variables are set in its 
 - \`FLEET_CREW_ID\` — the Crewmate's unique ID (e.g. \`my-sector-crew-a1b2\`)
 - \`FLEET_SECTOR_ID\` — the Sector it was deployed to
 - \`FLEET_MISSION_ID\` — the Mission ID it is working on
-- \`FLEET_MISSION_TYPE\` — the mission type (\`research\`, \`code\`, or \`review\`)
+- \`FLEET_MISSION_TYPE\` — the mission type (\`research\`, \`code\`, \`review\`, or \`architect\`)
 
 Crew can use these to identify themselves in comms:
 


### PR DESCRIPTION
## Summary
- Adds a new `architect` mission type that deploys a read-only crew to analyze the codebase and produce an implementation blueprint as cargo
- Updates `research` and `review` preambles in `hull.ts` to match the feature-dev agent format (code-explorer and code-reviewer roles respectively)
- Architect crew uses the same tool set and completion behavior as `research` — output captured as cargo, git changes discarded

## Test plan
- [ ] `fleet missions add --sector <id> --type architect --summary "..." --prompt "..."` creates a mission successfully
- [ ] Architect crew spawns with the correct system prompt preamble and `FLEET_MISSION_TYPE=architect` env var
- [ ] Blueprint output is captured as cargo (`documentation_full` + `documentation_summary`)
- [ ] Git changes are discarded by safety guard
- [ ] `--type invalid` still returns a helpful error listing all four types
- [ ] Typecheck passes: `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)