### PR TITLE
fix(ui): extend active pane highlight to include header

### DIFF
--- a/src/renderer/src/components/PaneGrid.tsx
+++ b/src/renderer/src/components/PaneGrid.tsx
@@ -171,7 +171,7 @@ export function PaneGrid({
           );
         }
         return (
-          <div key={leaf.id} style={rectStyle(leaf.rect)} className="flex flex-col">
+          <div key={leaf.id} style={rectStyle(leaf.rect)} className={`flex flex-col ${leaf.id === activePaneId ? 'ring-2 ring-blue-500/70' : 'ring-1 ring-neutral-800/50'}`}>
             {root.type === 'split' && (
               <PaneHeader
                 paneId={leaf.id}

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -109,7 +109,7 @@ export function TerminalPane({
 
   return (
     <div
-      className={`relative h-full w-full overflow-hidden p-3 transition-[box-shadow] duration-0 ${isActive ? 'ring-2 ring-blue-500/70 bg-[#151515]' : 'ring-1 ring-neutral-800/50 bg-[#131313]'}`}
+      className={`relative h-full w-full overflow-hidden p-3 transition-[box-shadow] duration-0 ${isActive ? 'bg-[#151515]' : 'bg-[#131313]'}`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onFocus={onFocus}


### PR DESCRIPTION
## Summary
- Move the ring border styling from `TerminalPane` to the parent container in `PaneGrid` so the blue active-pane highlight wraps both the pane header and terminal content together

## Test plan
- [ ] Open Fleet with multiple panes (split horizontally or vertically)
- [ ] Click on a pane — the blue border should wrap around both the header and the terminal
- [ ] Verify inactive panes still show the subtle neutral ring
- [ ] Test with a single pane (no header) — highlight should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)