### PR TITLE
feat(sidebar): replace star command tab with mini CRT card

### DIFF
--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -7,6 +7,12 @@ import { TabItem } from './TabItem';
 import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from '../store/workspace-store';
 import { useNotificationStore } from '../store/notification-store';
 import { useCwdStore } from '../store/cwd-store';
+import { useStarCommandStore } from '../store/star-command-store';
+import admiralDefault from '../assets/admiral-default.png';
+import admiralSpeaking from '../assets/admiral-speaking.png';
+import admiralThinking from '../assets/admiral-thinking.png';
+import admiralAlert from '../assets/admiral-alert.png';
+import admiralStandby from '../assets/admiral-standby.png';
 import { clearCreatedPty, serializePane } from '../hooks/use-terminal';
 import { injectLiveCwd } from '../lib/workspace-utils';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
@@ -31,6 +37,110 @@ function getFirstLeaf(tab: Tab): PaneLeaf | null {
 }
 
 const AUTO_SAVE_DEBOUNCE_MS = 500;
+
+const ADMIRAL_IMAGES: Record<string, string> = {
+  default: admiralDefault,
+  speaking: admiralSpeaking,
+  thinking: admiralThinking,
+  alert: admiralAlert,
+  standby: admiralStandby
+};
+
+function StarCommandTabCard({
+  isActive,
+  onClick
+}: {
+  isActive: boolean;
+  onClick: () => void;
+}): React.JSX.Element {
+  const { admiralAvatarState, admiralStatus, crewList, unreadCount } = useStarCommandStore();
+
+  const activeCrew = crewList.filter((c) => c.status === 'active').length;
+  const errorCrew = crewList.filter((c) => c.status === 'error' || c.status === 'lost').length;
+  const admiralSrc = ADMIRAL_IMAGES[admiralAvatarState] ?? ADMIRAL_IMAGES.default;
+
+  const statusDotClass =
+    admiralStatus === 'running'
+      ? 'bg-green-400'
+      : admiralStatus === 'starting'
+        ? 'bg-yellow-400 animate-pulse'
+        : 'bg-neutral-600';
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer rounded-md overflow-hidden relative transition-all"
+      style={{
+        background: isActive ? '#0a0a1a' : 'rgba(10,10,26,0.4)',
+        border: isActive ? '1px solid rgba(20,184,166,0.35)' : '1px solid rgba(255,255,255,0.05)',
+        boxShadow: isActive ? '0 0 10px rgba(20,184,166,0.15), inset 0 0 20px rgba(20,184,166,0.03)' : 'none'
+      }}
+    >
+      {/* Scanline overlay */}
+      <div
+        className="absolute inset-0 pointer-events-none z-10"
+        style={{
+          backgroundImage: 'repeating-linear-gradient(transparent 0px, transparent 1px, rgba(0,0,0,0.12) 1px, rgba(0,0,0,0.12) 2px)',
+          backgroundSize: '100% 2px'
+        }}
+      />
+
+      <div className="relative z-20 flex items-center gap-2.5 px-2.5 py-2">
+        {/* Admiral avatar */}
+        <div className="flex-shrink-0 relative">
+          <img
+            src={admiralSrc}
+            alt="Admiral"
+            width={32}
+            height={32}
+            className="rounded-sm"
+            style={{ imageRendering: 'pixelated' }}
+          />
+          {/* Status dot */}
+          <span
+            className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border border-neutral-900 ${statusDotClass}`}
+          />
+        </div>
+
+        {/* Text content */}
+        <div className="flex-1 min-w-0">
+          <div
+            className="font-mono uppercase tracking-widest leading-none mb-1"
+            style={{
+              fontSize: '9px',
+              color: isActive ? 'rgb(45,212,191)' : 'rgba(45,212,191,0.5)'
+            }}
+          >
+            Star Command
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[9px] font-mono text-neutral-500">
+              {activeCrew > 0 ? (
+                <span className="text-green-400/70">{activeCrew} active</span>
+              ) : (
+                <span>no crew</span>
+              )}
+            </span>
+            {errorCrew > 0 && (
+              <span className="text-[9px] font-mono text-red-400/80">{errorCrew} err</span>
+            )}
+            {unreadCount > 0 && (
+              <span
+                className="text-[9px] font-mono font-semibold px-1 rounded-sm animate-pulse"
+                style={{
+                  background: 'rgba(20,184,166,0.2)',
+                  color: 'rgb(45,212,191)'
+                }}
+              >
+                {unreadCount}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function Sidebar({
   updateReady,
@@ -426,26 +536,11 @@ export function Sidebar({
           {workspace.tabs
             .filter((tab) => tab.type === 'star-command')
             .map((tab) => (
-              <div
+              <StarCommandTabCard
                 key={tab.id}
-                data-tab-id={tab.id}
-                className={`
-                flex items-center gap-2 px-3 py-1.5 cursor-pointer rounded-md text-sm min-h-[44px] transition-colors
-                ${
-                  tab.id === activeTabId
-                    ? 'bg-neutral-700 text-white border-l-2 border-yellow-500'
-                    : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 border-l-2 border-transparent'
-                }
-              `}
-                onClick={() => {
-                  setActiveTab(tab.id);
-                }}
-              >
-                <span className="text-yellow-400 flex-shrink-0">★</span>
-                <div className="flex-1 min-w-0">
-                  <div className="truncate text-sm leading-tight font-semibold">Star Command</div>
-                </div>
-              </div>
+                isActive={tab.id === activeTabId}
+                onClick={() => setActiveTab(tab.id)}
+              />
             ))}
           {workspace.tabs.filter((t) => t.type === 'star-command').length > 0 && (
             <div className="h-px bg-neutral-800 mx-1 my-1" />


### PR DESCRIPTION
## Summary
- Replaces the plain flat Star Command sidebar tab with a distinctive mini CRT command card
- Shows animated admiral avatar, live crew/unread stats, and teal glow — matching the Star Command window's sci-fi aesthetic
- All data sourced from the existing Zustand store, no new state or IPC required

## Test plan
- [ ] Star Command card renders in sidebar when on another tab
- [ ] Admiral avatar swaps correctly between default/thinking/speaking/alert/standby states
- [ ] Status dot reflects admiral running (green), starting (yellow pulse), stopped (gray)
- [ ] Active crew count and unread comms badge update live
- [ ] Card glows teal when active, dims when inactive
- [ ] Clicking the card navigates to Star Command

🤖 Generated with [Claude Code](https://claude.com/claude-code)