### PR TITLE
fix(terminal): re-hide xterm cursor on window focus restore

### DIFF
--- a/docs/learnings/2026-03-23-double-cursor-on-workspace-switch.md
+++ b/docs/learnings/2026-03-23-double-cursor-on-workspace-switch.md
@@ -1,0 +1,30 @@
+# Double Cursor After Workspace Switch
+
+## What happened
+
+When running a TUI like Claude Code inside Fleet, switching macOS workspaces (Mission Control) and returning showed **two cursors** simultaneously:
+1. The TUI-drawn cursor glyph (rendered by Claude Code into the terminal buffer)
+2. xterm.js's hardware cursor (which should be suppressed in TUI/alt-screen mode)
+
+## Root cause
+
+Fleet's cursor suppressor (`createTerminal` in `use-terminal.ts`) intercepts `\x1b[?25h` (DECTCEM show-cursor) from PTY data via `term.parser.registerCsiHandler`. This works for suppressing cursor show sequences that come through the **PTY data stream**.
+
+However, when the Electron window regains focus after a workspace switch, **xterm.js internally re-enables its hardware cursor** as part of its focus-restore logic. This internal path completely bypasses the CSI parser handler — xterm never writes `\x1b[?25h` through the parser; it directly tells its renderer to show the cursor.
+
+## Fix
+
+Added a `window` `focus` event listener in `createTerminal`. When the window regains focus while `tuiMode` is active (alt-screen or `cursorHidden: true`), we write `\x1b[?25l` to re-hide xterm's hardware cursor. The listener is cleaned up in `cursorSuppressor.dispose()`.
+
+```javascript
+const onWindowFocus = (): void => {
+  if (tuiMode && term.element) {
+    term.write('\x1b[?25l');
+  }
+};
+window.addEventListener('focus', onWindowFocus);
+```
+
+## Key lesson
+
+`term.parser.registerCsiHandler` only intercepts sequences from **external data** (PTY output written through `term.write()`). xterm.js internal state changes (focus/blur handling, renderer repaints) bypass the parser entirely. For behaviors that must persist across window focus events, use `window.addEventListener('focus', ...)`.

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -164,9 +164,21 @@ function createTerminal(
         return false; // always pass through to xterm's default handler
       });
 
+  // Re-suppress xterm's hardware cursor after window focus restore.
+  // When the Electron window regains focus (e.g. after switching macOS workspaces),
+  // xterm internally re-enables its hardware cursor — bypassing the CSI parser suppressor.
+  // Re-hiding it here ensures the TUI-drawn cursor glyph is the only cursor visible.
+  const onWindowFocus = (): void => {
+    if (tuiMode && term.element) {
+      term.write('\x1b[?25l');
+    }
+  };
+  window.addEventListener('focus', onWindowFocus);
+
   const cursorSuppressor: { dispose(): void } = {
     dispose(): void {
       tuiMode = false;
+      window.removeEventListener('focus', onWindowFocus);
       decsetSuppressor.dispose();
       decrstSuppressor?.dispose();
     }


### PR DESCRIPTION
## Summary
- After switching macOS workspaces and returning, two cursors appeared in TUI terminals (e.g. Claude Code): xterm's hardware cursor + the TUI-drawn cursor glyph
- Root cause: xterm.js internally re-enables its hardware cursor when the Electron window regains focus, bypassing the CSI parser suppressor (which only intercepts PTY data)
- Fix: listen to `window` `focus` event and re-write `\x1b[?25l` whenever `tuiMode` is active; listener is cleaned up on terminal dispose

## Test plan
- [ ] Open Fleet with a Claude Code session running (TUI in alt-screen mode)
- [ ] Switch to another macOS workspace (Mission Control / swipe)
- [ ] Switch back to Fleet — verify only one cursor is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)