### PR TITLE
fix: classify fleet_open files by type

### DIFF
--- a/docs/learnings/pi-fleet-open-pane-type.md
+++ b/docs/learnings/pi-fleet-open-pane-type.md
@@ -1,0 +1,32 @@
+# Pi `fleet_open` opened images as plain text
+
+## What happened
+
+The Pi extension `resources/pi-extensions/fleet-files.ts` sends a bridge request with only `{ path }`.
+
+On the Fleet side, `src/main/index.ts` handled that `file.open` bridge request by hard-coding:
+
+```ts
+paneType: 'file'
+```
+
+So every file opened through the Pi bridge was treated as a text file, even when the path was an image or markdown file. That is why images could show up as plain text instead of opening in the image viewer.
+
+## Why it was easy to miss
+
+The normal `fleet open` CLI path already had extension-based classification for images and markdown. The Pi bridge path was a separate implementation and had drifted from the CLI behavior.
+
+## Fix
+
+- Added shared file-opening helpers in `src/shared/file-open.ts`
+- Updated `src/main/index.ts` bridge handling to:
+  - resolve the path
+  - reject directories
+  - reject blocked binary formats
+  - classify the pane type from the file extension
+- Updated `src/main/fleet-cli.ts` to use the same shared helper so CLI and Pi bridge stay consistent
+- Added `src/shared/__tests__/file-open.test.ts` for the shared classification logic
+
+## Takeaway
+
+When the same behavior exists in both CLI and bridge code paths, keep the file-type classification in one shared helper instead of duplicating extension lists in multiple places.

--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -1,60 +1,9 @@
 import { createConnection } from 'node:net';
 import { randomUUID } from 'node:crypto';
-import { join, resolve, extname } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync, statSync } from 'node:fs';
-
-const IMAGE_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.svg',
-  '.bmp',
-  '.ico'
-]);
-
-const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
-
-const BINARY_BLOCKLIST = new Set([
-  '.zip',
-  '.tar',
-  '.gz',
-  '.7z',
-  '.rar',
-  '.exe',
-  '.dmg',
-  '.pkg',
-  '.deb',
-  '.rpm',
-  '.iso',
-  '.bin',
-  '.dll',
-  '.so',
-  '.dylib',
-  '.o',
-  '.a',
-  '.wasm',
-  '.class',
-  '.jar',
-  '.war',
-  '.pdf',
-  '.doc',
-  '.docx',
-  '.xls',
-  '.xlsx',
-  '.ppt',
-  '.pptx',
-  '.mp3',
-  '.mp4',
-  '.mov',
-  '.avi',
-  '.mkv',
-  '.flac',
-  '.wav',
-  '.aac'
-]);
+import { getPaneTypeForFilePath, isBinaryBlockedFilePath } from '../shared/file-open';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -567,18 +516,12 @@ export async function runCLI(
         continue;
       }
 
-      const ext = extname(resolved).toLowerCase();
-      if (BINARY_BLOCKLIST.has(ext)) {
+      if (isBinaryBlockedFilePath(resolved)) {
         errors.push(`Error: unsupported binary file: ${p}`);
         continue;
       }
 
-      const paneType = IMAGE_EXTENSIONS.has(ext)
-        ? ('image' as const)
-        : MARKDOWN_EXTENSIONS.has(ext)
-          ? ('markdown' as const)
-          : ('file' as const);
-      files.push({ path: resolved, paneType });
+      files.push({ path: resolved, paneType: getPaneTypeForFilePath(resolved) });
     }
 
     if (files.length === 0) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,10 +2,10 @@ import { app, BrowserWindow, ipcMain, Notification, nativeImage, net, protocol }
 import { safeOpenExternal } from './safe-external';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { homedir } from 'os';
 import { PtyManager } from './pty-manager';
 import { LayoutStore } from './layout-store';
@@ -30,6 +30,7 @@ import { enrichProcessEnv } from './shell-env';
 import { resolveBootstrapWorkspacePath } from './workspace-path';
 import type { HostContextPayload } from '../shared/ipc-api';
 import type { NotificationLevel, UpdateStatus, ImageSettings } from '../shared/types';
+import { getPaneTypeForFilePath, isBinaryBlockedFilePath } from '../shared/file-open';
 import { createLogger } from './logger';
 import { initCopilot, stopCopilot, pruneDeadCopilotSessions } from './copilot/index';
 import pkg from 'electron-updater';
@@ -337,16 +338,25 @@ void app.whenReady().then(async () => {
   fleetBridge.onRequest(async (type, payload, _paneId) => {
     switch (type) {
       case 'file.open': {
-        const filePath = typeof payload.path === 'string' ? payload.path : '';
-        if (!filePath) throw new Error('file.open requires a path');
+        const rawPath = typeof payload.path === 'string' ? payload.path : '';
+        if (!rawPath) throw new Error('file.open requires a path');
+
+        const filePath = resolve(rawPath);
+        if (!existsSync(filePath)) throw new Error(`file not found: ${filePath}`);
+        if (statSync(filePath).isDirectory()) {
+          throw new Error(`directories not supported, use a file path: ${filePath}`);
+        }
+        if (isBinaryBlockedFilePath(filePath)) {
+          throw new Error(`unsupported binary file: ${filePath}`);
+        }
+
+        const paneType = getPaneTypeForFilePath(filePath);
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send(IPC_CHANNELS.FILE_OPEN_IN_TAB, {
-            files: [
-              { path: filePath, paneType: 'file', label: filePath.split('/').pop() ?? filePath }
-            ]
+            files: [{ path: filePath, paneType, label: filePath.split('/').pop() ?? filePath }]
           });
         }
-        return { ok: true };
+        return { ok: true, paneType };
       }
       default:
         throw new Error(`Unknown bridge command: ${type}`);

--- a/src/shared/__tests__/file-open.test.ts
+++ b/src/shared/__tests__/file-open.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getFileExtension, getPaneTypeForFilePath, isBinaryBlockedFilePath } from '../file-open';
+
+describe('file-open helpers', () => {
+  it('extracts lowercase extensions from paths', () => {
+    expect(getFileExtension('/tmp/Photo.PNG')).toBe('.png');
+  });
+
+  it('returns image pane type for image files', () => {
+    expect(getPaneTypeForFilePath('/tmp/example.webp')).toBe('image');
+  });
+
+  it('returns markdown pane type for markdown files', () => {
+    expect(getPaneTypeForFilePath('/tmp/README.md')).toBe('markdown');
+  });
+
+  it('returns file pane type for non-image, non-markdown files', () => {
+    expect(getPaneTypeForFilePath('/tmp/index.ts')).toBe('file');
+  });
+
+  it('detects blocked binary files', () => {
+    expect(isBinaryBlockedFilePath('/tmp/report.pdf')).toBe(true);
+    expect(isBinaryBlockedFilePath('/tmp/report.txt')).toBe(false);
+  });
+});

--- a/src/shared/file-open.ts
+++ b/src/shared/file-open.ts
@@ -1,0 +1,70 @@
+export const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.bmp',
+  '.ico'
+]);
+
+export const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+
+export const BINARY_BLOCKLIST = new Set([
+  '.zip',
+  '.tar',
+  '.gz',
+  '.7z',
+  '.rar',
+  '.exe',
+  '.dmg',
+  '.pkg',
+  '.deb',
+  '.rpm',
+  '.iso',
+  '.bin',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.o',
+  '.a',
+  '.wasm',
+  '.class',
+  '.jar',
+  '.war',
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.ppt',
+  '.pptx',
+  '.mp3',
+  '.mp4',
+  '.mov',
+  '.avi',
+  '.mkv',
+  '.flac',
+  '.wav',
+  '.aac'
+]);
+
+export type OpenablePaneType = 'file' | 'image' | 'markdown';
+
+export function getFileExtension(filePath: string): string {
+  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+  const idx = fileName.lastIndexOf('.');
+  return idx > 0 ? fileName.slice(idx).toLowerCase() : '';
+}
+
+export function getPaneTypeForFilePath(filePath: string): OpenablePaneType {
+  const ext = getFileExtension(filePath);
+  if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+  if (MARKDOWN_EXTENSIONS.has(ext)) return 'markdown';
+  return 'file';
+}
+
+export function isBinaryBlockedFilePath(filePath: string): boolean {
+  return BINARY_BLOCKLIST.has(getFileExtension(filePath));
+}


### PR DESCRIPTION
## Summary\n- investigate why Pi's fleet_open opened images as plain text\n- share file-open classification logic between the CLI and Pi bridge paths\n- validate bridge opens reject blocked binaries/directories and pick the correct pane type\n\n## Testing\n- not run (node_modules missing in this worktree, so vitest/tsc were unavailable)