### PR TITLE
feat(release): add plain text release notes pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,15 @@ jobs:
         run: npx electron-builder install-app-deps
       - name: Build app
         run: npx electron-vite build
+      - name: Extract release notes config
+        run: npx tsx scripts/extract-release-notes.ts /tmp/release-extra.json
       - name: Package, sign, notarize and publish
         uses: nick-fields/retry@v3
         with:
           max_attempts: 3
           timeout_minutes: 20
           retry_wait_seconds: 30
-          command: npx electron-builder --mac --arm64 --publish always
+          command: npx electron-builder --mac --arm64 --publish always --config /tmp/release-extra.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -67,13 +69,15 @@ jobs:
         run: npx electron-builder install-app-deps
       - name: Build app
         run: npx electron-vite build
+      - name: Extract release notes config
+        run: npx tsx scripts/extract-release-notes.ts /tmp/release-extra.json
       - name: Package, sign, notarize and publish
         uses: nick-fields/retry@v3
         with:
           max_attempts: 3
           timeout_minutes: 20
           retry_wait_seconds: 30
-          command: npx electron-builder --mac --x64 --publish always
+          command: npx electron-builder --mac --x64 --publish always --config /tmp/release-extra.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -92,10 +96,14 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Extract release notes config
+        run: npx tsx scripts/extract-release-notes.ts $env:TEMP\release-extra.json
+        shell: pwsh
       - name: Build and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx electron-vite build && npx electron-builder --win --publish always
+        run: npx electron-vite build && npx electron-builder --win --publish always --config $env:TEMP\release-extra.json
+        shell: pwsh
 
   release-linux:
     needs: [verify-version]
@@ -107,10 +115,12 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Extract release notes config
+        run: npx tsx scripts/extract-release-notes.ts /tmp/release-extra.json
       - name: Build and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx electron-vite build && npx electron-builder --linux --publish always
+        run: npx electron-vite build && npx electron-builder --linux --publish always --config /tmp/release-extra.json
 
   publish-release:
     needs: [release-mac-arm64, release-mac-x64, release-win, release-linux]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v2.6.0
+- Fixed issue where restored tabs showed full terminal history on app relaunch
+- Release notes in the Updates tab now display as plain text
+
+## v2.5.0
+- Initial release notes support

--- a/scripts/extract-release-notes.ts
+++ b/scripts/extract-release-notes.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = join(__dirname, '..');
+
+const outputPath = process.argv[2];
+if (!outputPath) {
+  console.error('Usage: extract-release-notes.ts <output-path>');
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+const version = pkg.version as string;
+
+const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
+const lines = changelog.split('\n');
+
+const heading = `## v${version}`;
+const startIdx = lines.findIndex((l) => l.trim() === heading);
+if (startIdx === -1) {
+  console.error(`No changelog entry found for ${heading}`);
+  process.exit(1);
+}
+
+const notes: string[] = [];
+for (let i = startIdx + 1; i < lines.length; i++) {
+  if (lines[i].startsWith('## ')) break;
+  notes.push(lines[i]);
+}
+
+const releaseNotes = notes.join('\n').trim();
+
+const config = {
+  releaseInfo: {
+    releaseNotes,
+  },
+};
+
+writeFileSync(outputPath, JSON.stringify(config, null, 2));
+console.log(`Wrote release notes for v${version} to ${outputPath}`);


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` with version-tagged entries for manual maintenance
- Add `scripts/extract-release-notes.ts` to extract notes for the current package.json version
- Inject `releaseInfo.releaseNotes` into electron-builder via `--config` flag in all four CI jobs (mac-arm64, mac-x64, win, linux)

This prevents electron-updater from falling back to the HTML GitHub release body, ensuring clean plain text is shown in the Updates tab.

## Test plan
- [ ] Run `npx tsx scripts/extract-release-notes.ts /tmp/test.json` and verify JSON output contains `releaseInfo.releaseNotes` as plain text
- [ ] Trigger a release build and confirm `latest-mac.yml` / `latest.yml` / `latest-linux.yml` assets include a `releaseNotes` field
- [ ] Verify the Updates tab in the app shows plain text instead of HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)