### PR TITLE
fix(starbase): emit starbase-changed when crew completes without next mission

### DIFF
--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -359,6 +359,11 @@ export class CrewService {
   private autoDeployNext(): void {
     const { db } = this.deps;
 
+    // Notify UI that a crew completed — hull.ts writes directly to DB without going through the
+    // service layer, so it never emits starbase-changed. Without this, the UI snapshot stays stale
+    // when there is no next mission to deploy (deployCrew emits it when there is one).
+    this.deps.eventBus?.emit('starbase-changed', { type: 'starbase-changed' });
+
     // Atomically claim the next queued mission — prevents concurrent deployments from racing
     const claim = db
       .prepare<[], QueuedMissionRow>(


### PR DESCRIPTION
## Summary
- `hull.ts` writes directly to the DB, bypassing the service layer, so it never emits `starbase-changed`
- Without this fix, the UI snapshot stays stale when a crew completes but the queue is empty (no next mission to deploy)
- `autoDeployNext` now emits `starbase-changed` unconditionally before checking the queue

## Test plan
- [ ] Complete a mission with an empty queue — verify the UI updates without requiring a manual refresh
- [ ] Complete a mission with a queued mission — verify the next mission deploys and UI updates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)