### PR TITLE
fix(ui): improve pane header visibility and contrast

### DIFF
--- a/src/renderer/src/components/PaneHeader.tsx
+++ b/src/renderer/src/components/PaneHeader.tsx
@@ -68,7 +68,7 @@ export function PaneHeader({ paneId, label, labelIsCustom }: PaneHeaderProps): R
   );
 
   return (
-    <div className="flex items-center h-6 px-2 bg-neutral-900 border-b border-neutral-800 text-xs text-neutral-400 select-none shrink-0">
+    <div className="flex items-center h-6 px-2 bg-neutral-800/80 border-b border-neutral-700 text-xs text-neutral-300 select-none shrink-0">
       {isEditing ? (
         <input
           ref={inputRef}


### PR DESCRIPTION
## Summary
- Pane name headers were blending into the terminal background, making them hard to distinguish
- Lightened background (`bg-neutral-900` → `bg-neutral-800/80`), border (`border-neutral-800` → `border-neutral-700`), and text (`text-neutral-400` → `text-neutral-300`) for better contrast

## Test plan
- [ ] Verify pane headers are visually distinct from terminal background
- [ ] Check that custom pane names and path-based labels both render clearly
- [ ] Confirm the header doesn't look too bright or jarring against the dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)