### PR TITLE
feat: add telescope picker — multi-mode fuzzy finder modal

### DIFF
--- a/docs/superpowers/plans/2026-04-11-telescope-picker.md
+++ b/docs/superpowers/plans/2026-04-11-telescope-picker.md
@@ -1,0 +1,1536 @@
+# Telescope Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a multi-mode telescope picker modal to Fleet — a unified fuzzy finder with Files, Grep, Browse, and Panes modes, two-column layout with preview panel, triggered from the pane toolbar and keyboard shortcut.
+
+**Architecture:** Thin `TelescopeModal` shell component delegates to pluggable mode modules via a shared `TelescopeMode` interface. Each mode is a separate file. A new `FILE_GREP` IPC channel connects the Grep mode to a main-process backend that spawns `rg`/`grep`/`findstr`.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Radix UI Tooltip, lucide-react icons, Zustand (workspace store), Electron IPC, ripgrep/grep/findstr for content search.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-telescope-picker-design.md`
+
+---
+
+### Task 1: Types & Mode Interface
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/types.ts`
+
+- [ ] **Step 1: Create the types file**
+
+```typescript
+// src/renderer/src/components/Telescope/types.ts
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export type TelescopeItem = {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  subtitle?: string;
+  meta?: string;
+  /** Arbitrary data the mode needs for onSelect/renderPreview (file path, line number, pane id, etc.) */
+  data?: Record<string, unknown>;
+};
+
+export type TelescopeMode = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  placeholder: string;
+  onSearch: (query: string) => Promise<TelescopeItem[]> | TelescopeItem[];
+  renderPreview: (item: TelescopeItem) => ReactNode;
+  onSelect: (item: TelescopeItem) => void;
+  onAltSelect?: (item: TelescopeItem) => void;
+  /** Browse mode only: current path segments for breadcrumb display */
+  breadcrumbs?: string[];
+  /** Browse mode only: drill into a directory or jump to a breadcrumb path */
+  onNavigate?: (dir: string) => void;
+  /** Browse mode only: go up one directory */
+  onNavigateUp?: () => void;
+};
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: No new errors from the types file (it's just type declarations).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/types.ts
+git commit -m "feat(telescope): add TelescopeItem and TelescopeMode type definitions"
+```
+
+---
+
+### Task 2: IPC — FILE_GREP Channel & Types
+
+**Files:**
+- Modify: `src/shared/ipc-channels.ts:32` (add after FILE_SEARCH)
+- Modify: `src/shared/ipc-api.ts:138` (add after FileSearchResponse)
+
+- [ ] **Step 1: Add the IPC channel constant**
+
+In `src/shared/ipc-channels.ts`, add after the `FILE_SEARCH` line (line 32):
+
+```typescript
+  FILE_GREP: 'file:grep',
+```
+
+- [ ] **Step 2: Add the request/response types**
+
+In `src/shared/ipc-api.ts`, add after the `FileSearchResponse` type (after line 138):
+
+```typescript
+export type FileGrepRequest = {
+  requestId: number;
+  query: string;
+  cwd: string;
+  limit?: number;
+};
+
+export type FileGrepResult = {
+  file: string;
+  relativePath: string;
+  line: number;
+  text: string;
+  contextBefore?: string[];
+  contextAfter?: string[];
+};
+
+export type FileGrepResponse =
+  | { success: true; requestId: number; results: FileGrepResult[] }
+  | { success: false; requestId: number; error: string };
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS (new types are additive, nothing consumes them yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/ipc-channels.ts src/shared/ipc-api.ts
+git commit -m "feat(telescope): add FILE_GREP IPC channel and request/response types"
+```
+
+---
+
+### Task 3: file-grep.ts Backend
+
+**Files:**
+- Create: `src/main/file-grep.ts`
+
+This follows the exact same pattern as `src/main/file-search.ts` — spawn a process, parse stdout, normalize results, kill previous on new request.
+
+- [ ] **Step 1: Create the file-grep module**
+
+```typescript
+// src/main/file-grep.ts
+import { spawn, type ChildProcess } from 'child_process';
+import { relative } from 'path';
+import type { FileGrepRequest, FileGrepResponse, FileGrepResult } from '../shared/ipc-api';
+
+let activeProcess: ChildProcess | null = null;
+
+function killActive(): void {
+  if (activeProcess && !activeProcess.killed) {
+    activeProcess.kill('SIGTERM');
+  }
+  activeProcess = null;
+}
+
+function buildCommand(
+  query: string,
+  cwd: string,
+  limit: number
+): { cmd: string; args: string[] } {
+  // Try ripgrep first (cross-platform, fast, respects .gitignore)
+  return {
+    cmd: 'rg',
+    args: [
+      '--no-heading',
+      '--line-number',
+      '--color', 'never',
+      '--max-count', String(limit),
+      '-B', '1',
+      '-A', '1',
+      '--', query, cwd
+    ]
+  };
+}
+
+function buildFallbackCommand(
+  query: string,
+  cwd: string,
+  limit: number
+): { cmd: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return {
+      cmd: 'findstr',
+      args: ['/s', '/n', '/i', '/c:' + query, cwd + '\\*']
+    };
+  }
+  return {
+    cmd: 'grep',
+    args: ['-rn', '-m', String(limit), '--include=*', '--', query, cwd]
+  };
+}
+
+/**
+ * Parse ripgrep output with context lines (-B1 -A1).
+ * Format: filename:line:text  or  filename-line-text (context lines use -)
+ * Group separator: --
+ */
+function parseRgOutput(stdout: string, cwd: string): FileGrepResult[] {
+  const results: FileGrepResult[] = [];
+  const blocks = stdout.split('--\n');
+
+  for (const block of blocks) {
+    const lines = block.split('\n').filter(Boolean);
+    let matchResult: FileGrepResult | null = null;
+    const before: string[] = [];
+    const after: string[] = [];
+
+    for (const line of lines) {
+      // Match line: file:line:text
+      const matchLine = line.match(/^(.+?):(\d+):(.*)$/);
+      // Context line: file-line-text
+      const contextLine = line.match(/^(.+?)-(\d+)-(.*)$/);
+
+      if (matchLine && !matchResult) {
+        matchResult = {
+          file: matchLine[1],
+          relativePath: relative(cwd, matchLine[1]),
+          line: parseInt(matchLine[2], 10),
+          text: matchLine[3],
+          contextBefore: [],
+          contextAfter: []
+        };
+      } else if (contextLine && !matchResult) {
+        before.push(contextLine[3]);
+      } else if (contextLine && matchResult) {
+        after.push(contextLine[3]);
+      } else if (matchLine && matchResult) {
+        // Additional match in same block — flush current and start new
+        matchResult.contextBefore = before.splice(0);
+        matchResult.contextAfter = after.splice(0);
+        results.push(matchResult);
+        matchResult = {
+          file: matchLine[1],
+          relativePath: relative(cwd, matchLine[1]),
+          line: parseInt(matchLine[2], 10),
+          text: matchLine[3],
+          contextBefore: [],
+          contextAfter: []
+        };
+      }
+    }
+
+    if (matchResult) {
+      matchResult.contextBefore = before;
+      matchResult.contextAfter = after;
+      results.push(matchResult);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Parse grep/findstr output (no context lines for simplicity).
+ * Format: filename:line:text
+ */
+function parseFallbackOutput(stdout: string, cwd: string): FileGrepResult[] {
+  const results: FileGrepResult[] = [];
+  const lines = stdout.split('\n').filter(Boolean);
+
+  for (const line of lines) {
+    const match = line.match(/^(.+?):(\d+):(.*)$/);
+    if (match) {
+      results.push({
+        file: match[1],
+        relativePath: relative(cwd, match[1]),
+        line: parseInt(match[2], 10),
+        text: match[3]
+      });
+    }
+  }
+
+  return results;
+}
+
+export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse> {
+  killActive();
+
+  const { requestId, query, cwd } = req;
+  const limit = req.limit ?? 50;
+
+  if (!query.trim()) {
+    return { success: true, requestId, results: [] };
+  }
+
+  const { cmd, args } = buildCommand(query, cwd, limit);
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let timedOut = false;
+
+    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    activeProcess = proc;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill('SIGTERM');
+    }, 10000);
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      activeProcess = null;
+
+      const errCode = (err as NodeJS.ErrnoException).code;
+      if (errCode === 'ENOENT') {
+        // rg not found — fall back
+        const fallback = buildFallbackCommand(query, cwd, limit);
+        let fallbackStdout = '';
+
+        const fallbackProc = spawn(fallback.cmd, fallback.args, {
+          stdio: ['ignore', 'pipe', 'pipe']
+        });
+        activeProcess = fallbackProc;
+
+        const fallbackTimer = setTimeout(() => {
+          fallbackProc.kill('SIGTERM');
+        }, 10000);
+
+        fallbackProc.stdout.on('data', (chunk: Buffer) => {
+          fallbackStdout += chunk.toString();
+        });
+
+        fallbackProc.on('close', () => {
+          clearTimeout(fallbackTimer);
+          activeProcess = null;
+          const results = parseFallbackOutput(fallbackStdout, cwd).slice(0, limit);
+          resolve({ success: true, requestId, results });
+        });
+
+        fallbackProc.on('error', () => {
+          clearTimeout(fallbackTimer);
+          activeProcess = null;
+          resolve({ success: false, requestId, error: 'No grep tool available' });
+        });
+        return;
+      }
+
+      resolve({ success: false, requestId, error: `Grep failed: ${err.message}` });
+    });
+
+    proc.on('close', () => {
+      clearTimeout(timer);
+      activeProcess = null;
+
+      if (timedOut && !stdout.trim()) {
+        resolve({ success: false, requestId, error: 'Grep timed out' });
+        return;
+      }
+
+      const results = parseRgOutput(stdout, cwd).slice(0, limit);
+      resolve({ success: true, requestId, results });
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/file-grep.ts
+git commit -m "feat(telescope): add file-grep backend with rg/grep/findstr fallback"
+```
+
+---
+
+### Task 4: Wire FILE_GREP into IPC & Preload
+
+**Files:**
+- Modify: `src/main/ipc-handlers.ts:425` (add after FILE_SEARCH handler)
+- Modify: `src/preload/index.ts:204` (add after file.search in the file namespace)
+
+- [ ] **Step 1: Register the IPC handler**
+
+In `src/main/ipc-handlers.ts`, add the import at the top alongside the existing `searchFiles` import:
+
+```typescript
+import { grepFiles } from './file-grep';
+```
+
+Then add the handler after the `FILE_SEARCH` handler (after line 425):
+
+```typescript
+  ipcMain.handle(IPC_CHANNELS.FILE_GREP, async (_event, req: FileGrepRequest) =>
+    grepFiles(req)
+  );
+```
+
+Also add the `FileGrepRequest` import from `'../shared/ipc-api'` to the existing import statement.
+
+- [ ] **Step 2: Add to preload API**
+
+In `src/preload/index.ts`, add after `file.search` (after line 204):
+
+```typescript
+    grep: async (req: FileGrepRequest): Promise<FileGrepResponse> =>
+      typedInvoke(IPC_CHANNELS.FILE_GREP, req),
+```
+
+Also add `FileGrepRequest` and `FileGrepResponse` to the existing import from `'../shared/ipc-api'`.
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/ipc-handlers.ts src/preload/index.ts
+git commit -m "feat(telescope): wire FILE_GREP IPC handler and preload API"
+```
+
+---
+
+### Task 5: Keyboard Shortcut Definition
+
+**Files:**
+- Modify: `src/renderer/src/lib/shortcuts.ts:145` (add before closing bracket of ALL_SHORTCUTS)
+
+- [ ] **Step 1: Add the telescope shortcut**
+
+In `src/renderer/src/lib/shortcuts.ts`, add to the `ALL_SHORTCUTS` array before the closing `]` (after the inject-skills entry ending on line 145):
+
+```typescript
+  {
+    id: 'telescope',
+    label: 'Telescope finder',
+    mac: { key: 'T', meta: true, shift: true },
+    other: { key: 'T', ctrl: true, shift: true }
+  }
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/lib/shortcuts.ts
+git commit -m "feat(telescope): add Cmd+Shift+T keyboard shortcut definition"
+```
+
+---
+
+### Task 6: Files Mode
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/modes/files-mode.ts`
+
+- [ ] **Step 1: Create the files mode**
+
+```typescript
+// src/renderer/src/components/Telescope/modes/files-mode.ts
+import { File } from 'lucide-react';
+import { createElement } from 'react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { getFileIcon } from '../../../lib/file-icons';
+import { quotePathForShell, bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+type FileEntry = {
+  path: string;
+  relativePath: string;
+  name: string;
+};
+
+let cachedFiles: FileEntry[] = [];
+let cachedCwd: string | null = null;
+let loadingPromise: Promise<void> | null = null;
+
+function ensureFilesLoaded(cwd: string): void {
+  if (cachedCwd === cwd && cachedFiles.length > 0) return;
+  if (loadingPromise) return;
+  cachedCwd = cwd;
+  loadingPromise = window.fleet.file.list(cwd).then((result) => {
+    if (result.success) {
+      cachedFiles = result.files;
+    }
+    loadingPromise = null;
+  });
+}
+
+export function createFilesMode(cwd: string, activePaneId: string | null): TelescopeMode {
+  // Pre-load files on mode creation
+  ensureFilesLoaded(cwd);
+
+  return {
+    id: 'files',
+    label: 'Files',
+    icon: File,
+    placeholder: 'Search files by name...',
+
+    onSearch: (query: string): TelescopeItem[] => {
+      if (!query.trim()) {
+        // Show recent files
+        const recentFiles = useWorkspaceStore.getState().recentFiles;
+        return recentFiles.slice(0, 15).map((filePath) => {
+          const name = filePath.split('/').pop() ?? filePath;
+          const parentDir = filePath.split('/').slice(0, -1).join('/');
+          return {
+            id: filePath,
+            icon: getFileIcon(name, 14),
+            title: name,
+            subtitle: parentDir.replace(window.fleet.homeDir, '~'),
+            meta: 'recent',
+            data: { filePath }
+          };
+        });
+      }
+
+      return cachedFiles
+        .filter((f) => fuzzyMatch(query, f.relativePath) || fuzzyMatch(query, f.name))
+        .slice(0, 50)
+        .map((f) => ({
+          id: f.path,
+          icon: getFileIcon(f.name, 14),
+          title: f.name,
+          subtitle: f.relativePath.includes('/')
+            ? f.relativePath.split('/').slice(0, -1).join('/')
+            : undefined,
+          data: { filePath: f.path }
+        }));
+    },
+
+    renderPreview: (item: TelescopeItem) => {
+      // Preview rendering is handled by TelescopeModal via file.read()
+      // Return null — the modal fetches content based on item.data.filePath
+      return null;
+    },
+
+    onSelect: (item: TelescopeItem) => {
+      const filePath = item.data?.filePath as string;
+      if (filePath) {
+        useWorkspaceStore.getState().openFile(filePath);
+      }
+    },
+
+    onAltSelect: (item: TelescopeItem) => {
+      const filePath = item.data?.filePath as string;
+      if (filePath && activePaneId) {
+        const quoted = quotePathForShell(filePath, window.fleet.platform) + ' ';
+        window.fleet.pty.input({ paneId: activePaneId, data: bracketedPaste(quoted) });
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/modes/files-mode.ts
+git commit -m "feat(telescope): add Files mode — fuzzy file search in cwd"
+```
+
+---
+
+### Task 7: Grep Mode
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/modes/grep-mode.ts`
+
+- [ ] **Step 1: Create the grep mode**
+
+```typescript
+// src/renderer/src/components/Telescope/modes/grep-mode.ts
+import { TextSearch } from 'lucide-react';
+import { createElement } from 'react';
+import { quotePathForShell, bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+let requestCounter = 0;
+
+export function createGrepMode(cwd: string, activePaneId: string | null): TelescopeMode {
+  return {
+    id: 'grep',
+    label: 'Grep',
+    icon: TextSearch,
+    placeholder: 'Search file contents...',
+
+    onSearch: async (query: string): Promise<TelescopeItem[]> => {
+      if (!query.trim()) return [];
+
+      const requestId = ++requestCounter;
+      const res = await window.fleet.file.grep({
+        requestId,
+        query: query.trim(),
+        cwd,
+        limit: 50
+      });
+
+      // Discard stale responses
+      if (requestId !== requestCounter) return [];
+
+      if (!res.success) return [];
+
+      return res.results.map((r) => ({
+        id: `${r.file}:${r.line}`,
+        icon: createElement('span', { className: 'text-[10px] text-neutral-500 font-mono w-4 text-right' }, String(r.line)),
+        title: r.relativePath,
+        subtitle: r.text.trim(),
+        meta: `L${r.line}`,
+        data: {
+          filePath: r.file,
+          line: r.line,
+          contextBefore: r.contextBefore,
+          contextAfter: r.contextAfter
+        }
+      }));
+    },
+
+    renderPreview: (item: TelescopeItem) => {
+      // Preview rendering handled by TelescopeModal — fetches file content and scrolls to line
+      return null;
+    },
+
+    onSelect: (item: TelescopeItem) => {
+      const filePath = item.data?.filePath as string;
+      if (filePath) {
+        useWorkspaceStore.getState().openFile(filePath);
+      }
+    },
+
+    onAltSelect: (item: TelescopeItem) => {
+      const filePath = item.data?.filePath as string;
+      const line = item.data?.line as number;
+      if (filePath && activePaneId) {
+        const text = quotePathForShell(filePath, window.fleet.platform) + ':' + line + ' ';
+        window.fleet.pty.input({ paneId: activePaneId, data: bracketedPaste(text) });
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/modes/grep-mode.ts
+git commit -m "feat(telescope): add Grep mode — content search via FILE_GREP IPC"
+```
+
+---
+
+### Task 8: Browse Mode
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/modes/browse-mode.ts`
+
+- [ ] **Step 1: Create the browse mode**
+
+```typescript
+// src/renderer/src/components/Telescope/modes/browse-mode.ts
+import { FolderOpen, Folder, File } from 'lucide-react';
+import { createElement } from 'react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { getFileIcon } from '../../../lib/file-icons';
+import { quotePathForShell, bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+type DirEntry = {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+};
+
+type BrowseState = {
+  currentDir: string;
+  entries: DirEntry[];
+  loading: boolean;
+};
+
+export function createBrowseMode(
+  cwd: string,
+  activePaneId: string | null,
+  onStateChange: () => void
+): TelescopeMode & { getState: () => BrowseState } {
+  const state: BrowseState = {
+    currentDir: cwd,
+    entries: [],
+    loading: true
+  };
+
+  function loadDir(dir: string): void {
+    state.currentDir = dir;
+    state.loading = true;
+    state.entries = [];
+    onStateChange();
+
+    void window.fleet.file.readdir(dir).then((res) => {
+      if (res.success) {
+        state.entries = res.entries
+          .sort((a, b) => {
+            // Directories first, then alphabetical
+            if (a.isDirectory && !b.isDirectory) return -1;
+            if (!a.isDirectory && b.isDirectory) return 1;
+            return a.name.localeCompare(b.name);
+          });
+      }
+      state.loading = false;
+      onStateChange();
+    });
+  }
+
+  // Initial load
+  loadDir(cwd);
+
+  function getBreadcrumbs(): string[] {
+    const homeDir = window.fleet.homeDir;
+    const dir = state.currentDir;
+    if (dir.startsWith(homeDir)) {
+      const rel = dir.slice(homeDir.length);
+      const parts = rel.split('/').filter(Boolean);
+      return ['~', ...parts];
+    }
+    return dir.split('/').filter(Boolean);
+  }
+
+  function breadcrumbToPath(index: number): string {
+    const crumbs = getBreadcrumbs();
+    if (crumbs[0] === '~') {
+      if (index === 0) return window.fleet.homeDir;
+      const parts = crumbs.slice(1, index + 1);
+      return window.fleet.homeDir + '/' + parts.join('/');
+    }
+    const parts = crumbs.slice(0, index + 1);
+    return '/' + parts.join('/');
+  }
+
+  return {
+    id: 'browse',
+    label: 'Browse',
+    icon: FolderOpen,
+    placeholder: 'Filter current directory...',
+
+    get breadcrumbs(): string[] {
+      return getBreadcrumbs();
+    },
+
+    onNavigate: (dir: string) => {
+      loadDir(dir);
+    },
+
+    onNavigateUp: () => {
+      const parent = state.currentDir.split('/').slice(0, -1).join('/') || '/';
+      loadDir(parent);
+    },
+
+    onSearch: (query: string): TelescopeItem[] => {
+      const filtered = query.trim()
+        ? state.entries.filter((e) => fuzzyMatch(query, e.name))
+        : state.entries;
+
+      return filtered.map((entry) => ({
+        id: entry.path,
+        icon: entry.isDirectory
+          ? createElement(Folder, { size: 14, className: 'text-blue-400' })
+          : getFileIcon(entry.name, 14),
+        title: entry.name,
+        subtitle: entry.isDirectory ? 'Directory' : undefined,
+        data: { filePath: entry.path, isDirectory: entry.isDirectory }
+      }));
+    },
+
+    renderPreview: (item: TelescopeItem) => {
+      // TelescopeModal handles: file.read() for files, file.readdir() for directories
+      return null;
+    },
+
+    onSelect: (item: TelescopeItem) => {
+      if (item.data?.isDirectory) {
+        loadDir(item.data.filePath as string);
+      } else {
+        const filePath = item.data?.filePath as string;
+        if (filePath) {
+          useWorkspaceStore.getState().openFile(filePath);
+        }
+      }
+    },
+
+    onAltSelect: (item: TelescopeItem) => {
+      const filePath = item.data?.filePath as string;
+      if (filePath && activePaneId) {
+        const quoted = quotePathForShell(filePath, window.fleet.platform) + ' ';
+        window.fleet.pty.input({ paneId: activePaneId, data: bracketedPaste(quoted) });
+      }
+    },
+
+    getState: () => state
+  };
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/modes/browse-mode.ts
+git commit -m "feat(telescope): add Browse mode — directory navigation with breadcrumbs"
+```
+
+---
+
+### Task 9: Panes Mode
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/modes/panes-mode.ts`
+
+- [ ] **Step 1: Create the panes mode**
+
+```typescript
+// src/renderer/src/components/Telescope/modes/panes-mode.ts
+import { TerminalSquare } from 'lucide-react';
+import { createElement } from 'react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { useWorkspaceStore, collectPaneLeafs } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+export function createPanesMode(): TelescopeMode {
+  return {
+    id: 'panes',
+    label: 'Panes',
+    icon: TerminalSquare,
+    placeholder: 'Search open panes...',
+
+    onSearch: (query: string): TelescopeItem[] => {
+      const state = useWorkspaceStore.getState();
+      const activeTab = state.workspace.tabs.find((t) => t.id === state.activeTabId);
+      if (!activeTab) return [];
+
+      const leafs = collectPaneLeafs(activeTab.splitRoot);
+
+      const filtered = query.trim()
+        ? leafs.filter((leaf) => {
+            const label = leaf.label ?? leaf.paneType ?? 'terminal';
+            return fuzzyMatch(query, label) || fuzzyMatch(query, leaf.cwd);
+          })
+        : leafs;
+
+      return filtered.map((leaf) => {
+        const label = leaf.label ?? leaf.paneType ?? 'terminal';
+        const isActive = leaf.id === state.activePaneId;
+        return {
+          id: leaf.id,
+          icon: createElement(TerminalSquare, {
+            size: 14,
+            className: isActive ? 'text-green-400' : 'text-neutral-500'
+          }),
+          title: label,
+          subtitle: leaf.cwd.replace(window.fleet.homeDir, '~'),
+          meta: isActive ? 'active' : undefined,
+          data: { paneId: leaf.id, cwd: leaf.cwd, paneType: leaf.paneType ?? 'terminal' }
+        };
+      });
+    },
+
+    renderPreview: (item: TelescopeItem) => {
+      // TelescopeModal renders pane info (label, cwd, type)
+      return null;
+    },
+
+    onSelect: (item: TelescopeItem) => {
+      const paneId = item.data?.paneId as string;
+      if (paneId) {
+        useWorkspaceStore.getState().setActivePane(paneId);
+        document.dispatchEvent(
+          new CustomEvent('fleet:refocus-pane', { detail: { paneId } })
+        );
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/modes/panes-mode.ts
+git commit -m "feat(telescope): add Panes mode — switch between open terminal panes"
+```
+
+---
+
+### Task 10: TelescopeModal Shell Component
+
+**Files:**
+- Create: `src/renderer/src/components/Telescope/TelescopeModal.tsx`
+
+This is the main modal shell — layout, mode tabs, keyboard nav, preview panel. It delegates search/actions to the active mode.
+
+- [ ] **Step 1: Create the modal component**
+
+```typescript
+// src/renderer/src/components/Telescope/TelescopeModal.tsx
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { useWorkspaceStore } from '../../store/workspace-store';
+import { createFilesMode } from './modes/files-mode';
+import { createGrepMode } from './modes/grep-mode';
+import { createBrowseMode } from './modes/browse-mode';
+import { createPanesMode } from './modes/panes-mode';
+import type { TelescopeMode, TelescopeItem } from './types';
+
+type TelescopeModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  cwd: string;
+};
+
+const MODE_IDS = ['files', 'grep', 'browse', 'panes'] as const;
+
+export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): React.JSX.Element | null {
+  const [activeModeId, setActiveModeId] = useState<string>('files');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<TelescopeItem[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previewDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const activePaneId = useWorkspaceStore((s) => s.activePaneId);
+
+  // Force re-render when browse mode state changes
+  const [, forceUpdate] = useState(0);
+  const triggerUpdate = useCallback(() => forceUpdate((n) => n + 1), []);
+
+  // Create modes (memoized per cwd/paneId)
+  const modes = useMemo((): Record<string, TelescopeMode> => {
+    if (!isOpen) return {};
+    return {
+      files: createFilesMode(cwd, activePaneId),
+      grep: createGrepMode(cwd, activePaneId),
+      browse: createBrowseMode(cwd, activePaneId, triggerUpdate),
+      panes: createPanesMode()
+    };
+  }, [isOpen, cwd, activePaneId, triggerUpdate]);
+
+  const activeMode = modes[activeModeId];
+
+  // Reset state when opening
+  useEffect(() => {
+    if (isOpen) {
+      setActiveModeId('files');
+      setQuery('');
+      setResults([]);
+      setSelectedIndex(0);
+      setPreviewContent(null);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  // Run search when query or mode changes
+  useEffect(() => {
+    if (!isOpen || !activeMode) return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const delay = activeModeId === 'grep' ? 300 : 50;
+
+    debounceRef.current = setTimeout(() => {
+      const result = activeMode.onSearch(query);
+      if (result instanceof Promise) {
+        void result.then((items) => {
+          setResults(items);
+          setSelectedIndex(0);
+        });
+      } else {
+        setResults(result);
+        setSelectedIndex(0);
+      }
+    }, delay);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [isOpen, query, activeModeId, activeMode]);
+
+  // Load preview for selected item
+  useEffect(() => {
+    if (!isOpen || results.length === 0) {
+      setPreviewContent(null);
+      return;
+    }
+
+    const item = results[selectedIndex];
+    if (!item) return;
+
+    if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+
+    previewDebounceRef.current = setTimeout(() => {
+      const filePath = item.data?.filePath as string | undefined;
+      const isDirectory = item.data?.isDirectory as boolean | undefined;
+      const paneId = item.data?.paneId as string | undefined;
+
+      if (paneId) {
+        // Panes mode — show pane info
+        const paneType = item.data?.paneType as string;
+        const paneCwd = item.data?.cwd as string;
+        setPreviewContent(`Pane: ${item.title}\nType: ${paneType}\nCWD: ${paneCwd}`);
+        setPreviewLoading(false);
+      } else if (isDirectory && filePath) {
+        // Browse mode directory — show directory listing
+        setPreviewLoading(true);
+        void window.fleet.file.readdir(filePath).then((res) => {
+          if (res.success) {
+            const listing = res.entries
+              .sort((a, b) => {
+                if (a.isDirectory && !b.isDirectory) return -1;
+                if (!a.isDirectory && b.isDirectory) return 1;
+                return a.name.localeCompare(b.name);
+              })
+              .map((e) => (e.isDirectory ? `📁 ${e.name}/` : `   ${e.name}`))
+              .join('\n');
+            setPreviewContent(listing || '(empty directory)');
+          } else {
+            setPreviewContent('(unable to read directory)');
+          }
+          setPreviewLoading(false);
+        });
+      } else if (filePath) {
+        // File — show contents
+        setPreviewLoading(true);
+        void window.fleet.file.read(filePath).then((res) => {
+          if (res.success) {
+            // Show first 200 lines
+            const lines = res.data.content.split('\n').slice(0, 200);
+            const highlightLine = item.data?.line as number | undefined;
+            const numbered = lines.map((line, i) => {
+              const lineNum = String(i + 1).padStart(4, ' ');
+              const marker = highlightLine === i + 1 ? '>' : ' ';
+              return `${marker}${lineNum} │ ${line}`;
+            });
+            setPreviewContent(numbered.join('\n'));
+          } else {
+            setPreviewContent('(unable to read file)');
+          }
+          setPreviewLoading(false);
+        });
+      } else {
+        setPreviewContent(null);
+      }
+    }, 100);
+
+    return () => {
+      if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+    };
+  }, [isOpen, results, selectedIndex]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const child = listRef.current?.querySelector(`[data-result-index="${selectedIndex}"]`);
+    if (child instanceof HTMLElement) child.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  const handleSelect = useCallback(() => {
+    const item = results[selectedIndex];
+    if (item && activeMode) {
+      activeMode.onSelect(item);
+      // Don't close for browse mode directory navigation
+      if (activeModeId === 'browse' && item.data?.isDirectory) return;
+      onClose();
+    }
+  }, [results, selectedIndex, activeMode, activeModeId, onClose]);
+
+  const handleAltSelect = useCallback(() => {
+    const item = results[selectedIndex];
+    if (item && activeMode?.onAltSelect) {
+      activeMode.onAltSelect(item);
+      onClose();
+    }
+  }, [results, selectedIndex, activeMode, onClose]);
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
+    const isMod = e.metaKey || e.ctrlKey;
+
+    // Mode switching: Cmd/Ctrl + 1-4
+    if (isMod && e.key >= '1' && e.key <= '4') {
+      e.preventDefault();
+      const modeId = MODE_IDS[parseInt(e.key, 10) - 1];
+      if (modeId) {
+        setActiveModeId(modeId);
+        setQuery('');
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && e.shiftKey) {
+      e.preventDefault();
+      handleAltSelect();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSelect();
+    } else if (e.key === 'Backspace' && !query && activeModeId === 'browse' && activeMode?.onNavigateUp) {
+      e.preventDefault();
+      activeMode.onNavigateUp();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!isOpen || !activeMode) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="mt-[10vh] w-[800px] max-h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header: search input + mode tabs */}
+        <div className="px-3 py-2 border-b border-neutral-800 flex items-center gap-2">
+          <Search size={14} className="text-neutral-500 shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={activeMode.placeholder}
+            className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500"
+          />
+          {/* Mode tabs */}
+          <div className="flex items-center gap-0.5 ml-2">
+            {MODE_IDS.map((modeId, i) => {
+              const mode = modes[modeId];
+              if (!mode) return null;
+              const Icon = mode.icon;
+              const isActive = modeId === activeModeId;
+              return (
+                <Tooltip.Provider key={modeId} delayDuration={300}>
+                  <Tooltip.Root>
+                    <Tooltip.Trigger asChild>
+                      <button
+                        onClick={() => { setActiveModeId(modeId); setQuery(''); }}
+                        className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded transition-colors ${
+                          isActive
+                            ? 'bg-neutral-700 text-neutral-200'
+                            : 'text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800'
+                        }`}
+                      >
+                        <Icon size={12} />
+                        {mode.label}
+                      </button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Content
+                        side="bottom"
+                        sideOffset={6}
+                        className="px-2 py-1 text-xs text-white bg-neutral-800 border border-neutral-700 rounded shadow-lg z-50"
+                      >
+                        {window.fleet.platform === 'darwin' ? 'Cmd' : 'Ctrl'}+{i + 1}
+                        <Tooltip.Arrow className="fill-neutral-800" />
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                </Tooltip.Provider>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Breadcrumbs (Browse mode only) */}
+        {activeModeId === 'browse' && activeMode.breadcrumbs && (
+          <div className="px-3 py-1 border-b border-neutral-800 flex items-center gap-1 text-xs text-neutral-500 overflow-x-auto">
+            {activeMode.breadcrumbs.map((crumb, i) => (
+              <span key={i} className="flex items-center gap-1 shrink-0">
+                {i > 0 && <span className="text-neutral-700">/</span>}
+                <button
+                  onClick={() => {
+                    // Navigate to the breadcrumb path
+                    const crumbs = activeMode.breadcrumbs!;
+                    let path: string;
+                    if (crumbs[0] === '~') {
+                      if (i === 0) path = window.fleet.homeDir;
+                      else path = window.fleet.homeDir + '/' + crumbs.slice(1, i + 1).join('/');
+                    } else {
+                      path = '/' + crumbs.slice(0, i + 1).join('/');
+                    }
+                    activeMode.onNavigate?.(path);
+                  }}
+                  className="hover:text-neutral-300 transition-colors"
+                >
+                  {crumb}
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Body: results + preview */}
+        <div className="flex flex-1 min-h-0">
+          {/* Results column */}
+          <div ref={listRef} className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1">
+            {results.length === 0 ? (
+              <div className="px-3 py-8 text-sm text-neutral-500 text-center">
+                {query ? 'No results' : activeModeId === 'grep' ? 'Type to search file contents...' : 'No items'}
+              </div>
+            ) : (
+              results.map((item, i) => (
+                <button
+                  key={item.id}
+                  data-result-index={i}
+                  className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left transition-colors ${
+                    i === selectedIndex
+                      ? 'bg-neutral-700 text-white'
+                      : 'text-neutral-300 hover:bg-neutral-800'
+                  }`}
+                  onMouseEnter={() => setSelectedIndex(i)}
+                  onClick={() => {
+                    setSelectedIndex(i);
+                    handleSelect();
+                  }}
+                >
+                  <span className="shrink-0">{item.icon}</span>
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <span className="truncate font-medium text-[13px]">{item.title}</span>
+                    {item.subtitle && (
+                      <span className="truncate text-[11px] text-neutral-500">{item.subtitle}</span>
+                    )}
+                  </div>
+                  {item.meta && (
+                    <span className="text-[10px] text-neutral-600 shrink-0">{item.meta}</span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* Preview column */}
+          <div className="w-[60%] overflow-auto p-3">
+            {previewLoading ? (
+              <div className="text-sm text-neutral-500 text-center py-8">Loading preview...</div>
+            ) : previewContent ? (
+              <pre className="text-[12px] leading-5 text-neutral-400 font-mono whitespace-pre overflow-x-auto">
+                {previewContent}
+              </pre>
+            ) : (
+              <div className="text-sm text-neutral-600 text-center py-8">No preview available</div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
+          <span>↑↓ navigate</span>
+          <span>↵ {activeModeId === 'panes' ? 'focus' : 'open'}</span>
+          {activeModeId !== 'panes' && <span>⇧↵ paste path</span>}
+          {activeModeId === 'browse' && <span>⌫ up dir</span>}
+          <span>esc dismiss</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/Telescope/TelescopeModal.tsx
+git commit -m "feat(telescope): add TelescopeModal shell with two-column layout and mode switching"
+```
+
+---
+
+### Task 11: Wire into App.tsx
+
+**Files:**
+- Modify: `src/renderer/src/App.tsx`
+
+- [ ] **Step 1: Add import**
+
+Add at the top of `App.tsx` alongside the other overlay imports:
+
+```typescript
+import { TelescopeModal } from './components/Telescope/TelescopeModal';
+```
+
+- [ ] **Step 2: Add state**
+
+Add alongside the other overlay state declarations (near line 122):
+
+```typescript
+  const [telescopeOpen, setTelescopeOpen] = useState(false);
+```
+
+- [ ] **Step 3: Add event listener**
+
+Add alongside the other toggle event listeners (after the clipboard-history listener, ~line 219):
+
+```typescript
+  // Telescope modal toggle (Cmd+Shift+T)
+  useEffect(() => {
+    const handler = (): void => setTelescopeOpen((prev) => !prev);
+    document.addEventListener('fleet:toggle-telescope', handler);
+    return () => document.removeEventListener('fleet:toggle-telescope', handler);
+  }, []);
+```
+
+- [ ] **Step 4: Render the component**
+
+Add alongside the other overlay renders (after `ClipboardHistoryOverlay`):
+
+```typescript
+      <TelescopeModal
+        isOpen={telescopeOpen}
+        onClose={() => setTelescopeOpen(false)}
+        cwd={focusedPaneCwd}
+      />
+```
+
+- [ ] **Step 5: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/App.tsx
+git commit -m "feat(telescope): wire TelescopeModal into App.tsx with event listener"
+```
+
+---
+
+### Task 12: Add Toolbar Button & Event Dispatching
+
+**Files:**
+- Modify: `src/renderer/src/components/PaneToolbar.tsx`
+- Modify: `src/renderer/src/components/TerminalPane.tsx`
+
+- [ ] **Step 1: Add Telescope icon import and prop to PaneToolbar**
+
+In `src/renderer/src/components/PaneToolbar.tsx`:
+
+Add `Telescope` to the lucide-react import on line 1:
+
+```typescript
+import { Columns2, Rows2, Search, X, GitBranch, FileSearch, Clipboard, BookOpen, Crosshair, Telescope } from 'lucide-react';
+```
+
+Add `onTelescope` to the `PaneToolbarProps` type (after `onAnnotate` on line 40):
+
+```typescript
+  onTelescope?: () => void;
+```
+
+Add `onTelescope` to the destructured props (after `onAnnotate` on line 54):
+
+```typescript
+  onTelescope
+```
+
+- [ ] **Step 2: Add the Telescope button**
+
+In `PaneToolbar.tsx`, add the Telescope button after the `onAnnotate` block (after line 148) and before the Search in Pane button:
+
+```typescript
+        {onTelescope && (
+          <ToolbarTooltip label={`Telescope (${formatShortcut(getShortcut('telescope')!)})`}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onTelescope();
+              }}
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+            >
+              <Telescope size={14} />
+            </button>
+          </ToolbarTooltip>
+        )}
+```
+
+- [ ] **Step 3: Wire event in TerminalPane**
+
+In `src/renderer/src/components/TerminalPane.tsx`, add the `onTelescope` prop to the `PaneToolbar` render (around line 142, after `onAnnotate`):
+
+```typescript
+        onTelescope={() => document.dispatchEvent(new CustomEvent('fleet:toggle-telescope'))}
+```
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/PaneToolbar.tsx src/renderer/src/components/TerminalPane.tsx
+git commit -m "feat(telescope): add Telescope button to pane toolbar"
+```
+
+---
+
+### Task 13: Keyboard Shortcut Handler
+
+**Files:**
+- Modify: `src/renderer/src/App.tsx` (the global keydown handler)
+
+Check how existing shortcuts dispatch their events — likely a global keydown listener.
+
+- [ ] **Step 1: Find the global keydown handler**
+
+Look for where `matchesShortcut` is called in `App.tsx` or a related hook. The telescope shortcut needs to dispatch `fleet:toggle-telescope` when `Cmd+Shift+T` is pressed.
+
+Search for the existing shortcut dispatch pattern and add:
+
+```typescript
+    if (matchesShortcut(e, getShortcut('telescope')!)) {
+      e.preventDefault();
+      document.dispatchEvent(new CustomEvent('fleet:toggle-telescope'));
+    }
+```
+
+This should be added in the same keydown handler where other shortcuts like `quick-open`, `file-search`, and `clipboard-history` are handled.
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/App.tsx
+git commit -m "feat(telescope): add Cmd+Shift+T keyboard shortcut handler"
+```
+
+---
+
+### Task 14: Manual Testing & Polish
+
+**Files:**
+- No new files — testing and fixing issues found.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Test opening the telescope**
+
+1. Hover over a pane — verify the Telescope icon appears in the toolbar
+2. Click it — verify the modal opens centered with the two-column layout
+3. Press `Cmd+Shift+T` — verify the modal toggles
+4. Press `Escape` — verify it closes
+5. Click the backdrop — verify it closes
+
+- [ ] **Step 3: Test Files mode**
+
+1. Open telescope — should default to Files mode
+2. Empty query should show recent files
+3. Type a filename — verify fuzzy matching works
+4. Arrow keys should navigate, selected item should highlight
+5. Preview panel should show file contents for selected item
+6. Press Enter — should open file in a viewer tab
+7. Press Shift+Enter — should paste the path into the terminal
+
+- [ ] **Step 4: Test Grep mode**
+
+1. Press `Cmd+2` to switch to Grep mode
+2. Type a search term that exists in files in the cwd
+3. Results should show file:line with matching text
+4. Preview should show file contents scrolled to the matching line
+5. If `rg` is not installed, fallback to `grep` should work
+
+- [ ] **Step 5: Test Browse mode**
+
+1. Press `Cmd+3` to switch to Browse mode
+2. Should show directory listing of the pane's cwd
+3. Directories should be listed first
+4. Click a directory — should drill in, breadcrumbs should update
+5. Click a breadcrumb — should navigate back
+6. Press Backspace on empty query — should go up one directory
+7. Type to filter the current directory listing
+8. Enter on a file — should open in viewer
+9. Enter on a directory — should drill in
+
+- [ ] **Step 6: Test Panes mode**
+
+1. Split into multiple panes first
+2. Press `Cmd+4` to switch to Panes mode
+3. Should list all open panes with their labels and cwds
+4. Active pane should be marked
+5. Enter on a pane — should focus that pane and close the modal
+
+- [ ] **Step 7: Fix any issues found and commit**
+
+```bash
+git add -A
+git commit -m "fix(telescope): polish and fixes from manual testing"
+```
+
+- [ ] **Step 8: Final verification**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors.

--- a/docs/superpowers/specs/2026-04-11-telescope-picker-design.md
+++ b/docs/superpowers/specs/2026-04-11-telescope-picker-design.md
@@ -88,6 +88,10 @@ type TelescopeMode = {
   renderPreview: (item: TelescopeItem) => ReactNode;
   onSelect: (item: TelescopeItem) => void;
   onAltSelect?: (item: TelescopeItem) => void;
+  // Browse mode extensions (optional, only used by browse-mode)
+  breadcrumbs?: string[];            // current path segments for breadcrumb display
+  onNavigate?: (dir: string) => void; // drill into directory or jump to breadcrumb
+  onNavigateUp?: () => void;          // go up one directory (Backspace on empty query)
 };
 ```
 

--- a/docs/superpowers/specs/2026-04-11-telescope-picker-design.md
+++ b/docs/superpowers/specs/2026-04-11-telescope-picker-design.md
@@ -1,0 +1,205 @@
+# Telescope Picker Design
+
+A multi-mode fuzzy finder modal for Fleet, inspired by telescope.nvim and OS file explorers. Provides a unified interface for finding files, searching content, browsing directories, and switching panes.
+
+## Requirements
+
+- Four switchable modes: Files, Grep, Browse, Panes
+- Two-column layout: results list (left) + preview panel (right)
+- Context-dependent select action per mode
+- Coexists with existing overlays (QuickOpenOverlay, FileSearchOverlay) — does not replace them
+- New keyboard shortcut + pane toolbar button
+- Cross-platform (macOS, Linux, Windows)
+
+## Architecture: Modal Shell + Pluggable Modes
+
+A thin `TelescopeModal` shell owns the layout and delegates to mode modules via a shared interface. Each mode is a separate file implementing `TelescopeMode`.
+
+### File Structure
+
+```
+src/renderer/src/components/Telescope/
+  TelescopeModal.tsx          — modal shell: layout, mode tabs, keyboard nav, preview column
+  types.ts                    — TelescopeMode interface, TelescopeItem type
+  modes/
+    files-mode.ts             — fuzzy file search in cwd
+    grep-mode.ts              — content search via FILE_GREP IPC
+    browse-mode.ts            — directory navigation with breadcrumbs
+    panes-mode.ts             — open pane listing from workspace store
+
+src/main/file-grep.ts          — rg/grep/findstr backend
+```
+
+### Modified Files
+
+```
+src/shared/ipc-channels.ts     — add FILE_GREP channel constant
+src/shared/ipc-api.ts          — add FileGrepRequest/Response/Result types
+src/preload/index.ts            — add window.fleet.file.grep()
+src/main/ipc-handlers.ts       — register FILE_GREP handler
+src/renderer/src/App.tsx        — add telescope state, render TelescopeModal, wire event
+src/renderer/src/components/PaneToolbar.tsx — add Telescope button
+src/renderer/src/components/TerminalPane.tsx — pass onTelescope to PaneToolbar
+src/shared/shortcuts.ts         — add telescope shortcut definition
+```
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  search input                                mode tabs  │
+├──────────────────────────┬──────────────────────────────┤
+│                          │                              │
+│   Results list           │   Preview panel              │
+│   (keyboard navigable)   │   (file content / pane info) │
+│                          │                              │
+│   > item 1 (selected)    │   1  import React from ...   │
+│     item 2               │   2  import { useState }...  │
+│     item 3               │   3                          │
+│                          │                              │
+├──────────────────────────┴──────────────────────────────┤
+│  ↑↓ navigate  ↵ open  ⇧↵ paste path  esc dismiss       │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Width: ~800px (wider than existing 560px overlays for preview column)
+- Height: max 70vh, positioned at 10vh from top
+- Results column: ~40% width, scrollable
+- Preview column: ~60% width, scrollable, monospace font, line numbers
+- Backdrop: `bg-black/60` click-to-dismiss (same as existing overlays)
+
+## Mode Interface
+
+```typescript
+type TelescopeItem = {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  subtitle?: string;
+  meta?: string;
+};
+
+type TelescopeMode = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  placeholder: string;
+  onSearch: (query: string) => Promise<TelescopeItem[]> | TelescopeItem[];
+  renderPreview: (item: TelescopeItem) => ReactNode;
+  onSelect: (item: TelescopeItem) => void;
+  onAltSelect?: (item: TelescopeItem) => void;
+};
+```
+
+## Mode Behaviors
+
+### Files (`Cmd+1`)
+
+- Searches via `window.fleet.file.list(cwd)` + client-side fuzzy match
+- Empty query shows recent files from workspace store
+- Preview: file contents via `window.fleet.file.read()`
+- Enter: open file in viewer pane
+- Shift+Enter: paste path into terminal
+
+### Grep (`Cmd+2`)
+
+- New IPC channel `FILE_GREP` — runs `rg` / `grep -rn` / `findstr` in the pane's cwd
+- Debounced search (300ms)
+- Each result: filename, line number, matching line text
+- Preview: file contents scrolled to matching line with highlight
+- Enter: open file in viewer at that line
+- Shift+Enter: paste `file:line` into terminal
+
+### Browse (`Cmd+3`)
+
+- Uses `window.fleet.file.readdir()` for current directory
+- Query acts as filter on current directory listing (not fuzzy search across tree)
+- Directories listed first, then files
+- Breadcrumb trail for navigation; clicking a segment jumps back up
+- Backspace on empty query navigates up one directory
+- Preview: file contents for files, directory listing for folders
+- Enter on file: open in viewer. Enter on directory: drill in.
+- Shift+Enter: paste path
+
+### Panes (`Cmd+4`)
+
+- Reads PaneLeaf nodes from workspace store layout tree
+- Shows: pane label (or shell name), cwd, pane type
+- Fuzzy search on label + cwd
+- Preview: pane info (label, shell, cwd, type)
+- Enter: focus that pane (setActivePane + fleet:refocus-pane)
+
+## IPC: FILE_GREP Channel
+
+```typescript
+// Request
+type FileGrepRequest = {
+  requestId: number;
+  query: string;
+  cwd: string;
+  limit?: number;        // default 50
+};
+
+// Response
+type FileGrepResponse = {
+  success: boolean;
+  requestId: number;
+  results: FileGrepResult[];
+  error?: string;
+};
+
+type FileGrepResult = {
+  file: string;          // absolute path
+  relativePath: string;  // relative to cwd
+  line: number;          // 1-based line number
+  text: string;          // the matching line content
+  contextBefore?: string[];
+  contextAfter?: string[];
+};
+```
+
+### Cross-Platform Strategy
+
+| Platform | Primary | Fallback |
+|----------|---------|----------|
+| All      | `rg` (ripgrep) | `grep -rn` (macOS/Linux) or `findstr` (Windows) |
+
+Implementation follows the same pattern as `src/main/file-search.ts`: try primary tool, catch ENOENT, spawn fallback. Results normalized to the same shape regardless of tool.
+
+## Keyboard Shortcuts
+
+### Opening
+
+- `Cmd+Shift+T` (macOS) / `Ctrl+Shift+T` (Windows/Linux)
+- Pane toolbar button (Telescope icon from lucide-react)
+
+### Inside the Modal
+
+| Key | Action |
+|-----|--------|
+| `Cmd+1` / `Ctrl+1` | Files mode |
+| `Cmd+2` / `Ctrl+2` | Grep mode |
+| `Cmd+3` / `Ctrl+3` | Browse mode |
+| `Cmd+4` / `Ctrl+4` | Panes mode |
+| `↑` / `↓` | Move selection |
+| `Enter` | Primary action (context-dependent) |
+| `Shift+Enter` | Paste path into terminal |
+| `Escape` | Close modal |
+| `Backspace` (empty query, Browse) | Navigate up one directory |
+
+### Event Wiring
+
+Custom event `fleet:toggle-telescope` dispatched from shortcut handler, caught in App.tsx. Toolbar button's onTelescope callback dispatches the same event.
+
+## Data Flow
+
+1. User presses `Cmd+Shift+T` or clicks toolbar button
+2. `fleet:toggle-telescope` event fires, App.tsx sets `telescopeOpen: true`, passes `focusedPaneCwd`
+3. TelescopeModal renders, defaults to Files mode
+4. User types — modal delegates to active mode's `onSearch(query)`
+5. Mode returns results — modal renders in left column
+6. Arrow keys change selection — modal calls `renderPreview(selectedItem)` for right column
+7. Enter — modal calls `onSelect(item)`, mode performs action
+8. Modal closes, dispatches `fleet:refocus-pane`
+
+Preview content fetched on selection change with ~100ms debounce. Loading indicator shown if read takes >200ms.

--- a/src/main/file-grep.ts
+++ b/src/main/file-grep.ts
@@ -1,0 +1,269 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { relative } from 'path';
+import type { FileGrepRequest, FileGrepResponse, FileGrepResult } from '../shared/ipc-api';
+
+let activeProcess: ChildProcess | null = null;
+
+function killActive(): void {
+  if (activeProcess && !activeProcess.killed) {
+    activeProcess.kill('SIGTERM');
+  }
+  activeProcess = null;
+}
+
+function buildRgCommand(
+  query: string,
+  cwd: string,
+  limit: number
+): { cmd: string; args: string[] } {
+  return {
+    cmd: 'rg',
+    args: [
+      '--no-heading',
+      '--line-number',
+      '--color',
+      'never',
+      '--max-count',
+      String(limit),
+      '-B',
+      '1',
+      '-A',
+      '1',
+      '--',
+      query,
+      cwd
+    ]
+  };
+}
+
+function buildFallbackCommand(
+  query: string,
+  cwd: string,
+  limit: number
+): { cmd: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return {
+      cmd: 'findstr',
+      args: ['/s', '/n', '/i', `/c:${query}`, `${cwd}\\*`]
+    };
+  }
+  return {
+    cmd: 'grep',
+    args: ['-rn', `-m`, String(limit), `--include=*`, '--', query, cwd]
+  };
+}
+
+/**
+ * Parse ripgrep output (--no-heading --line-number -B 1 -A 1).
+ *
+ * Match lines:  file:line:text
+ * Context lines: file-line-text
+ * Block separators: --
+ */
+function parseRgOutput(stdout: string, cwd: string, limit: number): FileGrepResult[] {
+  const results: FileGrepResult[] = [];
+  const lines = stdout.split('\n');
+
+  // Group lines into blocks separated by '--'
+  // Each block corresponds to one match with its context
+  interface Block {
+    file: string;
+    matchLine: number;
+    matchText: string;
+    before: string[];
+    after: string[];
+  }
+
+  const blocks: Block[] = [];
+  let currentBlock: Block | null = null;
+  let seenMatchInBlock = false;
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+
+    if (line === '--') {
+      // Block separator
+      if (currentBlock) {
+        blocks.push(currentBlock);
+      }
+      currentBlock = null;
+      seenMatchInBlock = false;
+      continue;
+    }
+
+    // Try match line: file:line:text (colons are separators, file may contain colons on Windows)
+    // rg uses ':' for matches and '-' for context lines after the last path separator
+    // Format: <file>:<linenum>:<text>  (match)
+    //         <file>-<linenum>-<text>  (context)
+    // We try match first
+    const matchRe = /^(.+):(\d+):(.*)$/;
+    const contextRe = /^(.+)-(\d+)-(.*)$/;
+
+    const matchResult = matchRe.exec(line);
+    if (matchResult) {
+      const [, file, lineNumStr, text] = matchResult;
+      const lineNum = parseInt(lineNumStr, 10);
+
+      if (!seenMatchInBlock) {
+        // This is a new match — start a new block
+        if (currentBlock) {
+          blocks.push(currentBlock);
+        }
+        currentBlock = {
+          file,
+          matchLine: lineNum,
+          matchText: text,
+          before: [],
+          after: []
+        };
+        seenMatchInBlock = true;
+      }
+      // If seenMatchInBlock is true, this could be a subsequent match within the
+      // same context window — treat it as a new block
+      continue;
+    }
+
+    const contextResult = contextRe.exec(line);
+    if (contextResult) {
+      const [, , lineNumStr, text] = contextResult;
+      const lineNum = parseInt(lineNumStr, 10);
+
+      if (currentBlock) {
+        if (lineNum < currentBlock.matchLine) {
+          currentBlock.before.push(text);
+        } else {
+          currentBlock.after.push(text);
+        }
+      }
+      continue;
+    }
+  }
+
+  // Don't forget last block
+  if (currentBlock) {
+    blocks.push(currentBlock);
+  }
+
+  for (const block of blocks) {
+    if (results.length >= limit) break;
+    results.push({
+      file: block.file,
+      relativePath: relative(cwd, block.file),
+      line: block.matchLine,
+      text: block.matchText,
+      contextBefore: block.before.length > 0 ? block.before : undefined,
+      contextAfter: block.after.length > 0 ? block.after : undefined
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Parse fallback grep/findstr output.
+ * Format: file:line:text (no context lines)
+ */
+function parseFallbackOutput(stdout: string, cwd: string, limit: number): FileGrepResult[] {
+  const results: FileGrepResult[] = [];
+  const lines = stdout.split('\n');
+
+  for (const raw of lines) {
+    if (results.length >= limit) break;
+    const line = raw.trimEnd();
+    if (!line) continue;
+
+    const match = /^(.+):(\d+):(.*)$/.exec(line);
+    if (!match) continue;
+
+    const [, file, lineNumStr, text] = match;
+    results.push({
+      file,
+      relativePath: relative(cwd, file),
+      line: parseInt(lineNumStr, 10),
+      text
+    });
+  }
+
+  return results;
+}
+
+export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse> {
+  killActive();
+
+  const { requestId, query, cwd } = req;
+  const limit = req.limit ?? 50;
+
+  if (!query.trim()) {
+    return { success: true, requestId, results: [] };
+  }
+
+  const { cmd, args } = buildRgCommand(query, cwd, limit);
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let timedOut = false;
+
+    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    activeProcess = proc;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill('SIGTERM');
+    }, 10000);
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      activeProcess = null;
+
+      const errCode = (err as NodeJS.ErrnoException).code;
+      if (errCode === 'ENOENT') {
+        // rg not found — fall back to grep/findstr
+        const { cmd: fbCmd, args: fbArgs } = buildFallbackCommand(query, cwd, limit);
+        const fbProc = spawn(fbCmd, fbArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+        activeProcess = fbProc;
+        let fbStdout = '';
+
+        const fbTimer = setTimeout(() => {
+          fbProc.kill('SIGTERM');
+        }, 10000);
+
+        fbProc.stdout.on('data', (chunk: Buffer) => {
+          fbStdout += chunk.toString();
+        });
+
+        fbProc.on('close', () => {
+          clearTimeout(fbTimer);
+          activeProcess = null;
+          const results = parseFallbackOutput(fbStdout, cwd, limit);
+          resolve({ success: true, requestId, results });
+        });
+
+        fbProc.on('error', (fbErr) => {
+          clearTimeout(fbTimer);
+          activeProcess = null;
+          resolve({ success: false, requestId, error: `Grep failed: ${fbErr.message}` });
+        });
+        return;
+      }
+
+      resolve({ success: false, requestId, error: `Grep failed: ${err.message}` });
+    });
+
+    proc.on('close', () => {
+      clearTimeout(timer);
+      activeProcess = null;
+
+      if (timedOut && !stdout.trim()) {
+        resolve({ success: false, requestId, error: 'Grep timed out' });
+        return;
+      }
+
+      const results = parseRgOutput(stdout, cwd, limit);
+      resolve({ success: true, requestId, results });
+    });
+  });
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,6 +22,7 @@ import type {
   PaneFocusedPayload,
   DirEntry,
   FileSearchRequest,
+  FileGrepRequest,
   LogEntry,
   WorktreeCreateRequest,
   WorktreeRemoveRequest
@@ -45,6 +46,7 @@ import type { FleetBridgeServer } from './fleet-bridge';
 import type { FleetSettings } from '../shared/types';
 import { checkSystemDeps } from './system-checker';
 import { searchFiles } from './file-search';
+import { grepFiles } from './file-grep';
 import { searchRecentImages } from './recent-images';
 import { startClipboardMonitor, getClipboardHistory } from './clipboard-monitor';
 import { onCopilotSettingsChanged } from './copilot/index';
@@ -422,6 +424,10 @@ export function registerIpcHandlers(
 
   ipcMain.handle(IPC_CHANNELS.FILE_SEARCH, async (_event, req: FileSearchRequest) =>
     searchFiles(req)
+  );
+
+  ipcMain.handle(IPC_CHANNELS.FILE_GREP, async (_event, req: FileGrepRequest) =>
+    grepFiles(req)
   );
 
   ipcMain.handle(IPC_CHANNELS.FILE_RECENT_IMAGES, async () => searchRecentImages());

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,8 @@ import type {
   ReaddirResponse,
   FileSearchRequest,
   FileSearchResponse,
+  FileGrepRequest,
+  FileGrepResponse,
   RecentImagesResponse,
   ClipboardHistoryResponse,
   LogEntry,
@@ -202,6 +204,8 @@ const fleetApi = {
     }> => typedInvoke(IPC_CHANNELS.FILE_STAT, filePath),
     search: async (req: FileSearchRequest): Promise<FileSearchResponse> =>
       typedInvoke(IPC_CHANNELS.FILE_SEARCH, req),
+    grep: async (req: FileGrepRequest): Promise<FileGrepResponse> =>
+      typedInvoke(IPC_CHANNELS.FILE_GREP, req),
     searchRecentImages: async (): Promise<RecentImagesResponse> =>
       typedInvoke(IPC_CHANNELS.FILE_RECENT_IMAGES)
   },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -23,6 +23,7 @@ import { GitChangesModal } from './components/GitChangesModal';
 import { QuickOpenOverlay } from './components/QuickOpenOverlay';
 import { FileSearchOverlay } from './components/FileSearchOverlay';
 import { ClipboardHistoryOverlay } from './components/ClipboardHistoryOverlay';
+import { TelescopeModal } from './components/Telescope/TelescopeModal';
 import { ImageGallery } from './components/ImageGallery/ImageGallery';
 import { AnnotateTab } from './components/AnnotateTab';
 import { PiTab } from './components/PiTab';
@@ -121,6 +122,7 @@ export function App(): React.JSX.Element {
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
   const [clipboardHistoryOpen, setClipboardHistoryOpen] = useState(false);
+  const [telescopeOpen, setTelescopeOpen] = useState(false);
   const [updateReady, setUpdateReady] = useState(false);
 
   // Load settings on startup
@@ -216,6 +218,13 @@ export function App(): React.JSX.Element {
     const handler = (): void => setClipboardHistoryOpen((prev) => !prev);
     document.addEventListener('fleet:toggle-clipboard-history', handler);
     return () => document.removeEventListener('fleet:toggle-clipboard-history', handler);
+  }, []);
+
+  // Telescope modal toggle (Cmd+Shift+T)
+  useEffect(() => {
+    const handler = (): void => setTelescopeOpen((prev) => !prev);
+    document.addEventListener('fleet:toggle-telescope', handler);
+    return () => document.removeEventListener('fleet:toggle-telescope', handler);
   }, []);
 
   // Open file dialog (Cmd+O)
@@ -840,6 +849,11 @@ export function App(): React.JSX.Element {
       <ClipboardHistoryOverlay
         isOpen={clipboardHistoryOpen}
         onClose={() => setClipboardHistoryOpen(false)}
+      />
+      <TelescopeModal
+        isOpen={telescopeOpen}
+        onClose={() => setTelescopeOpen(false)}
+        cwd={focusedPaneCwd ?? window.fleet.homeDir}
       />
       <AnnotateModal open={false} onClose={() => {}} />
       <ToastContainer />

--- a/src/renderer/src/components/PaneToolbar.tsx
+++ b/src/renderer/src/components/PaneToolbar.tsx
@@ -1,6 +1,22 @@
-import { Columns2, Rows2, Search, X, GitBranch, FileSearch, Clipboard, BookOpen, Crosshair, Telescope } from 'lucide-react';
+import {
+  Columns2,
+  Rows2,
+  Search,
+  X,
+  GitBranch,
+  FileSearch,
+  Clipboard,
+  BookOpen,
+  Crosshair,
+  Telescope
+} from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
+
+function shortcutLabel(id: string): string {
+  const def = getShortcut(id);
+  return def ? formatShortcut(def) : id;
+}
 
 function ToolbarTooltip({
   label,
@@ -61,7 +77,7 @@ export function PaneToolbar({
         className={`absolute top-2 right-2 z-20 transition-opacity flex items-center gap-0.5 bg-neutral-800/80 backdrop-blur-sm rounded-md border border-neutral-700/50 p-0.5 ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
         style={{ WebkitAppRegion: 'no-drag' }}
       >
-        <ToolbarTooltip label={`Split Right (${formatShortcut(getShortcut('split-right')!)})`}>
+        <ToolbarTooltip label={`Split Right (${shortcutLabel('split-right')})`}>
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -72,7 +88,7 @@ export function PaneToolbar({
             <Columns2 size={14} />
           </button>
         </ToolbarTooltip>
-        <ToolbarTooltip label={`Split Down (${formatShortcut(getShortcut('split-down')!)})`}>
+        <ToolbarTooltip label={`Split Down (${shortcutLabel('split-down')})`}>
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -84,7 +100,7 @@ export function PaneToolbar({
           </button>
         </ToolbarTooltip>
         {isGitRepo && (
-          <ToolbarTooltip label={`Git Changes (${formatShortcut(getShortcut('git-changes')!)})`}>
+          <ToolbarTooltip label={`Git Changes (${shortcutLabel('git-changes')})`}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -97,7 +113,7 @@ export function PaneToolbar({
           </ToolbarTooltip>
         )}
         {onFileSearch && (
-          <ToolbarTooltip label={`Search Files (${formatShortcut(getShortcut('file-search')!)})`}>
+          <ToolbarTooltip label={`Search Files (${shortcutLabel('file-search')})`}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -110,7 +126,7 @@ export function PaneToolbar({
           </ToolbarTooltip>
         )}
         {onClipboardHistory && (
-          <ToolbarTooltip label={`Clipboard History (${formatShortcut(getShortcut('clipboard-history')!)})`}>
+          <ToolbarTooltip label={`Clipboard History (${shortcutLabel('clipboard-history')})`}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -123,7 +139,7 @@ export function PaneToolbar({
           </ToolbarTooltip>
         )}
         {onInjectSkills && (
-          <ToolbarTooltip label={`Inject Fleet Skills (${formatShortcut(getShortcut('inject-skills')!)})`}>
+          <ToolbarTooltip label={`Inject Fleet Skills (${shortcutLabel('inject-skills')})`}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -149,7 +165,7 @@ export function PaneToolbar({
           </ToolbarTooltip>
         )}
         {onTelescope && (
-          <ToolbarTooltip label={`Telescope (${formatShortcut(getShortcut('telescope')!)})`}>
+          <ToolbarTooltip label={`Telescope (${shortcutLabel('telescope')})`}>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -161,7 +177,7 @@ export function PaneToolbar({
             </button>
           </ToolbarTooltip>
         )}
-        <ToolbarTooltip label={`Search in Pane (${formatShortcut(getShortcut('search')!)})`}>
+        <ToolbarTooltip label={`Search in Pane (${shortcutLabel('search')})`}>
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -172,7 +188,7 @@ export function PaneToolbar({
             <Search size={14} />
           </button>
         </ToolbarTooltip>
-        <ToolbarTooltip label={`Close Pane (${formatShortcut(getShortcut('close-pane')!)})`}>
+        <ToolbarTooltip label={`Close Pane (${shortcutLabel('close-pane')})`}>
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/src/renderer/src/components/PaneToolbar.tsx
+++ b/src/renderer/src/components/PaneToolbar.tsx
@@ -1,4 +1,4 @@
-import { Columns2, Rows2, Search, X, GitBranch, FileSearch, Clipboard, BookOpen, Crosshair } from 'lucide-react';
+import { Columns2, Rows2, Search, X, GitBranch, FileSearch, Clipboard, BookOpen, Crosshair, Telescope } from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
 
@@ -38,6 +38,7 @@ type PaneToolbarProps = {
   onClipboardHistory?: () => void;
   onInjectSkills?: () => void;
   onAnnotate?: () => void;
+  onTelescope?: () => void;
 };
 
 export function PaneToolbar({
@@ -51,7 +52,8 @@ export function PaneToolbar({
   onFileSearch,
   onClipboardHistory,
   onInjectSkills,
-  onAnnotate
+  onAnnotate,
+  onTelescope
 }: PaneToolbarProps): React.JSX.Element {
   return (
     <Tooltip.Provider delayDuration={300}>
@@ -143,6 +145,19 @@ export function PaneToolbar({
               className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
             >
               <Crosshair size={14} />
+            </button>
+          </ToolbarTooltip>
+        )}
+        {onTelescope && (
+          <ToolbarTooltip label={`Telescope (${formatShortcut(getShortcut('telescope')!)})`}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onTelescope();
+              }}
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+            >
+              <Telescope size={14} />
             </button>
           </ToolbarTooltip>
         )}

--- a/src/renderer/src/components/Telescope/TelescopeModal.tsx
+++ b/src/renderer/src/components/Telescope/TelescopeModal.tsx
@@ -1,0 +1,432 @@
+// src/renderer/src/components/Telescope/TelescopeModal.tsx
+import { useState, useEffect, useRef, useCallback, useMemo, useReducer } from 'react';
+import { Search } from 'lucide-react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { useWorkspaceStore } from '../../store/workspace-store';
+import { createFilesMode } from './modes/files-mode';
+import { createGrepMode } from './modes/grep-mode';
+import { createBrowseMode } from './modes/browse-mode';
+import { createPanesMode } from './modes/panes-mode';
+import type { TelescopeMode, TelescopeItem } from './types';
+
+type TelescopeModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  cwd: string;
+};
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
+const modKey = isMac ? '⌘' : 'Ctrl+';
+
+export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): React.JSX.Element | null {
+  const [activeModeId, setActiveModeId] = useState<string>('files');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<TelescopeItem[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previewDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const activePaneId = useWorkspaceStore((s) => s.activePaneId);
+
+  const triggerUpdate = useCallback(() => forceUpdate(), []);
+
+  const modes = useMemo(() => {
+    if (!isOpen) return {} as Record<string, TelescopeMode>;
+    return {
+      files: createFilesMode(cwd, activePaneId),
+      grep: createGrepMode(cwd, activePaneId),
+      browse: createBrowseMode(cwd, activePaneId, triggerUpdate),
+      panes: createPanesMode()
+    };
+  }, [isOpen, cwd, activePaneId, triggerUpdate]);
+
+  const modeList = useMemo<TelescopeMode[]>(
+    () => [modes.files, modes.grep, modes.browse, modes.panes].filter(Boolean),
+    [modes]
+  );
+
+  const activeMode = modes[activeModeId] as TelescopeMode | undefined;
+
+  // Reset on open
+  useEffect(() => {
+    if (isOpen) {
+      setActiveModeId('files');
+      setQuery('');
+      setResults([]);
+      setSelectedIndex(0);
+      setPreviewContent(null);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  // Search effect
+  useEffect(() => {
+    if (!isOpen || !activeMode) return;
+
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+
+    const delay = activeModeId === 'grep' ? 300 : 50;
+
+    searchDebounceRef.current = setTimeout(() => {
+      const result = activeMode.onSearch(query);
+      if (result instanceof Promise) {
+        result.then((items) => {
+          setResults(items);
+          setSelectedIndex(0);
+        });
+      } else {
+        setResults(result);
+        setSelectedIndex(0);
+      }
+    }, delay);
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, [isOpen, query, activeModeId, activeMode]);
+
+  // Preview effect
+  useEffect(() => {
+    if (!isOpen || results.length === 0) {
+      setPreviewContent(null);
+      return;
+    }
+
+    if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+
+    previewDebounceRef.current = setTimeout(() => {
+      const item = results[selectedIndex];
+      if (!item) {
+        setPreviewContent(null);
+        return;
+      }
+
+      const data = item.data;
+
+      if (data?.paneId) {
+        const paneInfo = [
+          `Pane: ${item.title}`,
+          `Type: ${String(data.paneType ?? 'terminal')}`,
+          `CWD: ${String(data.cwd ?? '')}`,
+          data.cwd ? `\nDirectory: ${String(data.cwd)}` : ''
+        ]
+          .filter(Boolean)
+          .join('\n');
+        setPreviewContent(paneInfo);
+        return;
+      }
+
+      if (data?.isDirectory && data?.filePath) {
+        setPreviewLoading(true);
+        window.fleet.file
+          .readdir(String(data.filePath))
+          .then((result) => {
+            if (result.success) {
+              const listing = result.entries
+                .sort((a, b) => {
+                  if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+                  return a.name.localeCompare(b.name);
+                })
+                .map((e) => (e.isDirectory ? `${e.name}/` : e.name))
+                .join('\n');
+              setPreviewContent(listing || '(empty directory)');
+            } else {
+              setPreviewContent('Could not read directory');
+            }
+          })
+          .finally(() => setPreviewLoading(false));
+        return;
+      }
+
+      if (data?.filePath) {
+        setPreviewLoading(true);
+        window.fleet.file
+          .read(String(data.filePath))
+          .then((result) => {
+            if (result.success && result.data.content != null) {
+              const lines = result.data.content.split('\n').slice(0, 200);
+              const targetLine = data.line != null ? Number(data.line) : null;
+              const numbered = lines.map((line, i) => {
+                const lineNum = i + 1;
+                const prefix = targetLine === lineNum ? `> ${String(lineNum).padStart(4)} ` : `  ${String(lineNum).padStart(4)} `;
+                return `${prefix}${line}`;
+              });
+              setPreviewContent(numbered.join('\n'));
+            } else {
+              setPreviewContent('Could not read file');
+            }
+          })
+          .finally(() => setPreviewLoading(false));
+        return;
+      }
+
+      setPreviewContent('No preview available');
+    }, 100);
+
+    return () => {
+      if (previewDebounceRef.current) clearTimeout(previewDebounceRef.current);
+    };
+  }, [isOpen, results, selectedIndex]);
+
+  // Scroll selected into view
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-result-index="${selectedIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): void => {
+      const cmdOrCtrl = e.metaKey || e.ctrlKey;
+
+      // Cmd/Ctrl + 1-4: switch mode
+      if (cmdOrCtrl && ['1', '2', '3', '4'].includes(e.key)) {
+        e.preventDefault();
+        const idx = parseInt(e.key, 10) - 1;
+        const target = modeList[idx];
+        if (target) {
+          setActiveModeId(target.id);
+          setQuery('');
+        }
+        return;
+      }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        const item = results[selectedIndex];
+        if (item && activeMode?.onAltSelect) activeMode.onAltSelect(item);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const item = results[selectedIndex];
+        if (!item || !activeMode) return;
+        const isDirectory = item.data?.isDirectory as boolean | undefined;
+        if (activeModeId === 'browse' && isDirectory) {
+          // navigate into directory — don't close
+          activeMode.onSelect(item);
+        } else {
+          activeMode.onSelect(item);
+          onClose();
+        }
+      } else if (e.key === 'Backspace' && query === '' && activeModeId === 'browse') {
+        e.preventDefault();
+        activeMode?.onNavigateUp?.();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [results, selectedIndex, activeMode, activeModeId, query, modeList, onClose]
+  );
+
+  if (!isOpen) return null;
+
+  const browseBreadcrumbs = activeModeId === 'browse' && activeMode?.breadcrumbs;
+
+  const renderBreadcrumbs = (): React.JSX.Element | null => {
+    if (!browseBreadcrumbs || browseBreadcrumbs.length === 0) return null;
+
+    // Reconstruct full paths for each crumb
+    const homeDir = window.fleet.homeDir;
+
+    return (
+      <div className="px-3 py-1.5 border-b border-neutral-800 flex items-center gap-1 text-xs text-neutral-400 overflow-x-auto min-w-0">
+        {browseBreadcrumbs.map((segment, i) => {
+          const isLast = i === browseBreadcrumbs.length - 1;
+          // Build the absolute path for this crumb
+          const pathUpToSegment = browseBreadcrumbs
+            .slice(0, i + 1)
+            .join('/')
+            .replace(/^~/, homeDir);
+
+          return (
+            <span key={i} className="flex items-center gap-1 shrink-0">
+              {i > 0 && <span className="text-neutral-600">/</span>}
+              <button
+                onClick={() => {
+                  if (!isLast) {
+                    activeMode?.onNavigate?.(pathUpToSegment);
+                  }
+                }}
+                className={
+                  isLast
+                    ? 'text-neutral-200 cursor-default'
+                    : 'text-neutral-400 hover:text-neutral-200 transition-colors'
+                }
+              >
+                {segment}
+              </button>
+            </span>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderPreviewPanel = (): React.JSX.Element => {
+    if (previewLoading) {
+      return <div className="text-xs text-neutral-500 p-3">Loading preview...</div>;
+    }
+
+    if (!previewContent) {
+      return <div className="text-xs text-neutral-600 p-3 italic">Select an item to preview</div>;
+    }
+
+    return (
+      <pre className="text-[11px] text-neutral-300 font-mono leading-relaxed whitespace-pre-wrap break-all">
+        {previewContent}
+      </pre>
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="mt-[10vh] w-[800px] max-h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header: search input + mode tabs */}
+        <div className="flex items-center border-b border-neutral-700">
+          {/* Search input */}
+          <div className="flex items-center gap-2 px-3 py-2 flex-1 min-w-0">
+            <Search size={14} className="text-neutral-500 shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={activeMode?.placeholder ?? 'Search...'}
+              className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500 min-w-0"
+            />
+          </div>
+
+          {/* Mode tabs */}
+          <div className="flex items-center gap-0.5 px-2 py-1.5 border-l border-neutral-700 shrink-0">
+            <Tooltip.Provider delayDuration={500}>
+              {modeList.map((mode, i) => {
+                const Icon = mode.icon;
+                const shortcut = `${modKey}${i + 1}`;
+                const isActive = mode.id === activeModeId;
+                return (
+                  <Tooltip.Root key={mode.id}>
+                    <Tooltip.Trigger asChild>
+                      <button
+                        onClick={() => {
+                          setActiveModeId(mode.id);
+                          setQuery('');
+                          inputRef.current?.focus();
+                        }}
+                        className={`flex items-center gap-1.5 px-2 py-1 text-[11px] rounded transition-colors ${
+                          isActive
+                            ? 'bg-neutral-700 text-neutral-200'
+                            : 'text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800'
+                        }`}
+                      >
+                        <Icon size={12} />
+                        {mode.label}
+                      </button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Content
+                        side="bottom"
+                        className="z-50 rounded bg-neutral-800 border border-neutral-700 px-2 py-1 text-[11px] text-neutral-300 shadow-md"
+                        sideOffset={4}
+                      >
+                        {shortcut}
+                        <Tooltip.Arrow className="fill-neutral-800" />
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                );
+              })}
+            </Tooltip.Provider>
+          </div>
+        </div>
+
+        {/* Breadcrumbs (browse mode only) */}
+        {renderBreadcrumbs()}
+
+        {/* Body */}
+        <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+          {/* Results column */}
+          <div
+            ref={listRef}
+            className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1"
+          >
+            {results.length === 0 ? (
+              <div className="px-3 py-4 text-xs text-neutral-600 text-center italic">
+                {query ? 'No results' : 'Type to search'}
+              </div>
+            ) : (
+              results.map((item, i) => {
+                const isSelected = i === selectedIndex;
+                return (
+                  <button
+                    key={item.id}
+                    data-result-index={i}
+                    className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
+                      isSelected
+                        ? 'bg-neutral-700 text-white'
+                        : 'text-neutral-300 hover:bg-neutral-800'
+                    }`}
+                    onMouseEnter={() => setSelectedIndex(i)}
+                    onClick={() => {
+                      if (!activeMode) return;
+                      const isDirectory = item.data?.isDirectory as boolean | undefined;
+                      if (activeModeId === 'browse' && isDirectory) {
+                        activeMode.onSelect(item);
+                      } else {
+                        activeMode.onSelect(item);
+                        onClose();
+                      }
+                    }}
+                  >
+                    <span className="text-neutral-500 shrink-0 flex items-center">{item.icon}</span>
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="truncate text-sm font-medium">{item.title}</span>
+                      {item.subtitle && (
+                        <span className="truncate text-xs text-neutral-500">{item.subtitle}</span>
+                      )}
+                    </div>
+                    {item.meta && (
+                      <span className="text-[10px] text-neutral-600 shrink-0">{item.meta}</span>
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          {/* Preview column */}
+          <div className="w-[60%] overflow-auto p-3">
+            {renderPreviewPanel()}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
+          <span>↑↓ navigate</span>
+          <span>↵ open/focus</span>
+          {activeModeId !== 'panes' && <span>⇧↵ paste path</span>}
+          {activeModeId === 'browse' && <span>⌫ up dir</span>}
+          <span>esc dismiss</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/Telescope/TelescopeModal.tsx
+++ b/src/renderer/src/components/Telescope/TelescopeModal.tsx
@@ -18,7 +18,11 @@ type TelescopeModalProps = {
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC');
 const modKey = isMac ? '⌘' : 'Ctrl+';
 
-export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): React.JSX.Element | null {
+export function TelescopeModal({
+  isOpen,
+  onClose,
+  cwd
+}: TelescopeModalProps): React.JSX.Element | null {
   const [activeModeId, setActiveModeId] = useState<string>('files');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<TelescopeItem[]>([]);
@@ -76,7 +80,7 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
     searchDebounceRef.current = setTimeout(() => {
       const result = activeMode.onSearch(query);
       if (result instanceof Promise) {
-        result.then((items) => {
+        void result.then((items) => {
           setResults(items);
           setSelectedIndex(0);
         });
@@ -102,19 +106,16 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
 
     previewDebounceRef.current = setTimeout(() => {
       const item = results[selectedIndex];
-      if (!item) {
-        setPreviewContent(null);
-        return;
-      }
-
       const data = item.data;
 
-      if (data?.paneId) {
+      if (typeof data?.paneId === 'string') {
+        const paneType = typeof data.paneType === 'string' ? data.paneType : 'terminal';
+        const cwd = typeof data.cwd === 'string' ? data.cwd : '';
         const paneInfo = [
           `Pane: ${item.title}`,
-          `Type: ${String(data.paneType ?? 'terminal')}`,
-          `CWD: ${String(data.cwd ?? '')}`,
-          data.cwd ? `\nDirectory: ${String(data.cwd)}` : ''
+          `Type: ${paneType}`,
+          `CWD: ${cwd}`,
+          cwd ? `\nDirectory: ${cwd}` : ''
         ]
           .filter(Boolean)
           .join('\n');
@@ -122,10 +123,12 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
         return;
       }
 
-      if (data?.isDirectory && data?.filePath) {
+      const filePath = typeof data?.filePath === 'string' ? data.filePath : null;
+
+      if (filePath !== null && data?.isDirectory === true) {
         setPreviewLoading(true);
-        window.fleet.file
-          .readdir(String(data.filePath))
+        void window.fleet.file
+          .readdir(filePath)
           .then((result) => {
             if (result.success) {
               const listing = result.entries
@@ -144,17 +147,20 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
         return;
       }
 
-      if (data?.filePath) {
+      if (filePath !== null) {
         setPreviewLoading(true);
-        window.fleet.file
-          .read(String(data.filePath))
+        void window.fleet.file
+          .read(filePath)
           .then((result) => {
-            if (result.success && result.data.content != null) {
+            if (result.success) {
               const lines = result.data.content.split('\n').slice(0, 200);
-              const targetLine = data.line != null ? Number(data.line) : null;
+              const targetLine = typeof data?.line === 'number' ? data.line : null;
               const numbered = lines.map((line, i) => {
                 const lineNum = i + 1;
-                const prefix = targetLine === lineNum ? `> ${String(lineNum).padStart(4)} ` : `  ${String(lineNum).padStart(4)} `;
+                const prefix =
+                  targetLine === lineNum
+                    ? `> ${String(lineNum).padStart(4)} `
+                    : `  ${String(lineNum).padStart(4)} `;
                 return `${prefix}${line}`;
               });
               setPreviewContent(numbered.join('\n'));
@@ -189,9 +195,8 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
       if (cmdOrCtrl && ['1', '2', '3', '4'].includes(e.key)) {
         e.preventDefault();
         const idx = parseInt(e.key, 10) - 1;
-        const target = modeList[idx];
-        if (target) {
-          setActiveModeId(target.id);
+        if (idx >= 0 && idx < modeList.length) {
+          setActiveModeId(modeList[idx].id);
           setQuery('');
         }
         return;
@@ -205,14 +210,15 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
         setSelectedIndex((i) => Math.max(i - 1, 0));
       } else if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault();
-        const item = results[selectedIndex];
-        if (item && activeMode?.onAltSelect) activeMode.onAltSelect(item);
+        if (selectedIndex < results.length && activeMode?.onAltSelect) {
+          activeMode.onAltSelect(results[selectedIndex]);
+        }
       } else if (e.key === 'Enter') {
         e.preventDefault();
+        if (selectedIndex >= results.length || !activeMode) return;
         const item = results[selectedIndex];
-        if (!item || !activeMode) return;
-        const isDirectory = item.data?.isDirectory as boolean | undefined;
-        if (activeModeId === 'browse' && isDirectory) {
+        const isDirectory = item.data?.isDirectory;
+        if (activeModeId === 'browse' && isDirectory === true) {
           // navigate into directory — don't close
           activeMode.onSelect(item);
         } else {
@@ -255,8 +261,8 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
               {i > 0 && <span className="text-neutral-600">/</span>}
               <button
                 onClick={() => {
-                  if (!isLast) {
-                    activeMode?.onNavigate?.(pathUpToSegment);
+                  if (!isLast && activeMode.onNavigate) {
+                    activeMode.onNavigate(pathUpToSegment);
                   }
                 }}
                 className={
@@ -291,10 +297,7 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex justify-center bg-black/60"
-      onClick={onClose}
-    >
+    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
       <div
         className="mt-[10vh] w-[800px] max-h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
         onClick={(e) => e.stopPropagation()}
@@ -364,10 +367,7 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
         {/* Body */}
         <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
           {/* Results column */}
-          <div
-            ref={listRef}
-            className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1"
-          >
+          <div ref={listRef} className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1">
             {results.length === 0 ? (
               <div className="px-3 py-4 text-xs text-neutral-600 text-center italic">
                 {query ? 'No results' : 'Type to search'}
@@ -387,8 +387,8 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
                     onMouseEnter={() => setSelectedIndex(i)}
                     onClick={() => {
                       if (!activeMode) return;
-                      const isDirectory = item.data?.isDirectory as boolean | undefined;
-                      if (activeModeId === 'browse' && isDirectory) {
+                      const isDirectory = item.data?.isDirectory;
+                      if (activeModeId === 'browse' && isDirectory === true) {
                         activeMode.onSelect(item);
                       } else {
                         activeMode.onSelect(item);
@@ -413,9 +413,7 @@ export function TelescopeModal({ isOpen, onClose, cwd }: TelescopeModalProps): R
           </div>
 
           {/* Preview column */}
-          <div className="w-[60%] overflow-auto p-3">
-            {renderPreviewPanel()}
-          </div>
+          <div className="w-[60%] overflow-auto p-3">{renderPreviewPanel()}</div>
         </div>
 
         {/* Footer */}

--- a/src/renderer/src/components/Telescope/modes/browse-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/browse-mode.ts
@@ -1,0 +1,122 @@
+// src/renderer/src/components/Telescope/modes/browse-mode.ts
+import { createElement } from 'react';
+import { Folder, FolderOpen } from 'lucide-react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { getFileIcon } from '../../../lib/file-icons';
+import { quotePathForShell, bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { DirEntry } from '../../../../../shared/ipc-api';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+type BrowseState = {
+  currentDir: string;
+  entries: DirEntry[];
+  loading: boolean;
+};
+
+export function createBrowseMode(
+  cwd: string,
+  activePaneId: string | null,
+  onStateChange: () => void
+): TelescopeMode & { getState: () => BrowseState } {
+  const state: BrowseState = {
+    currentDir: cwd,
+    entries: [],
+    loading: false
+  };
+
+  async function loadDir(dir: string): Promise<void> {
+    state.currentDir = dir;
+    state.loading = true;
+    onStateChange();
+
+    const result = await window.fleet.file.readdir(dir);
+    if (result.success) {
+      // Sort: directories first, then alphabetical within each group
+      state.entries = [...result.entries].sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) {
+          return a.isDirectory ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    } else {
+      state.entries = [];
+    }
+
+    state.loading = false;
+    onStateChange();
+  }
+
+  // Initial load
+  loadDir(cwd);
+
+  const mode: TelescopeMode & { getState: () => BrowseState } = {
+    id: 'browse',
+    label: 'Browse',
+    icon: FolderOpen,
+    placeholder: 'Filter current directory...',
+
+    get breadcrumbs(): string[] {
+      const dir = state.currentDir;
+      const homeDir = window.fleet.homeDir;
+      if (dir.startsWith(homeDir)) {
+        const relative = dir.slice(homeDir.length);
+        const parts = relative.split('/').filter(Boolean);
+        return ['~', ...parts];
+      }
+      return dir.split('/').filter(Boolean);
+    },
+
+    onNavigate: (dir: string) => {
+      loadDir(dir);
+    },
+
+    onNavigateUp: () => {
+      const parent = state.currentDir.split('/').slice(0, -1).join('/') || '/';
+      loadDir(parent);
+    },
+
+    onSearch: (query: string): TelescopeItem[] => {
+      const entries = query
+        ? state.entries.filter((e) => fuzzyMatch(query, e.name))
+        : state.entries;
+
+      return entries.map((entry): TelescopeItem => ({
+        id: entry.path,
+        icon: entry.isDirectory
+          ? createElement(Folder, { size: 14, className: 'text-blue-400' })
+          : getFileIcon(entry.name),
+        title: entry.name,
+        subtitle: entry.isDirectory ? 'Directory' : undefined,
+        data: { filePath: entry.path, isDirectory: entry.isDirectory }
+      }));
+    },
+
+    onSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      const isDirectory = item.data?.isDirectory as boolean | undefined;
+      if (!filePath) return;
+      if (isDirectory) {
+        loadDir(filePath);
+      } else {
+        useWorkspaceStore.getState().openFile(filePath);
+      }
+    },
+
+    onAltSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      if (!filePath || !activePaneId) return;
+      const quoted = quotePathForShell(filePath, window.fleet.platform);
+      window.fleet.pty.input({
+        paneId: activePaneId,
+        data: bracketedPaste(quoted + ' ')
+      });
+    },
+
+    renderPreview: () => null,
+
+    getState: () => state
+  };
+
+  return mode;
+}

--- a/src/renderer/src/components/Telescope/modes/browse-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/browse-mode.ts
@@ -48,7 +48,7 @@ export function createBrowseMode(
   }
 
   // Initial load
-  loadDir(cwd);
+  void loadDir(cwd);
 
   const mode: TelescopeMode & { getState: () => BrowseState } = {
     id: 'browse',
@@ -68,12 +68,12 @@ export function createBrowseMode(
     },
 
     onNavigate: (dir: string) => {
-      loadDir(dir);
+      void loadDir(dir);
     },
 
     onNavigateUp: () => {
       const parent = state.currentDir.split('/').slice(0, -1).join('/') || '/';
-      loadDir(parent);
+      void loadDir(parent);
     },
 
     onSearch: (query: string): TelescopeItem[] => {
@@ -81,31 +81,33 @@ export function createBrowseMode(
         ? state.entries.filter((e) => fuzzyMatch(query, e.name))
         : state.entries;
 
-      return entries.map((entry): TelescopeItem => ({
-        id: entry.path,
-        icon: entry.isDirectory
-          ? createElement(Folder, { size: 14, className: 'text-blue-400' })
-          : getFileIcon(entry.name),
-        title: entry.name,
-        subtitle: entry.isDirectory ? 'Directory' : undefined,
-        data: { filePath: entry.path, isDirectory: entry.isDirectory }
-      }));
+      return entries.map(
+        (entry): TelescopeItem => ({
+          id: entry.path,
+          icon: entry.isDirectory
+            ? createElement(Folder, { size: 14, className: 'text-blue-400' })
+            : getFileIcon(entry.name),
+          title: entry.name,
+          subtitle: entry.isDirectory ? 'Directory' : undefined,
+          data: { filePath: entry.path, isDirectory: entry.isDirectory }
+        })
+      );
     },
 
     onSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      const isDirectory = item.data?.isDirectory as boolean | undefined;
-      if (!filePath) return;
-      if (isDirectory) {
-        loadDir(filePath);
+      const filePath = item.data?.filePath;
+      const isDirectory = item.data?.isDirectory;
+      if (typeof filePath !== 'string') return;
+      if (isDirectory === true) {
+        void loadDir(filePath);
       } else {
         useWorkspaceStore.getState().openFile(filePath);
       }
     },
 
     onAltSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      if (!filePath || !activePaneId) return;
+      const filePath = item.data?.filePath;
+      if (typeof filePath !== 'string' || !activePaneId) return;
       const quoted = quotePathForShell(filePath, window.fleet.platform);
       window.fleet.pty.input({
         paneId: activePaneId,

--- a/src/renderer/src/components/Telescope/modes/files-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/files-mode.ts
@@ -1,0 +1,96 @@
+// src/renderer/src/components/Telescope/modes/files-mode.ts
+import { File } from 'lucide-react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { getFileIcon } from '../../../lib/file-icons';
+import { quotePathForShell, bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+type FileEntry = {
+  path: string;
+  relativePath: string;
+  name: string;
+};
+
+/** Module-level cache: cwd → file listing */
+const fileCache = new Map<string, FileEntry[]>();
+
+function makeItem(file: FileEntry): TelescopeItem {
+  return {
+    id: file.path,
+    icon: getFileIcon(file.name),
+    title: file.name,
+    subtitle: file.relativePath,
+    data: { filePath: file.path }
+  };
+}
+
+export function createFilesMode(cwd: string, activePaneId: string | null): TelescopeMode {
+  // Pre-load file listing in the background
+  if (!fileCache.has(cwd)) {
+    window.fleet.file.list(cwd).then((result) => {
+      if (result.success && result.files) {
+        fileCache.set(cwd, result.files);
+      }
+    });
+  }
+
+  return {
+    id: 'files',
+    label: 'Files',
+    icon: File,
+    placeholder: 'Search files by name...',
+
+    onSearch: async (query: string): Promise<TelescopeItem[]> => {
+      if (!query) {
+        // Return recent files (first 15)
+        const recentFiles = useWorkspaceStore.getState().recentFiles.slice(0, 15);
+        return recentFiles.map((filePath) => {
+          const name = filePath.split('/').pop() ?? filePath;
+          return {
+            id: filePath,
+            icon: getFileIcon(name),
+            title: name,
+            subtitle: filePath,
+            data: { filePath }
+          };
+        });
+      }
+
+      // Ensure cache is populated (may have been set by pre-load)
+      let files = fileCache.get(cwd);
+      if (!files) {
+        const result = await window.fleet.file.list(cwd);
+        if (result.success && result.files) {
+          fileCache.set(cwd, result.files);
+          files = result.files;
+        } else {
+          files = [];
+        }
+      }
+
+      return files
+        .filter((f) => fuzzyMatch(query, f.relativePath) || fuzzyMatch(query, f.name))
+        .slice(0, 50)
+        .map(makeItem);
+    },
+
+    onSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      if (!filePath) return;
+      useWorkspaceStore.getState().openFile(filePath);
+    },
+
+    onAltSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      if (!filePath || !activePaneId) return;
+      const quoted = quotePathForShell(filePath, window.fleet.platform);
+      window.fleet.pty.input({
+        paneId: activePaneId,
+        data: bracketedPaste(quoted + ' ')
+      });
+    },
+
+    renderPreview: () => null
+  };
+}

--- a/src/renderer/src/components/Telescope/modes/files-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/files-mode.ts
@@ -28,10 +28,8 @@ function makeItem(file: FileEntry): TelescopeItem {
 export function createFilesMode(cwd: string, activePaneId: string | null): TelescopeMode {
   // Pre-load file listing in the background
   if (!fileCache.has(cwd)) {
-    window.fleet.file.list(cwd).then((result) => {
-      if (result.success && result.files) {
-        fileCache.set(cwd, result.files);
-      }
+    void window.fleet.file.list(cwd).then((result) => {
+      fileCache.set(cwd, result.files);
     });
   }
 
@@ -61,12 +59,8 @@ export function createFilesMode(cwd: string, activePaneId: string | null): Teles
       let files = fileCache.get(cwd);
       if (!files) {
         const result = await window.fleet.file.list(cwd);
-        if (result.success && result.files) {
-          fileCache.set(cwd, result.files);
-          files = result.files;
-        } else {
-          files = [];
-        }
+        fileCache.set(cwd, result.files);
+        files = result.files;
       }
 
       return files
@@ -76,14 +70,14 @@ export function createFilesMode(cwd: string, activePaneId: string | null): Teles
     },
 
     onSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      if (!filePath) return;
+      const filePath = item.data?.filePath;
+      if (typeof filePath !== 'string') return;
       useWorkspaceStore.getState().openFile(filePath);
     },
 
     onAltSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      if (!filePath || !activePaneId) return;
+      const filePath = item.data?.filePath;
+      if (typeof filePath !== 'string' || !activePaneId) return;
       const quoted = quotePathForShell(filePath, window.fleet.platform);
       window.fleet.pty.input({
         paneId: activePaneId,

--- a/src/renderer/src/components/Telescope/modes/grep-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/grep-mode.ts
@@ -1,0 +1,68 @@
+// src/renderer/src/components/Telescope/modes/grep-mode.ts
+import { createElement } from 'react';
+import { TextSearch } from 'lucide-react';
+import { bracketedPaste } from '../../../lib/shell-utils';
+import { useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+export function createGrepMode(cwd: string, activePaneId: string | null): TelescopeMode {
+  let requestCounter = 0;
+
+  return {
+    id: 'grep',
+    label: 'Grep',
+    icon: TextSearch,
+    placeholder: 'Search file contents...',
+
+    onSearch: async (query: string): Promise<TelescopeItem[]> => {
+      if (!query) return [];
+
+      const myRequest = ++requestCounter;
+      const requestId = myRequest;
+
+      const response = await window.fleet.file.grep({ requestId, query, cwd, limit: 50 });
+
+      // Discard stale responses
+      if (myRequest !== requestCounter) return [];
+
+      if (!response.success) return [];
+
+      return response.results.map((result) => ({
+        id: `${result.file}:${result.line}`,
+        icon: createElement(
+          'span',
+          { style: { fontFamily: 'monospace', fontSize: '11px', opacity: 0.7 } },
+          String(result.line)
+        ),
+        title: result.relativePath,
+        subtitle: result.text.trim(),
+        meta: `L${result.line}`,
+        data: {
+          filePath: result.file,
+          line: result.line,
+          contextBefore: result.contextBefore,
+          contextAfter: result.contextAfter
+        }
+      }));
+    },
+
+    onSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      if (!filePath) return;
+      useWorkspaceStore.getState().openFile(filePath);
+    },
+
+    onAltSelect: (item) => {
+      const filePath = item.data?.filePath as string | undefined;
+      const line = item.data?.line as number | undefined;
+      if (!filePath || !activePaneId) return;
+      const ref = line != null ? `${filePath}:${line}` : filePath;
+      window.fleet.pty.input({
+        paneId: activePaneId,
+        data: bracketedPaste(ref)
+      });
+    },
+
+    renderPreview: () => null
+  };
+}

--- a/src/renderer/src/components/Telescope/modes/grep-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/grep-mode.ts
@@ -47,16 +47,17 @@ export function createGrepMode(cwd: string, activePaneId: string | null): Telesc
     },
 
     onSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      if (!filePath) return;
+      const filePath = item.data?.filePath;
+      if (typeof filePath !== 'string') return;
       useWorkspaceStore.getState().openFile(filePath);
     },
 
     onAltSelect: (item) => {
-      const filePath = item.data?.filePath as string | undefined;
-      const line = item.data?.line as number | undefined;
-      if (!filePath || !activePaneId) return;
-      const ref = line != null ? `${filePath}:${line}` : filePath;
+      const filePath = item.data?.filePath;
+      const line = item.data?.line;
+      if (typeof filePath !== 'string' || !activePaneId) return;
+      const lineNum = typeof line === 'number' ? line : null;
+      const ref = lineNum != null ? `${filePath}:${lineNum}` : filePath;
       window.fleet.pty.input({
         paneId: activePaneId,
         data: bracketedPaste(ref)

--- a/src/renderer/src/components/Telescope/modes/panes-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/panes-mode.ts
@@ -1,0 +1,56 @@
+// src/renderer/src/components/Telescope/modes/panes-mode.ts
+import { createElement } from 'react';
+import { TerminalSquare } from 'lucide-react';
+import { fuzzyMatch } from '../../../lib/commands';
+import { collectPaneLeafs, useWorkspaceStore } from '../../../store/workspace-store';
+import type { TelescopeMode, TelescopeItem } from '../types';
+
+export function createPanesMode(): TelescopeMode {
+  return {
+    id: 'panes',
+    label: 'Panes',
+    icon: TerminalSquare,
+    placeholder: 'Search open panes...',
+
+    onSearch: (query: string): TelescopeItem[] => {
+      const state = useWorkspaceStore.getState();
+      const activeTab = state.workspace.tabs.find((t) => t.id === state.activeTabId);
+      if (!activeTab) return [];
+
+      const leafs = collectPaneLeafs(activeTab.splitRoot);
+
+      const filtered = query
+        ? leafs.filter((leaf) => {
+            const label = leaf.label ?? leaf.paneType ?? 'terminal';
+            return fuzzyMatch(query, label) || fuzzyMatch(query, leaf.cwd);
+          })
+        : leafs;
+
+      return filtered.map((leaf) => {
+        const isActive = leaf.id === state.activePaneId;
+        return {
+          id: leaf.id,
+          icon: createElement(TerminalSquare, {
+            size: 14,
+            className: isActive ? 'text-green-400' : 'text-neutral-500'
+          }),
+          title: leaf.label ?? leaf.paneType ?? 'terminal',
+          subtitle: leaf.cwd.replace(window.fleet.homeDir, '~'),
+          meta: isActive ? 'active' : undefined,
+          data: { paneId: leaf.id, cwd: leaf.cwd, paneType: leaf.paneType ?? 'terminal' }
+        };
+      });
+    },
+
+    onSelect: (item) => {
+      const paneId = item.data?.paneId as string | undefined;
+      if (!paneId) return;
+      useWorkspaceStore.getState().setActivePane(paneId);
+      requestAnimationFrame(() => {
+        document.dispatchEvent(new CustomEvent('fleet:refocus-pane', { detail: { paneId } }));
+      });
+    },
+
+    renderPreview: () => null
+  };
+}

--- a/src/renderer/src/components/Telescope/modes/panes-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/panes-mode.ts
@@ -43,8 +43,8 @@ export function createPanesMode(): TelescopeMode {
     },
 
     onSelect: (item) => {
-      const paneId = item.data?.paneId as string | undefined;
-      if (!paneId) return;
+      const paneId = item.data?.paneId;
+      if (typeof paneId !== 'string') return;
       useWorkspaceStore.getState().setActivePane(paneId);
       requestAnimationFrame(() => {
         document.dispatchEvent(new CustomEvent('fleet:refocus-pane', { detail: { paneId } }));

--- a/src/renderer/src/components/Telescope/types.ts
+++ b/src/renderer/src/components/Telescope/types.ts
@@ -1,0 +1,30 @@
+// src/renderer/src/components/Telescope/types.ts
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export type TelescopeItem = {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  subtitle?: string;
+  meta?: string;
+  /** Arbitrary data the mode needs for onSelect/renderPreview (file path, line number, pane id, etc.) */
+  data?: Record<string, unknown>;
+};
+
+export type TelescopeMode = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  placeholder: string;
+  onSearch: (query: string) => Promise<TelescopeItem[]> | TelescopeItem[];
+  renderPreview: (item: TelescopeItem) => ReactNode;
+  onSelect: (item: TelescopeItem) => void;
+  onAltSelect?: (item: TelescopeItem) => void;
+  /** Browse mode only: current path segments for breadcrumb display */
+  breadcrumbs?: string[];
+  /** Browse mode only: drill into a directory or jump to a breadcrumb path */
+  onNavigate?: (dir: string) => void;
+  /** Browse mode only: go up one directory */
+  onNavigateUp?: () => void;
+};

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -139,6 +139,7 @@ export function TerminalPane({
           focus();
         }}
         onAnnotate={() => openAnnotateModal()}
+        onTelescope={() => document.dispatchEvent(new CustomEvent('fleet:toggle-telescope'))}
       />
       <SearchBar
         isOpen={searchOpen}

--- a/src/renderer/src/hooks/use-pane-navigation.ts
+++ b/src/renderer/src/hooks/use-pane-navigation.ts
@@ -159,6 +159,12 @@ export function usePaneNavigation(): void {
         return;
       }
 
+      if (matchesShortcut(e, sc('telescope'))) {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent('fleet:toggle-telescope'));
+        return;
+      }
+
       if (matchesShortcut(e, sc('inject-skills'))) {
         e.preventDefault();
         if (activePaneId) {

--- a/src/renderer/src/lib/shortcuts.ts
+++ b/src/renderer/src/lib/shortcuts.ts
@@ -142,6 +142,12 @@ export const ALL_SHORTCUTS: ShortcutDef[] = [
     label: 'Inject Fleet Skills',
     mac: { key: '.', meta: true, shift: true },
     other: { key: '.', ctrl: true, shift: true }
+  },
+  {
+    id: 'telescope',
+    label: 'Telescope finder',
+    mac: { key: 'T', meta: true, shift: true },
+    other: { key: 'T', ctrl: true, shift: true }
   }
 ];
 

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -137,6 +137,26 @@ export type FileSearchResponse =
   | { success: true; requestId: number; results: FileSearchResult[] }
   | { success: false; requestId: number; error: string };
 
+export type FileGrepRequest = {
+  requestId: number;
+  query: string;
+  cwd: string;
+  limit?: number;
+};
+
+export type FileGrepResult = {
+  file: string;
+  relativePath: string;
+  line: number;
+  text: string;
+  contextBefore?: string[];
+  contextAfter?: string[];
+};
+
+export type FileGrepResponse =
+  | { success: true; requestId: number; results: FileGrepResult[] }
+  | { success: false; requestId: number; error: string };
+
 export type RecentImageResult = {
   path: string;
   name: string;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -30,6 +30,7 @@ export const IPC_CHANNELS = {
   FILE_READ_BINARY: 'file:read-binary',
   FILE_OPEN_IN_TAB: 'file:open-in-tab',
   FILE_SEARCH: 'file:search',
+  FILE_GREP: 'file:grep',
   FILE_RECENT_IMAGES: 'file:recent-images',
   CLIPBOARD_HISTORY: 'clipboard:history',
   CLIPBOARD_CHANGED: 'clipboard:changed',


### PR DESCRIPTION
## Summary

- Add a telescope-style multi-mode fuzzy finder modal with four modes: **Files** (fuzzy search in cwd), **Grep** (content search via ripgrep/grep/findstr), **Browse** (directory navigation with breadcrumbs), and **Panes** (switch between open terminals)
- Two-column layout with results list (left) and live preview panel (right) showing file contents, directory listings, or pane info
- Opens via `Cmd+Shift+T` keyboard shortcut or new Telescope button in pane hover toolbar. Modes switchable with `Cmd+1-4`. Context-dependent actions: Enter opens files/focuses panes, Shift+Enter pastes path into terminal

## New files
- `src/renderer/src/components/Telescope/` — modal shell, types, and 4 mode modules
- `src/main/file-grep.ts` — cross-platform grep backend (rg → grep/findstr fallback)

## Modified files
- `src/shared/ipc-channels.ts`, `src/shared/ipc-api.ts` — FILE_GREP channel + types
- `src/preload/index.ts` — `window.fleet.file.grep()` API
- `src/main/ipc-handlers.ts` — register FILE_GREP handler
- `src/renderer/src/App.tsx` — telescope state, event listener, render
- `src/renderer/src/components/PaneToolbar.tsx` — Telescope toolbar button
- `src/renderer/src/components/TerminalPane.tsx` — wire telescope event
- `src/renderer/src/lib/shortcuts.ts` — Cmd+Shift+T shortcut definition
- `src/renderer/src/hooks/use-pane-navigation.ts` — shortcut handler

## Test plan
- [ ] Hover pane toolbar → Telescope icon visible
- [ ] `Cmd+Shift+T` opens/closes the modal
- [ ] Files mode: fuzzy search files, Enter opens in viewer, Shift+Enter pastes path
- [ ] Grep mode: content search returns matching lines with preview
- [ ] Browse mode: directory navigation, breadcrumbs, Backspace goes up
- [ ] Panes mode: lists open panes, Enter focuses selected pane
- [ ] Preview panel updates on selection change
- [ ] Escape and backdrop click close the modal
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)