### PR TITLE
fix(ui): replace ambiguous x icon with "clear title" text in pane header

### DIFF
--- a/src/renderer/src/components/PaneHeader.tsx
+++ b/src/renderer/src/components/PaneHeader.tsx
@@ -91,17 +91,10 @@ export function PaneHeader({ paneId, label, labelIsCustom }: PaneHeaderProps): R
         <button
           className="ml-1 text-neutral-500 hover:text-neutral-300 transition-colors"
           onClick={() => resetPaneLabel(paneId)}
-          title="Reset to path"
-          aria-label="Reset pane name"
+          title="Clear custom title and show path"
+          aria-label="Clear pane title"
         >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-            <path
-              d="M2 2l6 6M8 2l-6 6"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-            />
-          </svg>
+          clear title
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replace the `×` SVG icon on custom pane title headers with explicit "clear title" text
- The x icon was confusing because it looked like a close button — a well-documented UX anti-pattern (NNG research shows text labels outperform standalone icons for non-universal actions)
- Updated tooltip and aria-label for clarity

## Test plan
- [ ] Set a custom pane title (double-click header or Shift+F2)
- [ ] Verify "clear title" text appears next to the custom title
- [ ] Click "clear title" and verify it reverts to the cwd path
- [ ] Verify "clear title" is not shown for non-custom (default path) headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)