### PR TITLE
fix(analyst): increase timeout to 30s, make configurable, add retry

### DIFF
--- a/src/main/__tests__/analyst.test.ts
+++ b/src/main/__tests__/analyst.test.ts
@@ -10,7 +10,23 @@ vi.mock('child_process', async (importOriginal) => {
   return { ...actual, spawn: vi.fn(() => mockProc) };
 });
 
+import { spawn } from 'child_process';
 import { Analyst } from '../starbase/analyst';
+
+/** Build a fake process that never closes (used to trigger timeout). */
+function makeMockProcThatNeverCloses() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.kill = vi.fn();
+  return proc;
+}
 
 /** Build a fake EventEmitter-based process that emits stdout data then closes. */
 function makeMockProc(stdoutData: string, exitCode = 0) {
@@ -47,33 +63,34 @@ describe('Analyst', () => {
   beforeEach(() => {
     db = makeDb();
     mockProc = null;
+    vi.mocked(spawn).mockClear();
   });
 
   describe('classifyError', () => {
     it('returns classification from valid LLM JSON', async () => {
       mockProc = makeMockProc('{"classification": "transient", "reason": "network blip"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('Error: connection reset');
       expect(result).toBe('transient');
     });
 
     it('returns non-retryable from valid LLM JSON', async () => {
       mockProc = makeMockProc('{"classification": "non-retryable", "reason": "missing file"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('ENOENT: no such file or directory');
       expect(result).toBe('non-retryable');
     });
 
     it('parses JSON inside a code fence', async () => {
       mockProc = makeMockProc('Sure!\n```json\n{"classification": "persistent", "reason": "same error"}\n```');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('the same error again');
       expect(result).toBe('persistent');
     });
 
     it('returns null and writes degraded comms on non-zero exit', async () => {
       mockProc = makeMockProc('', 1);
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('some error');
       expect(result).toBeNull();
       expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('analyst_degraded'));
@@ -81,21 +98,21 @@ describe('Analyst', () => {
 
     it('returns null on malformed JSON', async () => {
       mockProc = makeMockProc('not json at all');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('some error');
       expect(result).toBeNull();
     });
 
     it('returns null on unknown classification value', async () => {
       mockProc = makeMockProc('{"classification": "unknown-thing", "reason": "x"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.classifyError('some error');
       expect(result).toBeNull();
     });
 
     it('rate-limits analyst_degraded comms to once per 5 minutes per method', async () => {
       mockProc = makeMockProc('', 1);
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       await analyst.classifyError('err1');
 
       // Immediately fail again — should NOT write a second comms
@@ -112,14 +129,14 @@ describe('Analyst', () => {
   describe('summarizeCILogs', () => {
     it('returns the summary string from valid LLM JSON', async () => {
       mockProc = makeMockProc('{"summary": "Build failed: missing dependency foo"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.summarizeCILogs('...raw CI logs...');
       expect(result).toBe('Build failed: missing dependency foo');
     });
 
     it('returns null on missing summary field', async () => {
       mockProc = makeMockProc('{"wrong": "field"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.summarizeCILogs('logs');
       expect(result).toBeNull();
     });
@@ -128,21 +145,21 @@ describe('Analyst', () => {
   describe('extractPRVerdict', () => {
     it('returns APPROVE verdict', async () => {
       mockProc = makeMockProc('{"verdict": "APPROVE", "notes": "Looks good"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.extractPRVerdict('LGTM, great work');
       expect(result).toEqual({ verdict: 'APPROVE', notes: 'Looks good' });
     });
 
     it('returns REQUEST_CHANGES verdict', async () => {
       mockProc = makeMockProc('{"verdict": "REQUEST_CHANGES", "notes": "Missing tests"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.extractPRVerdict('Missing test coverage');
       expect(result).toEqual({ verdict: 'REQUEST_CHANGES', notes: 'Missing tests' });
     });
 
     it('returns null for invalid verdict value', async () => {
       mockProc = makeMockProc('{"verdict": "MAYBE", "notes": "not sure"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.extractPRVerdict('some output');
       expect(result).toBeNull();
     });
@@ -151,16 +168,44 @@ describe('Analyst', () => {
   describe('writeHailingContext', () => {
     it('returns context string from valid LLM JSON', async () => {
       mockProc = makeMockProc('{"context": "The crew appears stuck waiting for user input."}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.writeHailingContext('Should I push to main?');
       expect(result).toBe('The crew appears stuck waiting for user input.');
     });
 
     it('returns null on invalid schema', async () => {
       mockProc = makeMockProc('{"wrong": "field"}');
-      const analyst = new Analyst({ db: db as any });
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
       const result = await analyst.writeHailingContext('question');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('timeout and retry', () => {
+    it('retries once on timeout and returns result from second attempt', async () => {
+      // Create the success proc lazily so setImmediate is scheduled after the retry spawns it,
+      // not eagerly before the first timeout fires.
+      let callCount = 0;
+      vi.mocked(spawn).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return makeMockProcThatNeverCloses() as any;
+        return makeMockProc('{"classification": "transient", "reason": "blip"}') as any;
+      });
+
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
+      const result = await analyst.classifyError('some error');
+      expect(result).toBe('transient');
+      expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
+    });
+
+    it('triggers degraded fallback on double timeout', async () => {
+      vi.mocked(spawn).mockImplementation(() => makeMockProcThatNeverCloses() as any);
+
+      const analyst = new Analyst({ db: db as any, timeoutMs: 100 });
+      const result = await analyst.classifyError('some error');
+      expect(result).toBeNull();
+      expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('analyst_degraded'));
+      expect(vi.mocked(spawn).mock.calls).toHaveLength(2);
     });
   });
 });

--- a/src/main/starbase/analyst.ts
+++ b/src/main/starbase/analyst.ts
@@ -4,7 +4,7 @@ import { spawn } from 'child_process';
 import { filterEnv as defaultFilterEnv } from '../env-utils';
 
 const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
-const TIMEOUT_MS = 5000;
+const TIMEOUT_MS = 30_000; // 30 seconds — allows for Claude CLI cold-start + network latency
 const DEGRADED_COOLDOWN_MS = 5 * 60 * 1000;
 
 export class AnalystError extends Error {
@@ -21,18 +21,21 @@ export interface AnalystDeps {
   db: Database.Database;
   filterEnv?: () => Record<string, string>;
   model?: string;
+  timeoutMs?: number;
 }
 
 export class Analyst {
   private readonly db: Database.Database;
   private readonly getEnv: () => Record<string, string>;
   private readonly model: string;
+  private readonly timeoutMs: number;
   private readonly lastDegradedAt = new Map<string, number>();
 
   constructor(deps: AnalystDeps) {
     this.db = deps.db;
     this.getEnv = deps.filterEnv ?? defaultFilterEnv;
     this.model = deps.model ?? DEFAULT_MODEL;
+    this.timeoutMs = deps.timeoutMs ?? TIMEOUT_MS;
   }
 
   /** Extract the first JSON object from free-form LLM text output. */
@@ -56,11 +59,11 @@ export class Analyst {
   }
 
   /**
-   * Spawn `claude --print --model <model>`, write prompt to stdin,
+   * Single attempt: spawn `claude --print --model <model>`, write prompt to stdin,
    * collect stdout, parse the first JSON object from the response.
-   * Kills the process after TIMEOUT_MS if it hasn't exited.
+   * Kills the process and rejects with 'Analyst subprocess timed out' after timeoutMs.
    */
-  private run(prompt: string): Promise<unknown> {
+  private runAttempt(prompt: string): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const proc = spawn('claude', ['--print', '--model', this.model], {
         env: this.getEnv(),
@@ -74,7 +77,7 @@ export class Analyst {
         timedOut = true;
         proc.kill('SIGKILL');
         reject(new Error('Analyst subprocess timed out'));
-      }, TIMEOUT_MS);
+      }, this.timeoutMs);
 
       proc.stdout.on('data', (chunk: Buffer) => {
         stdout += chunk.toString();
@@ -104,6 +107,19 @@ export class Analyst {
         clearTimeout(timer);
         reject(err);
       });
+    });
+  }
+
+  /**
+   * Run the analyst subprocess, retrying once on timeout to guard against
+   * transient cold-start spikes. A second timeout propagates to the caller.
+   */
+  private run(prompt: string): Promise<unknown> {
+    return this.runAttempt(prompt).catch((err: unknown) => {
+      if (err instanceof Error && err.message === 'Analyst subprocess timed out') {
+        return this.runAttempt(prompt);
+      }
+      throw err;
     });
   }
 


### PR DESCRIPTION
## Summary
- Raises `TIMEOUT_MS` from 5s to 30s in `analyst.ts` — the 5s budget was consistently too tight for real conditions (Claude CLI cold-start ~0.5–2s + Anthropic API latency ~1–4s P50, up to 15s under load), causing silent fallback to the regex path
- Adds optional `timeoutMs` to `AnalystDeps` so tests inject 100ms and production can tune without a code change
- Adds one retry on timeout before triggering the degraded-comms fallback, guarding against transient cold-start spikes

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run test src/main/__tests__/analyst.test.ts` — 16/16 pass, including two new timeout/retry cases:
  - single timeout → retry → success
  - double timeout → degraded fallback + `analyst_degraded` comms written

🤖 Generated with [Claude Code](https://claude.com/claude-code)