### PR TITLE
fix: include repair missions in review and fix crew dispatch

### DIFF
--- a/src/main/starbase/sentinel.ts
+++ b/src/main/starbase/sentinel.ts
@@ -853,7 +853,7 @@ export class Sentinel {
        JOIN sectors s ON s.id = m.sector_id
        WHERE m.status = 'pending-review'
          AND m.pr_branch IS NOT NULL
-         AND m.type = 'code'
+         AND m.type IN ('code', 'repair')
        ORDER BY m.priority ASC, m.completed_at ASC
        LIMIT ?`
       )
@@ -919,7 +919,7 @@ NOTES: <your review notes — specific file:line references for issues>`;
        JOIN sectors s ON s.id = m.sector_id
        WHERE m.status = 'changes-requested'
          AND m.pr_branch IS NOT NULL
-         AND m.type = 'code'
+         AND m.type IN ('code', 'repair')
        ORDER BY m.priority ASC
        LIMIT 5`
       )


### PR DESCRIPTION
## Summary
- Repair missions complete with `pending-review` status but were excluded from automatic review crew dispatch due to `m.type = 'code'` filter
- Changed queries to include repair missions: `m.type IN ('code', 'repair')`
- Research missions remain excluded, maintaining the original safety net
- Fixes #150

## Test plan
- [x] TypeScript type checking passes
- [x] Linter passes (pre-existing warnings only)
- [ ] Verify repair mission reaches pending-review after crew completion
- [ ] Verify review_crew_dispatched event is logged for repair missions
- [ ] Verify review crews are dispatched for repair missions

🤖 Generated with [Claude Code](https://claude.com/claude-code)