### PR TITLE
fix(ci): remove node-pty prebuilds before universal mac build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
       - run: npm ci
       - name: Rebuild native Electron deps
         run: npx electron-builder install-app-deps
+      - name: Remove node-pty prebuilds for universal build
+        run: rm -rf node_modules/node-pty/prebuilds
       - name: Build app
         run: npx electron-vite build
       - name: Extract release notes config

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,7 +12,6 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
   - '!reference/**'
   - '!docs/**'
-  - '!**/node-pty/prebuilds/**'
 asarUnpack:
   - resources/**
 mac:


### PR DESCRIPTION
## Summary
- Adds a step in `release-mac` to remove `node_modules/node-pty/prebuilds` after `install-app-deps` and before packaging — this prevents electron-builder from failing when it detects byte-identical arm64/x64 prebuilds during universal binary merging
- Removes the ineffective `!**/node-pty/prebuilds/**` exclusion from `electron-builder.yml` (it was added as a prior failed fix attempt and had no effect on the merge failure)

## Test plan
- [ ] Trigger a release tag and verify the `release-mac` CI job completes successfully with a universal `.dmg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)