### PR TITLE
fix(ci): merge mac jobs into universal build, guard forceDevUpdateConfig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
             exit 1
           fi
 
-  release-mac-arm64:
+  release-mac:
     needs: [verify-version]
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -39,45 +39,13 @@ jobs:
         run: npx electron-vite build
       - name: Extract release notes config
         run: npx tsx scripts/extract-release-notes.ts /tmp/release-extra.json
-      - name: Package, sign, notarize and publish
+      - name: Package, sign, notarize and publish (universal)
         uses: nick-fields/retry@v3
         with:
           max_attempts: 3
-          timeout_minutes: 20
+          timeout_minutes: 40
           retry_wait_seconds: 30
-          command: npx electron-builder --mac --arm64 --publish always --config /tmp/release-extra.json
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-  release-mac-x64:
-    needs: [verify-version]
-    runs-on: macos-15-intel
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - name: Rebuild native Electron deps
-        run: npx electron-builder install-app-deps
-      - name: Build app
-        run: npx electron-vite build
-      - name: Extract release notes config
-        run: npx tsx scripts/extract-release-notes.ts /tmp/release-extra.json
-      - name: Package, sign, notarize and publish
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 20
-          retry_wait_seconds: 30
-          command: npx electron-builder --mac --x64 --publish always --config /tmp/release-extra.json
+          command: npx electron-builder --mac --universal --publish always --config /tmp/release-extra.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -123,7 +91,7 @@ jobs:
         run: npx electron-vite build && npx electron-builder --linux AppImage --publish always --config /tmp/release-extra.json
 
   publish-release:
-    needs: [release-mac-arm64, release-mac-x64, release-win, release-linux]
+    needs: [release-mac, release-win, release-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Publish draft release

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -731,7 +731,9 @@ void app.whenReady().then(() => {
 
   // --- Auto-updater: unified status pipeline ---
   // Allow checking for updates in dev mode via dev-app-update.yml
-  autoUpdater.forceDevUpdateConfig = true;
+  if (!app.isPackaged) {
+    autoUpdater.forceDevUpdateConfig = true;
+  }
 
   let updateState: 'idle' | 'checking' | 'downloading' | 'ready' = 'idle';
   let pendingVersion = '';


### PR DESCRIPTION
## Summary

Fixes #143 — arm64 Mac users receive an x64 zip during auto-update because two independent CI jobs both publish to `latest-mac.yml`, with whichever finishes last winning.

- **Replace `release-mac-arm64` + `release-mac-x64` with a single `release-mac` job** running on `macos-15` that builds a universal binary (`--universal`). A single job means a single `latest-mac.yml` write — no race condition.
- **Guard `autoUpdater.forceDevUpdateConfig`** behind `!app.isPackaged` so it only applies in development. Previously it was set unconditionally, which could interfere with update config resolution in packaged releases.

## Test plan

- [ ] Trigger a release tag and verify only one `release-mac` job runs
- [ ] Confirm `latest-mac.yml` references the universal zip (not separate arm64/x64 zips)
- [ ] Verify arm64 and x64 Macs can both download and install the update
- [ ] Confirm typecheck passes (`npm run typecheck`) — ✅ verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)