### PR TITLE
fix: open external links in system browser

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Notification, nativeImage } from 'electron';
+import { app, BrowserWindow, ipcMain, Notification, nativeImage, shell } from 'electron';
 import { appendFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { join, dirname } from 'path';
@@ -199,6 +199,20 @@ function createWindow(): void {
 
   mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
     console.error(`[renderer] Failed to load: ${errorCode} ${errorDescription}`);
+  });
+
+  // Intercept navigation away from app (e.g. <a href> without target)
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!url.startsWith('http://localhost') && !url.startsWith('file://')) {
+      event.preventDefault();
+      void shell.openExternal(url);
+    }
+  });
+
+  // Intercept window.open / target="_blank" links
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: 'deny' };
   });
 
   if (!app.isPackaged) {

--- a/src/renderer/src/components/star-command/MemoPanel.tsx
+++ b/src/renderer/src/components/star-command/MemoPanel.tsx
@@ -93,7 +93,24 @@ export function MemoPanel({ onClose }: MemoPanelProps): React.JSX.Element {
         <div className="flex-1 overflow-y-auto p-6">
           {content ? (
             <div className="prose prose-invert prose-sm max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  a: ({ href, children }) => (
+                    <a
+                      href={href}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        if (href) void window.fleet.shell.openExternal(href);
+                      }}
+                    >
+                      {children}
+                    </a>
+                  )
+                }}
+              >
+                {content}
+              </ReactMarkdown>
             </div>
           ) : (
             <div className="text-xs text-neutral-500">Select a memo to read</div>


### PR DESCRIPTION
## Summary
- Add `will-navigate` and `setWindowOpenHandler` guards in the main process to intercept any external navigation and route it to `shell.openExternal`
- Add a custom `a` component renderer in `MemoPanel` so markdown links call `window.fleet.shell.openExternal` instead of navigating the renderer window

## Test plan
- [ ] Click a markdown link in a memo — should open in system default browser, not inside the Fleet window
- [ ] Navigate to an external URL via address bar or `window.location` in devtools — should open in browser
- [ ] `window.open('https://...')` in renderer — should open in browser and return null

🤖 Generated with [Claude Code](https://claude.com/claude-code)