### PR TITLE
feat(telescope): dim gitignored files in browse mode

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -400,6 +400,30 @@ export function registerIpcHandlers(
     }
   });
 
+  // Check which entries in a directory are gitignored (returns ignored names)
+  ipcMain.handle(
+    IPC_CHANNELS.FILE_CHECK_IGNORED,
+    async (_event, { dirPath }: { dirPath: string }): Promise<string[]> => {
+      try {
+        const entries = await readdir(dirPath, { withFileTypes: true });
+        const names = entries
+          .filter((e) => e.isFile() || e.isDirectory())
+          .map((e) => e.name);
+        if (names.length === 0) return [];
+
+        const { stdout } = await execAsync(
+          `git check-ignore ${names.map((n) => `'${n.replace(/'/g, "'\\''")}'`).join(' ')}`,
+          { cwd: dirPath, maxBuffer: 1024 * 1024 }
+        );
+        return stdout.split('\n').filter(Boolean);
+      } catch {
+        // git check-ignore exits with code 1 when no files are ignored,
+        // or fails if not a git repo — both cases mean "nothing ignored"
+        return [];
+      }
+    }
+  );
+
   ipcMain.handle(IPC_CHANNELS.FILE_READ_BINARY, async (_event, filePath: string) => {
     try {
       const ext = extname(filePath).toLowerCase().slice(1);

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -406,9 +406,7 @@ export function registerIpcHandlers(
     async (_event, { dirPath }: { dirPath: string }): Promise<string[]> => {
       try {
         const entries = await readdir(dirPath, { withFileTypes: true });
-        const names = entries
-          .filter((e) => e.isFile() || e.isDirectory())
-          .map((e) => e.name);
+        const names = entries.filter((e) => e.isFile() || e.isDirectory()).map((e) => e.name);
         if (names.length === 0) return [];
 
         const { stdout } = await execAsync(

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -412,7 +412,7 @@ export function registerIpcHandlers(
         if (names.length === 0) return [];
 
         const { stdout } = await execAsync(
-          `git check-ignore ${names.map((n) => `'${n.replace(/'/g, "'\\''")}'`).join(' ')}`,
+          `git check-ignore -- ${names.map((n) => `'${n.replace(/'/g, "'\\''")}'`).join(' ')}`,
           { cwd: dirPath, maxBuffer: 1024 * 1024 }
         );
         return stdout.split('\n').filter(Boolean);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -207,7 +207,9 @@ const fleetApi = {
     grep: async (req: FileGrepRequest): Promise<FileGrepResponse> =>
       typedInvoke(IPC_CHANNELS.FILE_GREP, req),
     searchRecentImages: async (): Promise<RecentImagesResponse> =>
-      typedInvoke(IPC_CHANNELS.FILE_RECENT_IMAGES)
+      typedInvoke(IPC_CHANNELS.FILE_RECENT_IMAGES),
+    checkIgnored: async (dirPath: string): Promise<string[]> =>
+      typedInvoke(IPC_CHANNELS.FILE_CHECK_IGNORED, { dirPath })
   },
   clipboard: {
     getHistory: async (): Promise<ClipboardHistoryResponse> =>

--- a/src/renderer/src/components/Telescope/TelescopeModal.tsx
+++ b/src/renderer/src/components/Telescope/TelescopeModal.tsx
@@ -441,7 +441,9 @@ export function TelescopeModal({
                     className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
                       isSelected
                         ? 'bg-neutral-700 text-white'
-                        : 'text-neutral-300 hover:bg-neutral-800'
+                        : item.data?.isIgnored
+                          ? 'text-neutral-600 hover:bg-neutral-800'
+                          : 'text-neutral-300 hover:bg-neutral-800'
                     }`}
                     onMouseEnter={() => setSelectedIndex(i)}
                     onClick={() => {

--- a/src/renderer/src/components/Telescope/TelescopeModal.tsx
+++ b/src/renderer/src/components/Telescope/TelescopeModal.tsx
@@ -358,7 +358,7 @@ export function TelescopeModal({
   return (
     <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
       <div
-        className="mt-[10vh] w-[800px] max-h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
+        className="mt-[10vh] w-[800px] h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header: search input + mode tabs */}

--- a/src/renderer/src/components/Telescope/modes/browse-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/browse-mode.ts
@@ -8,10 +8,14 @@ import { useWorkspaceStore } from '../../../store/workspace-store';
 import type { DirEntry } from '../../../../../shared/ipc-api';
 import type { TelescopeMode, TelescopeItem } from '../types';
 
+// Module-level cache for gitignore results per directory
+const ignoreCache = new Map<string, Set<string>>();
+
 type BrowseState = {
   currentDir: string;
   entries: DirEntry[];
   loading: boolean;
+  ignoredNames: Set<string>;
 };
 
 export function createBrowseMode(
@@ -22,7 +26,8 @@ export function createBrowseMode(
   const state: BrowseState = {
     currentDir: cwd,
     entries: [],
-    loading: false
+    loading: false,
+    ignoredNames: new Set()
   };
 
   async function loadDir(dir: string): Promise<void> {
@@ -39,8 +44,16 @@ export function createBrowseMode(
         }
         return a.name.localeCompare(b.name);
       });
+
+      // Fetch gitignore status (use cache if available)
+      if (!ignoreCache.has(dir)) {
+        const ignored = await window.fleet.file.checkIgnored(dir);
+        ignoreCache.set(dir, new Set(ignored));
+      }
+      state.ignoredNames = ignoreCache.get(dir) ?? new Set();
     } else {
       state.entries = [];
+      state.ignoredNames = new Set();
     }
 
     state.loading = false;
@@ -89,7 +102,11 @@ export function createBrowseMode(
             : getFileIcon(entry.name),
           title: entry.name,
           subtitle: entry.isDirectory ? 'Directory' : undefined,
-          data: { filePath: entry.path, isDirectory: entry.isDirectory }
+          data: {
+            filePath: entry.path,
+            isDirectory: entry.isDirectory,
+            isIgnored: state.ignoredNames.has(entry.name) || entry.name === '.git'
+          }
         })
       );
     },

--- a/src/renderer/src/components/Telescope/modes/browse-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/browse-mode.ts
@@ -101,7 +101,6 @@ export function createBrowseMode(
             ? createElement(Folder, { size: 14, className: 'text-blue-400' })
             : getFileIcon(entry.name),
           title: entry.name,
-          subtitle: entry.isDirectory ? 'Directory' : undefined,
           data: {
             filePath: entry.path,
             isDirectory: entry.isDirectory,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -32,6 +32,7 @@ export const IPC_CHANNELS = {
   FILE_SEARCH: 'file:search',
   FILE_GREP: 'file:grep',
   FILE_RECENT_IMAGES: 'file:recent-images',
+  FILE_CHECK_IGNORED: 'file:check-ignored',
   CLIPBOARD_HISTORY: 'clipboard:history',
   CLIPBOARD_CHANGED: 'clipboard:changed',
   SYSTEM_CHECK: 'system:check',


### PR DESCRIPTION
## Summary
- Gitignored files/folders in telescope Browse mode now appear dimmed (`text-neutral-600`) so users can visually distinguish project files from build artifacts/dependencies
- New `FILE_CHECK_IGNORED` IPC channel runs `git check-ignore` on directory entries with per-directory caching
- Non-git directories work normally (no dimming, no errors)
- Removed redundant "Directory" subtitle — folder icon is sufficient
- Fixed telescope modal to use fixed height (`h-[70vh]`) instead of max-height to prevent distracting resizing

## Test plan
- [ ] Open telescope (Cmd+Shift+T), switch to Browse mode (Cmd+3)
- [ ] Navigate to project root — verify `node_modules/`, `dist/`, `.git/` appear dimmed
- [ ] Verify tracked files appear in normal color
- [ ] Select a dimmed file — verify it highlights white normally
- [ ] Navigate into a non-git directory (e.g. `~/`) — verify no dimming, no errors
- [ ] Verify modal height stays fixed when result count changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)