### PR TITLE
fix(crew): eliminate zombie crew bug and restore Sentinel watchdog

### DIFF
--- a/src/main/__tests__/crew-service.test.ts
+++ b/src/main/__tests__/crew-service.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CrewService, InsufficientMemoryError } from '../starbase/crew-service';
+import { Hull } from '../starbase/hull';
 import { StarbaseDB } from '../starbase/db';
 import { SectorService } from '../starbase/sector-service';
 import { MissionService } from '../starbase/mission-service';
@@ -160,5 +161,77 @@ describe('CrewService', () => {
         // intentionally no prBranch
       })
     ).rejects.toThrow('Repair mission');
+  });
+});
+
+describe('CrewService hull.start() failure handling', () => {
+  let crewSvc2: CrewService;
+
+  beforeEach(() => {
+    const wsDir = join(TEST_DIR, 'workspace');
+    const db2 = db; // reuse the same DB from outer beforeEach
+
+    const sectorSvc = new SectorService(db2.getDb(), wsDir);
+    const missionSvc = new MissionService(db2.getDb());
+    const configSvc = new ConfigService(db2.getDb());
+    // Disable the memory gate so tests aren't blocked by available RAM
+    configSvc.set('min_deploy_free_memory_gb', 0);
+    const wtMgr = new WorktreeManager(join(TEST_DIR, 'worktrees'));
+
+    crewSvc2 = new CrewService({
+      db: db2.getDb(),
+      starbaseId: db2.getStarbaseId(),
+      sectorService: sectorSvc,
+      missionService: missionSvc,
+      configService: configSvc,
+      worktreeManager: wtMgr
+    });
+  });
+
+  it('should clean up hull from map when hull.start() throws', async () => {
+    const missionSvc = crewSvc2['deps'].missionService;
+    const mission = missionSvc.addMission({
+      sectorId: 'api',
+      summary: 'Test',
+      prompt: 'do something'
+    });
+
+    const startSpy = vi.spyOn(Hull.prototype, 'start').mockImplementationOnce(() => {
+      throw new Error('concurrent deploy — mission already claimed');
+    });
+
+    await expect(
+      crewSvc2.deployCrew({ sectorId: 'api', missionId: mission.id, prompt: 'do something' })
+    ).rejects.toThrow('concurrent deploy');
+
+    expect(crewSvc2['hulls'].size).toBe(0);
+    startSpy.mockRestore();
+  });
+
+  it('should write deploy_failed comms when hull.start() throws', async () => {
+    const missionSvc = crewSvc2['deps'].missionService;
+    const mission = missionSvc.addMission({
+      sectorId: 'api',
+      summary: 'Test',
+      prompt: 'do something'
+    });
+
+    const startSpy = vi.spyOn(Hull.prototype, 'start').mockImplementationOnce(() => {
+      throw new Error('concurrent deploy — mission already claimed');
+    });
+
+    await expect(
+      crewSvc2.deployCrew({ sectorId: 'api', missionId: mission.id, prompt: 'do something' })
+    ).rejects.toThrow('concurrent deploy');
+
+    const commsRow = db
+      .getDb()
+      .prepare<
+        [],
+        { type: string }
+      >('SELECT type FROM comms WHERE type = ? ORDER BY id DESC LIMIT 1')
+      .get('deploy_failed');
+    expect(commsRow?.type).toBe('deploy_failed');
+    startSpy.mockRestore();
   });
 });

--- a/src/main/__tests__/hull.test.ts
+++ b/src/main/__tests__/hull.test.ts
@@ -873,3 +873,80 @@ describe('buildCargoHeader', () => {
     }
   });
 });
+
+describe('Hull activation ordering', () => {
+  function createMockProcess() {
+    const proc = new EventEmitter() as any;
+    proc.stdin = { write: vi.fn(), end: vi.fn(), writable: true };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.killed = false;
+    proc.pid = 42000;
+    proc.kill = vi.fn();
+    return proc;
+  }
+
+  function makeMission() {
+    return missionSvc.addMission({ sectorId: 'api', summary: 'Test', prompt: 'do something' });
+  }
+
+  function makeHullOpts(missionId: number): HullOpts {
+    return {
+      crewId: `crew-act-${missionId}`,
+      sectorId: 'api',
+      missionId,
+      prompt: 'do something',
+      worktreePath: WORKTREE_DIR,
+      worktreeBranch: 'crew/test-activation',
+      baseBranch: 'main',
+      sectorPath: SECTOR_DIR,
+      db: db.getDb(),
+      lifesignIntervalSec: 9999,
+      timeoutMin: 9999
+    };
+  }
+
+  it('should not insert a crew row when mission claim fails', () => {
+    const mission = makeMission();
+    // Pre-claim the mission so the activation UPDATE sees crew_id IS NOT NULL → 0 changes → throw
+    db.getDb()
+      .prepare("UPDATE missions SET crew_id = 'other-crew', status = 'active' WHERE id = ?")
+      .run(mission.id);
+
+    const hull = new Hull(makeHullOpts(mission.id));
+    expect(() => hull.start()).toThrow('already has an active crew');
+
+    const crewRow = db
+      .getDb()
+      .prepare<[number], { id: string }>('SELECT id FROM crew WHERE mission_id = ?')
+      .get(mission.id);
+    expect(crewRow).toBeUndefined();
+  });
+
+  it('should insert crew row only after mission is successfully claimed', () => {
+    mockProc = createMockProcess();
+    const mission = makeMission();
+    const opts = makeHullOpts(mission.id);
+    const hull = new Hull(opts);
+
+    hull.start();
+
+    const missionRow = db
+      .getDb()
+      .prepare<
+        [number],
+        { status: string; crew_id: string }
+      >('SELECT status, crew_id FROM missions WHERE id = ?')
+      .get(mission.id);
+    expect(missionRow?.status).toBe('active');
+    expect(missionRow?.crew_id).toBe(opts.crewId);
+
+    const crewRow = db
+      .getDb()
+      .prepare<[string], { status: string }>('SELECT status FROM crew WHERE id = ?')
+      .get(opts.crewId);
+    expect(crewRow?.status).toBe('active');
+
+    hull.kill();
+  });
+});

--- a/src/main/__tests__/reconciliation.test.ts
+++ b/src/main/__tests__/reconciliation.test.ts
@@ -244,4 +244,53 @@ describe('runReconciliation', () => {
     expect(summary.orphanedWorktrees).toEqual([]);
     expect(summary.retriedPushes).toEqual([]);
   });
+
+  it('should mark null-PID active crew older than 60s as lost', async () => {
+    const sectorDir = join(TEST_DIR, 'workspace', 'api');
+    insertSector('api', sectorDir);
+    const oldDate = sqliteDatetime(new Date(Date.now() - 120_000)); // 2 minutes ago
+    getDb()
+      .prepare(
+        "INSERT INTO crew (id, sector_id, status, pid, created_at) VALUES (?, 'api', 'active', NULL, ?)"
+      )
+      .run('zombie-old', oldDate);
+
+    const summary = await runReconciliation({
+      db: getDb(),
+      starbaseId: starbaseDb.getStarbaseId(),
+      worktreeBasePath: join(TEST_DIR, 'worktrees')
+    });
+
+    expect(summary.nullPidZombies).toContain('zombie-old');
+    expect(summary.lostCrew).toContain('zombie-old');
+
+    const row = getDb()
+      .prepare<[string], { status: string }>('SELECT status FROM crew WHERE id = ?')
+      .get('zombie-old');
+    expect(row?.status).toBe('lost');
+  });
+
+  it('should not mark null-PID active crew younger than 60s as lost', async () => {
+    const sectorDir = join(TEST_DIR, 'workspace', 'api');
+    insertSector('api', sectorDir);
+    const recentDate = sqliteDatetime(new Date(Date.now() - 10_000)); // 10 seconds ago
+    getDb()
+      .prepare(
+        "INSERT INTO crew (id, sector_id, status, pid, created_at) VALUES (?, 'api', 'active', NULL, ?)"
+      )
+      .run('zombie-young', recentDate);
+
+    const summary = await runReconciliation({
+      db: getDb(),
+      starbaseId: starbaseDb.getStarbaseId(),
+      worktreeBasePath: join(TEST_DIR, 'worktrees')
+    });
+
+    expect(summary.nullPidZombies).not.toContain('zombie-young');
+
+    const row = getDb()
+      .prepare<[string], { status: string }>('SELECT status FROM crew WHERE id = ?')
+      .get('zombie-young');
+    expect(row?.status).toBe('active');
+  });
 });

--- a/src/main/starbase-runtime-core.ts
+++ b/src/main/starbase-runtime-core.ts
@@ -19,6 +19,7 @@ import { CargoService } from './starbase/cargo-service';
 import { RetentionService } from './starbase/retention-service';
 import { ProtocolService } from './starbase/protocol-service';
 import { ShipsLog } from './starbase/ships-log';
+import { Sentinel } from './starbase/sentinel';
 import type { StarbaseRuntimeStatus } from '../shared/ipc-api';
 import { CodedError, toError } from './errors';
 
@@ -49,6 +50,7 @@ type RuntimeDeps = {
   firstOfficer: FirstOfficer;
   navigator: Navigator;
   lockfile: Lockfile | null;
+  sentinel?: Sentinel;
 };
 
 const RUNTIME_TRACE_FILE = '/tmp/fleet-starbase-runtime.log';
@@ -696,6 +698,18 @@ export class StarbaseRuntimeCore {
         trace('bootstrap memos dir ensured');
       }
 
+      const sentinel = new Sentinel({
+        db: localStarbaseDb.getDb(),
+        configService,
+        eventBus: this.eventBus,
+        crewService,
+        firstOfficer,
+        navigator,
+        missionService
+      });
+      sentinel.start();
+      trace('bootstrap sentinel started');
+
       this.deps = {
         starbaseDb: localStarbaseDb,
         sectorService,
@@ -710,7 +724,8 @@ export class StarbaseRuntimeCore {
         shipsLog,
         firstOfficer,
         navigator,
-        lockfile: localLockfile
+        lockfile: localLockfile,
+        sentinel
       };
       trace('bootstrap deps assigned');
 

--- a/src/main/starbase/crew-service.ts
+++ b/src/main/starbase/crew-service.ts
@@ -251,9 +251,36 @@ export class CrewService {
     this.hulls.set(crewId, hull);
 
     // 9. Start the Hull (headless — no paneId)
-    hull.start();
+    try {
+      hull.start();
+    } catch (err) {
+      // hull.start() throws if the mission was already claimed by a concurrent deploy.
+      // Clean up the in-memory hull reference so it doesn't linger as a zombie.
+      this.hulls.delete(crewId);
+      // Notify Admiral so the failure is visible
+      try {
+        db.prepare(
+          "INSERT INTO comms (from_crew, to_crew, type, payload) VALUES (NULL, 'admiral', 'deploy_failed', ?)"
+        ).run(
+          JSON.stringify({
+            missionId,
+            crewId,
+            reason: err instanceof Error ? err.message : String(err)
+          })
+        );
+        db.prepare(
+          "INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'deploy_failed', ?)"
+        ).run(
+          crewId,
+          JSON.stringify({ missionId, reason: err instanceof Error ? err.message : String(err) })
+        );
+      } catch {
+        // DB write failure in error path — non-fatal, already throwing
+      }
+      throw err;
+    }
 
-    // Increment global mission deployment budget counter
+    // Increment global mission deployment budget counter (only on successful start)
     db.prepare(
       'UPDATE missions SET mission_deployment_count = mission_deployment_count + 1 WHERE id = ?'
     ).run(missionId);

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -184,32 +184,35 @@ export class Hull {
     const lifesignSec = this.opts.lifesignIntervalSec ?? 10;
     const timeoutMin = this.opts.timeoutMin ?? 15;
 
-    // Insert crew record (tab_id is NULL — headless crew, no terminal tab)
-    db.prepare(
-      `INSERT INTO crew (id, tab_id, sector_id, mission_id, sector_path, worktree_path,
-        worktree_branch, status, mission_summary, pid, deadline, last_lifesign)
-       VALUES (?, NULL, ?, ?, ?, ?, ?, 'active', ?, NULL, datetime('now', '+${timeoutMin} minutes'), datetime('now'))`
-    ).run(
-      crewId,
-      sectorId,
-      missionId,
-      this.opts.sectorPath,
-      worktreePath,
-      worktreeBranch,
-      prompt.slice(0, 100)
-    );
+    // Activate mission and insert crew atomically — if either step fails the other is rolled back
+    db.transaction(() => {
+      // Activate mission FIRST — abort before inserting crew if another crew already claimed it
+      const activateResult = db
+        .prepare(
+          "UPDATE missions SET status = 'active', crew_id = ?, started_at = datetime('now') WHERE id = ? AND crew_id IS NULL AND status NOT IN ('completed', 'done', 'aborted', 'failed', 'failed-verification', 'escalated', 'approved')"
+        )
+        .run(crewId, missionId);
+      if (activateResult.changes === 0) {
+        throw new Error(
+          `Mission ${missionId} already has an active crew or is in a terminal state. Aborting duplicate deployment.`
+        );
+      }
 
-    // Activate mission atomically — abort if another crew already claimed it or mission is terminal
-    const activateResult = db
-      .prepare(
-        "UPDATE missions SET status = 'active', crew_id = ?, started_at = datetime('now') WHERE id = ? AND crew_id IS NULL AND status NOT IN ('completed', 'done', 'aborted', 'failed', 'failed-verification', 'escalated', 'approved')"
-      )
-      .run(crewId, missionId);
-    if (activateResult.changes === 0) {
-      throw new Error(
-        `Mission ${missionId} already has an active crew or is in a terminal state. Aborting duplicate deployment.`
+      // Insert crew record only after mission is claimed (tab_id is NULL — headless crew, no terminal tab)
+      db.prepare(
+        `INSERT INTO crew (id, tab_id, sector_id, mission_id, sector_path, worktree_path,
+          worktree_branch, status, mission_summary, pid, deadline, last_lifesign)
+         VALUES (?, NULL, ?, ?, ?, ?, ?, 'active', ?, NULL, datetime('now', '+${timeoutMin} minutes'), datetime('now'))`
+      ).run(
+        crewId,
+        sectorId,
+        missionId,
+        this.opts.sectorPath,
+        worktreePath,
+        worktreeBranch,
+        prompt.slice(0, 100)
       );
-    }
+    })();
 
     // Log deployment
     db.prepare("INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'deployed', ?)").run(

--- a/src/main/starbase/reconciliation.ts
+++ b/src/main/starbase/reconciliation.ts
@@ -15,6 +15,7 @@ type ReconciliationDeps = {
 
 type ReconciliationSummary = {
   lostCrew: string[];
+  nullPidZombies: string[];
   orphanedWorktrees: string[];
   retriedPushes: number[];
   requeuedMissions: number[];
@@ -36,18 +37,42 @@ export async function runReconciliation(deps: ReconciliationDeps): Promise<Recon
   const { db, starbaseId, worktreeBasePath } = deps;
   const summary: ReconciliationSummary = {
     lostCrew: [],
+    nullPidZombies: [],
     orphanedWorktrees: [],
     retriedPushes: [],
     requeuedMissions: [],
     cleanedErroredCrew: []
   };
 
-  // 1. Query all active crew
+  // 1a. Catch null-PID zombies older than 60 seconds — these are deploy failures
+  // that survived due to the hull.start() race condition (pre-Fix 3 legacy rows).
+  const nullPidZombies = db
+    .prepare<[], { id: string }>(
+      `SELECT id FROM crew WHERE status = 'active' AND pid IS NULL
+       AND created_at < datetime('now', '-60 seconds')`
+    )
+    .all();
+
+  for (const zombie of nullPidZombies) {
+    db.prepare("UPDATE crew SET status = 'lost', updated_at = datetime('now') WHERE id = ?").run(
+      zombie.id
+    );
+    db.prepare(
+      "INSERT INTO ships_log (crew_id, event_type, detail) VALUES (?, 'reconciliation', ?)"
+    ).run(
+      zombie.id,
+      JSON.stringify({ reason: 'null-PID zombie — deploy failed before process spawn' })
+    );
+    summary.nullPidZombies.push(zombie.id);
+    summary.lostCrew.push(zombie.id);
+  }
+
+  // 1b. Query active crew that have processes (null-PID zombies already handled above)
   const activeCrew = db
     .prepare<
       [],
       CrewRow
-    >("SELECT id, sector_id, pid, worktree_path, worktree_branch, created_at FROM crew WHERE status = 'active'")
+    >("SELECT id, sector_id, pid, worktree_path, worktree_branch, created_at FROM crew WHERE status = 'active' AND pid IS NOT NULL")
     .all();
 
   // 2-3. Check PIDs, mark dead ones as lost

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     include: ['src/main/__tests__/**/*.test.ts', 'src/renderer/src/**/__tests__/**/*.test.ts'],
     setupFiles: ['src/test-setup.ts'],
     clearMocks: true,
+    // @ts-expect-error — forceExit not in vitest 4.x InlineConfig type defs but accepted at runtime
     forceExit: true
   }
 });


### PR DESCRIPTION
## Summary

- **hull.ts (Fix 3 + atomic transaction)**: Reorder activation so mission is claimed via `UPDATE missions` *before* `INSERT INTO crew`. Both statements are wrapped in `db.transaction()` so a failed crew INSERT rolls back the mission claim atomically — no orphaned crew rows, no stuck-active missions.
- **crew-service.ts (Fix 2 + Fix 4)**: Wrap `hull.start()` in try/catch. On failure: delete the hull from the in-memory map, insert `deploy_failed` comms so Admiral is notified, insert ships_log entry, and re-throw. `mission_deployment_count` is only incremented on successful start.
- **reconciliation.ts (Fix 5)**: Add null-PID zombie detection before the active-crew PID loop. Crew rows with `status='active'`, `pid IS NULL`, and `created_at < now - 60s` are marked `lost` with a distinct reason string. The existing active-crew query is scoped to `pid IS NOT NULL` to avoid double-processing.
- **starbase-runtime-core.ts (Fix 1)**: Import and instantiate `Sentinel` after all deps are constructed. Call `sentinel.start()` and store in `this.deps.sentinel` so the continuous watchdog (lifesign checks, deadline enforcement, First Officer sweeps) is active from bootstrap.
- **vitest.config.ts**: Add `@ts-expect-error` for `forceExit` which is not in vitest 4.x `InlineConfig` type defs but is accepted at runtime.

## Test plan

- [ ] `npm run typecheck` — clean (pre-existing vitest.config.ts error suppressed with `@ts-expect-error`)
- [ ] `npm run lint` — clean (no new errors)
- [ ] `npm run build` — passes
- [ ] `hull.test.ts` — 24 tests pass including 2 new activation-ordering tests
- [ ] `crew-service.test.ts` — passes including 2 new hull failure cleanup tests
- [ ] `reconciliation.test.ts` — passes including 2 new null-PID zombie tests
- [ ] `sentinel.test.ts` + `sentinel-circuit-breaker.test.ts` + `sentinel-socket.test.ts` — 17 tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)