### PR TITLE
fix(missions): warn and surface missing --original-mission-id on repair missions

### DIFF
--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -449,7 +449,13 @@ export function validateCommand(command: string, args: Record<string, unknown>):
       }
       const prBranch = args['pr-branch'] ? toStr(args['pr-branch']) : undefined;
       if (toStr(args.type) === 'repair' && !prBranch) {
-        return `Error: --type repair requires --pr-branch <branch-name>.\n\nUsage: fleet missions add --type repair --pr-branch <branch> --sector <id> --summary "..." --prompt "..."`;
+        return `Error: --type repair requires --pr-branch <branch-name>.\n\nUsage: fleet missions add --type repair --pr-branch <branch> --original-mission-id <id> --sector <id> --summary "..." --prompt "..."`;
+      }
+      if (toStr(args.type) === 'repair' && !args['original-mission-id']) {
+        process.stderr.write(
+          'Warning: --type repair without --original-mission-id means the automated review dispatch will not trigger after repair completes.\n' +
+          'Provide --original-mission-id <code-mission-id> to link this repair to its original mission.\n'
+        );
       }
       if (!args.prompt) return `Error: missions add requires --prompt "...".\n\n${usage}`;
       if (!args.summary) return `Error: missions add requires --summary "...".\n\n${usage}`;

--- a/src/main/starbase/hull.ts
+++ b/src/main/starbase/hull.ts
@@ -1567,6 +1567,13 @@ The PR already exists. Your commits will be pushed to the existing PR branch aut
           stdio: 'pipe'
         });
         // PR exists — handle based on mission type
+        if (this.opts.missionType === 'repair' && this.opts.originalMissionId == null) {
+          console.error(
+            `[hull] Warning: repair mission ${missionId} has no originalMissionId — ` +
+            `falling into default pending-review branch. The original code mission will NOT be transitioned to pending-review ` +
+            `and automated review dispatch will not trigger. Use --original-mission-id when creating repair missions manually.`
+          );
+        }
         if (this.opts.missionType === 'repair' && this.opts.originalMissionId != null) {
           // Repair crew: transition ORIGINAL mission to pending-review for fresh review
           db.prepare(

--- a/src/main/starbase/workspace-templates.ts
+++ b/src/main/starbase/workspace-templates.ts
@@ -424,6 +424,7 @@ When a PR has CI failures or human review comments that need addressing after th
 # 1. Create a repair mission targeting the existing PR branch
 fleet missions add --sector <id> --type repair \\
   --pr-branch <branch-name> \\
+  --original-mission-id <original-code-mission-id> \\
   --summary "Fix CI failures on <feature>" \\
   --prompt "CI is failing with the following output: <paste ci output>. Fix the issues and push to the existing PR branch."
 


### PR DESCRIPTION
## Summary
- Adds a `stderr` warning in `fleet-cli.ts` when `--type repair` is used without `--original-mission-id`, preventing silent review dispatch failures
- Updates the Admiral repair workflow template in `workspace-templates.ts` to include `--original-mission-id <id>` so future sessions provide it by default
- Adds a `console.error` in `hull.ts` `createPR()` when a repair mission has `originalMissionId == null`, surfacing the wrong-branch condition in logs

## Root cause
Manually-created repair missions without `--original-mission-id` caused `hull.ts` to set the repair mission itself (type=`repair`) to `pending-review` instead of the original code mission. The sentinel's `reviewSweep` filters on `type = 'code'`, so the repair mission was never selected and no review crew was dispatched.

## Test plan
- [ ] Run `fleet missions add --type repair --pr-branch foo --sector bar --summary "x" --prompt "y"` — verify warning prints to stderr
- [ ] Confirm typecheck passes: `npm run typecheck`
- [ ] Confirm the repair workflow template in Admiral sessions now includes `--original-mission-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)