### PR TITLE
feat(pi): open plan mode docs in Fleet modal

### DIFF
--- a/docs/learnings/2026-04-27-fleet-bridge-handler-type.md
+++ b/docs/learnings/2026-04-27-fleet-bridge-handler-type.md
@@ -1,0 +1,16 @@
+# Fleet bridge handler return type and lint
+
+## Symptom
+
+While adding the Pi plan-open bridge command, changing `FleetBridgeServer`'s `RequestHandler` from `Promise<unknown>` to `unknown | Promise<unknown>` made lint report:
+
+- `@typescript-eslint/no-redundant-type-constituents` because `unknown` absorbs the union
+- `@typescript-eslint/await-thenable` at the call site that awaited the handler result
+
+## Fix
+
+Keep `RequestHandler` as `Promise<unknown>` and keep bridge request handlers `async`. If a handler is currently synchronous, use a real async boundary rather than changing the framework type.
+
+## Lesson
+
+Do not use `unknown | Promise<unknown>` for async callback return types in this codebase. It looks flexible, but lint treats `unknown` as overriding the promise branch and then flags awaited values as non-thenable.

--- a/docs/learnings/2026-04-28-pi-plan-modal-disconnect.md
+++ b/docs/learnings/2026-04-28-pi-plan-modal-disconnect.md
@@ -1,0 +1,21 @@
+# Pi plan modal bridge disconnect handling
+
+## Symptom
+
+The Pi plan modal response flow initially assumed that once `pi.plan_open` returned, the Fleet bridge would stay connected until the user clicked Approve/Reject/Continue. If the WebSocket disconnected after opening the modal but before the response, `exit_plan_mode` could wait forever. After adding delivery failure checks, the modal could also become effectively unclosable because every dismissal path tried to send `continue` through the disconnected bridge.
+
+## Fix
+
+- Add a disconnect callback to the Fleet Pi bridge extension client.
+- Have pending `exit_plan_mode` response waiters resolve as `continue` on bridge disconnect, matching abort behavior.
+- Make renderer-side response delivery failures visible but non-blocking by showing an error with a direct Dismiss escape hatch.
+- When invoking disconnect handlers, iterate over a copy so handlers can unsubscribe themselves without skipping later handlers.
+
+## Lesson
+
+For two-way UI flows over an agent bridge, handle all lifecycle edges explicitly:
+
+1. Request opened but response never arrives.
+2. Response send fails after user action.
+3. User needs a local dismiss path even if the agent can no longer be notified.
+4. Event handler arrays must tolerate handlers unregistering during dispatch.

--- a/resources/pi-extensions/fleet-bridge.ts
+++ b/resources/pi-extensions/fleet-bridge.ts
@@ -16,6 +16,7 @@ const MAX_RECONNECT_ATTEMPTS = 10;
 export type BridgeClient = {
   send: (type: string, payload: Record<string, unknown>) => Promise<unknown>;
   onEvent: (handler: (type: string, payload: Record<string, unknown>) => void) => void;
+  onDisconnect: (handler: () => void) => () => void;
   isConnected: () => boolean;
 };
 
@@ -37,6 +38,7 @@ export default function (_pi: ExtensionAPI): void {
   let requestId = 0;
   const pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
   const eventHandlers: Array<(type: string, payload: Record<string, unknown>) => void> = [];
+  const disconnectHandlers: Array<() => void> = [];
 
   function connect(): void {
     try {
@@ -73,6 +75,9 @@ export default function (_pi: ExtensionAPI): void {
 
       ws.onclose = () => {
         ws = null;
+        for (const handler of [...disconnectHandlers]) {
+          handler();
+        }
         if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
           reconnectAttempts++;
           setTimeout(connect, RECONNECT_DELAY_MS);
@@ -108,6 +113,13 @@ export default function (_pi: ExtensionAPI): void {
     },
     onEvent(handler) {
       eventHandlers.push(handler);
+    },
+    onDisconnect(handler) {
+      disconnectHandlers.push(handler);
+      return () => {
+        const index = disconnectHandlers.indexOf(handler);
+        if (index >= 0) disconnectHandlers.splice(index, 1);
+      };
     },
     isConnected() {
       return ws !== null && ws.readyState === WebSocket.OPEN;

--- a/resources/pi-extensions/fleet-plan-mode-policy.ts
+++ b/resources/pi-extensions/fleet-plan-mode-policy.ts
@@ -1,5 +1,3 @@
-const PLAN_PREVIEW_LINES = 60;
-
 const BLOCKED_IN_PLAN = new Set<string>(['write', 'edit', 'bash', 'fleet_run']);
 const REQUIRED_PLAN_MODE_TOOLS = ['read', 'grep', 'find', 'ls', 'fleet_open', 'exit_plan_mode'];
 
@@ -15,13 +13,6 @@ export function getPlanModeActiveTools(currentActiveTools: string[]): string[] {
   return next;
 }
 
-function previewPlan(plan: string): string {
-  const lines = plan.split('\n');
-  if (lines.length <= PLAN_PREVIEW_LINES) return plan;
-  const remaining = lines.length - PLAN_PREVIEW_LINES;
-  return `${lines.slice(0, PLAN_PREVIEW_LINES).join('\n')}\n\n(${remaining} more lines)`;
-}
-
-export function buildPlanApprovalMessage(planPath: string, plan: string): string {
-  return `Path: ${planPath}\n\n---\n\n${previewPlan(plan)}`;
+export function buildPlanApprovalMessage(planPath: string): string {
+  return `Plan written to:\n${planPath}\n\nReview it in the Fleet plan modal, then approve when ready.`;
 }

--- a/resources/pi-extensions/fleet-plan-mode.ts
+++ b/resources/pi-extensions/fleet-plan-mode.ts
@@ -32,6 +32,7 @@ import {
 type FleetBridgeClient = {
   send: (type: string, payload: Record<string, unknown>) => Promise<unknown>;
   onEvent: (handler: (type: string, payload: Record<string, unknown>) => void) => void;
+  onDisconnect: (handler: () => void) => () => void;
   isConnected: () => boolean;
 };
 
@@ -84,8 +85,13 @@ function isPlanReviewAction(value: unknown): value is PlanReviewAction {
   return value === 'approve' || value === 'reject' || value === 'continue';
 }
 
-function createPlanResponseWaiter(requestId: string, signal: AbortSignal | undefined) {
+function createPlanResponseWaiter(
+  requestId: string,
+  signal: AbortSignal | undefined,
+  bridge: FleetBridgeClient
+) {
   let abortHandler: (() => void) | undefined;
+  let unsubscribeDisconnect: (() => void) | undefined;
   let cleanup = () => {
     pendingPlanResponses.delete(requestId);
   };
@@ -94,15 +100,17 @@ function createPlanResponseWaiter(requestId: string, signal: AbortSignal | undef
     cleanup = () => {
       pendingPlanResponses.delete(requestId);
       if (abortHandler) signal?.removeEventListener('abort', abortHandler);
+      unsubscribeDisconnect?.();
     };
     const finish = (response: PlanReviewResponse) => {
       cleanup();
       resolve(response);
     };
     abortHandler = () => finish({ action: 'continue' });
+    unsubscribeDisconnect = bridge.onDisconnect(() => finish({ action: 'continue' }));
 
     pendingPlanResponses.set(requestId, { resolve: finish });
-    if (signal?.aborted) {
+    if (signal?.aborted || !bridge.isConnected()) {
       abortHandler();
       return;
     }
@@ -280,7 +288,7 @@ export default function (pi: ExtensionAPI): void {
       const bridge = globalThis.__fleetBridge;
       if (bridge?.isConnected()) {
         const requestId = randomUUID();
-        const responseWaiter = createPlanResponseWaiter(requestId, signal);
+        const responseWaiter = createPlanResponseWaiter(requestId, signal, bridge);
         try {
           await bridge.send('pi.plan_open', { path: planPath, requestId });
           review = await responseWaiter.promise;

--- a/resources/pi-extensions/fleet-plan-mode.ts
+++ b/resources/pi-extensions/fleet-plan-mode.ts
@@ -20,6 +20,7 @@ import {
   type ExtensionContext
 } from '@mariozechner/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -66,6 +67,51 @@ const PLAN_MODE_BLOCK_REASON =
 
 const TOPIC_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
+type PlanReviewAction = 'approve' | 'reject' | 'continue';
+
+type PlanReviewResponse = {
+  action: PlanReviewAction;
+  feedback?: string;
+};
+
+type PendingPlanResponse = {
+  resolve: (response: PlanReviewResponse) => void;
+};
+
+const pendingPlanResponses = new Map<string, PendingPlanResponse>();
+
+function isPlanReviewAction(value: unknown): value is PlanReviewAction {
+  return value === 'approve' || value === 'reject' || value === 'continue';
+}
+
+function createPlanResponseWaiter(requestId: string, signal: AbortSignal | undefined) {
+  let abortHandler: (() => void) | undefined;
+  let cleanup = () => {
+    pendingPlanResponses.delete(requestId);
+  };
+
+  const promise = new Promise<PlanReviewResponse>((resolve) => {
+    cleanup = () => {
+      pendingPlanResponses.delete(requestId);
+      if (abortHandler) signal?.removeEventListener('abort', abortHandler);
+    };
+    const finish = (response: PlanReviewResponse) => {
+      cleanup();
+      resolve(response);
+    };
+    abortHandler = () => finish({ action: 'continue' });
+
+    pendingPlanResponses.set(requestId, { resolve: finish });
+    if (signal?.aborted) {
+      abortHandler();
+      return;
+    }
+    signal?.addEventListener('abort', abortHandler, { once: true });
+  });
+
+  return { promise, cancel: cleanup };
+}
+
 const ExitPlanModeParams = Type.Object({
   plan: Type.String({
     description:
@@ -104,6 +150,18 @@ export default function (pi: ExtensionAPI): void {
   pi.registerTool(createGrepToolDefinition(cwd));
   pi.registerTool(createFindToolDefinition(cwd));
   pi.registerTool(createLsToolDefinition(cwd));
+
+  globalThis.__fleetBridge?.onEvent((type, payload) => {
+    if (type !== 'pi.plan_response') return;
+    const requestId = typeof payload.requestId === 'string' ? payload.requestId : '';
+    const action = payload.action;
+    if (!requestId || !isPlanReviewAction(action)) return;
+
+    pendingPlanResponses.get(requestId)?.resolve({
+      action,
+      feedback: typeof payload.feedback === 'string' ? payload.feedback : undefined
+    });
+  });
 
   function enterPlanMode(ctx: ExtensionContext): void {
     const activeTools = pi.getActiveTools();
@@ -161,6 +219,10 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on('session_shutdown', async (_event, ctx) => {
+    for (const pending of pendingPlanResponses.values()) {
+      pending.resolve({ action: 'continue' });
+    }
+    pendingPlanResponses.clear();
     if (planMode || savedActiveTools) leavePlanMode(ctx);
   });
 
@@ -184,7 +246,7 @@ export default function (pi: ExtensionAPI): void {
       'Call this when you have a complete plan ready for the user. Writes the plan to docs/plans/YYYY-MM-DD-<topic>.md, opens it in Fleet for review, then exits plan mode after approval so you can begin executing. Pass the plan as markdown in `plan` and a short kebab-case topic in `topic`.',
     parameters: ExitPlanModeParams,
 
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       if (!planMode) {
         return {
           content: [
@@ -214,11 +276,16 @@ export default function (pi: ExtensionAPI): void {
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
       writeFileSync(planPath, params.plan, 'utf-8');
 
+      let review: PlanReviewResponse | null = null;
       const bridge = globalThis.__fleetBridge;
       if (bridge?.isConnected()) {
+        const requestId = randomUUID();
+        const responseWaiter = createPlanResponseWaiter(requestId, signal);
         try {
-          await bridge.send('pi.plan_open', { path: planPath });
+          await bridge.send('pi.plan_open', { path: planPath, requestId });
+          review = await responseWaiter.promise;
         } catch (err) {
+          responseWaiter.cancel();
           ctx.ui.notify(
             `Plan written, but Fleet could not open it: ${err instanceof Error ? err.message : String(err)}`,
             'warning'
@@ -228,14 +295,20 @@ export default function (pi: ExtensionAPI): void {
         ctx.ui.notify('Plan written, but Fleet bridge is not connected.', 'warning');
       }
 
-      const approved = await ctx.ui.confirm('Approve plan?', buildPlanApprovalMessage(planPath));
+      if (!review) {
+        const approved = await ctx.ui.confirm('Approve plan?', buildPlanApprovalMessage(planPath));
+        review = { action: approved ? 'approve' : 'reject' };
+      }
 
-      if (!approved) {
+      if (review.action !== 'approve') {
+        const feedback = review.feedback?.trim();
+        const actionText =
+          review.action === 'reject' ? 'rejected the plan' : 'requested more planning';
         return {
           content: [
             {
               type: 'text' as const,
-              text: `User rejected the plan written to ${planPath}. Revise based on their feedback and call exit_plan_mode again when ready.`
+              text: `User ${actionText} for ${planPath}.${feedback ? ` Feedback: ${feedback}` : ''} Revise based on their feedback and call exit_plan_mode again when ready.`
             }
           ],
           details: undefined

--- a/resources/pi-extensions/fleet-plan-mode.ts
+++ b/resources/pi-extensions/fleet-plan-mode.ts
@@ -6,7 +6,7 @@
  * swapped to hide write/exec tools via pi.setActiveTools, with a
  * tool_call blocker as a final policy gate. The LLM
  * produces a markdown plan via the exit_plan_mode tool; the plan is
- * written to docs/plans/YYYY-MM-DD-<topic>.md after the user approves.
+ * written to docs/plans/YYYY-MM-DD-<topic>.md and opened in Fleet's plan modal.
  *
  * Also registers pi's built-in grep/find/ls tools, which are not in
  * the default toolset.
@@ -27,6 +27,16 @@ import {
   getPlanModeActiveTools,
   shouldBlockPlanModeTool
 } from './fleet-plan-mode-policy.ts';
+
+type FleetBridgeClient = {
+  send: (type: string, payload: Record<string, unknown>) => Promise<unknown>;
+  onEvent: (handler: (type: string, payload: Record<string, unknown>) => void) => void;
+  isConnected: () => boolean;
+};
+
+declare global {
+  var __fleetBridge: FleetBridgeClient | null; // eslint-disable-line no-var
+}
 
 const PLAN_MODE_STATUS_KEY = 'plan-mode';
 const PLAN_MODE_STATUS_LABEL = '📋 Plan Mode';
@@ -49,7 +59,7 @@ You are in plan mode. Only read-only tools are available (write, edit, bash, fle
 
 7. YAGNI. Plan only what's asked. No speculative features, flags, or abstractions.
 
-When you have enough that another engineer could execute without asking questions, call exit_plan_mode.`;
+When you have enough that another engineer could execute without asking questions, call exit_plan_mode. The plan will be written to a markdown file and opened in Fleet for review; do not include the full plan in a normal assistant message.`;
 
 const PLAN_MODE_BLOCK_REASON =
   'Plan mode is active — this tool is disabled. Use read-only tools to investigate, then call exit_plan_mode with your plan.';
@@ -171,7 +181,7 @@ export default function (pi: ExtensionAPI): void {
     name: 'exit_plan_mode',
     label: 'Exit Plan Mode',
     description:
-      'Call this when you have a complete plan ready for the user. Writes the plan to docs/plans/YYYY-MM-DD-<topic>.md after the user approves it, then exits plan mode so you can begin executing. Pass the plan as markdown in `plan` and a short kebab-case topic in `topic`.',
+      'Call this when you have a complete plan ready for the user. Writes the plan to docs/plans/YYYY-MM-DD-<topic>.md, opens it in Fleet for review, then exits plan mode after approval so you can begin executing. Pass the plan as markdown in `plan` and a short kebab-case topic in `topic`.',
     parameters: ExitPlanModeParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -200,26 +210,37 @@ export default function (pi: ExtensionAPI): void {
       }
 
       const planPath = resolvePlanPath(ctx.cwd, params.topic);
-      const approved = await ctx.ui.confirm(
-        'Approve plan?',
-        buildPlanApprovalMessage(planPath, params.plan)
-      );
+      const dir = join(ctx.cwd, 'docs', 'plans');
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      writeFileSync(planPath, params.plan, 'utf-8');
+
+      const bridge = globalThis.__fleetBridge;
+      if (bridge?.isConnected()) {
+        try {
+          await bridge.send('pi.plan_open', { path: planPath });
+        } catch (err) {
+          ctx.ui.notify(
+            `Plan written, but Fleet could not open it: ${err instanceof Error ? err.message : String(err)}`,
+            'warning'
+          );
+        }
+      } else {
+        ctx.ui.notify('Plan written, but Fleet bridge is not connected.', 'warning');
+      }
+
+      const approved = await ctx.ui.confirm('Approve plan?', buildPlanApprovalMessage(planPath));
 
       if (!approved) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: 'User rejected the plan. Revise based on their feedback and call exit_plan_mode again when ready.'
+              text: `User rejected the plan written to ${planPath}. Revise based on their feedback and call exit_plan_mode again when ready.`
             }
           ],
           details: undefined
         };
       }
-
-      const dir = join(ctx.cwd, 'docs', 'plans');
-      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-      writeFileSync(planPath, params.plan, 'utf-8');
 
       leavePlanMode(ctx);
 

--- a/src/main/__tests__/fleet-cli.test.ts
+++ b/src/main/__tests__/fleet-cli.test.ts
@@ -204,6 +204,23 @@ describe('--help via runCLI', () => {
   });
 });
 
+// ── fleet pi plan_open tests ─────────────────────────────────────────────────
+
+describe('fleet pi plan_open', () => {
+  it('requires a path before opening the socket', async () => {
+    const out = await runCLI(['pi', 'plan_open'], '/tmp/no-socket.sock');
+    expect(out).toBe('Usage: fleet pi plan_open <path>');
+  });
+
+  it('validates the plan file exists before opening the socket', async () => {
+    const out = await runCLI(
+      ['pi', 'plan_open', '/tmp/fleet-missing-plan.md'],
+      '/tmp/no-socket.sock'
+    );
+    expect(out).toContain('file not found');
+  });
+});
+
 // ── FleetCLI.send basic tests ─────────────────────────────────────────────────
 
 describe('FleetCLI.send', () => {

--- a/src/main/__tests__/fleet-plan-mode-extension.test.ts
+++ b/src/main/__tests__/fleet-plan-mode-extension.test.ts
@@ -27,14 +27,11 @@ describe('fleet plan mode extension helpers', () => {
     expect(shouldBlockPlanModeTool('read')).toBe(false);
   });
 
-  it('builds approval text with target path and a 60-line plan preview', () => {
-    const plan = Array.from({ length: 62 }, (_, index) => `Line ${index + 1}`).join('\n');
-    const message = buildPlanApprovalMessage('/repo/docs/plans/2026-04-25-demo.md', plan);
+  it('builds approval text with target path but no plan body', () => {
+    const message = buildPlanApprovalMessage('/repo/docs/plans/2026-04-25-demo.md');
 
-    expect(message).toContain('Path: /repo/docs/plans/2026-04-25-demo.md');
-    expect(message).toContain('Line 1');
-    expect(message).toContain('Line 60');
-    expect(message).not.toContain('Line 61');
-    expect(message).toContain('(2 more lines)');
+    expect(message).toContain('/repo/docs/plans/2026-04-25-demo.md');
+    expect(message).toContain('Review it in the Fleet plan modal');
+    expect(message).not.toContain('Line 1');
   });
 });

--- a/src/main/fleet-bridge.ts
+++ b/src/main/fleet-bridge.ts
@@ -125,11 +125,11 @@ export class FleetBridgeServer {
     }
   }
 
-  sendEvent(paneId: string, event: BridgeEvent): void {
+  sendEvent(paneId: string, event: BridgeEvent): boolean {
     const ws = this.connections.get(paneId);
-    if (ws && ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify(event));
-    }
+    if (!ws || ws.readyState !== ws.OPEN) return false;
+    ws.send(JSON.stringify(event));
+    return true;
   }
 
   broadcast(event: BridgeEvent): void {

--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -356,6 +356,7 @@ Manage images and open files from the terminal.
 | images | Generate, edit, and transform AI images. |
 | open | Open files or images in Fleet tabs. |
 | annotate | Visually annotate web page elements for AI agents. |
+| pi | Open Pi agent tabs and Pi plan documents. |
 
 ## Examples
 
@@ -391,6 +392,27 @@ Supports code files and common image formats (png, jpg, gif, webp, svg).
 fleet open src/main.ts
 fleet open screenshot.png diagram.svg
 fleet open ./README.md ../other-repo/notes.txt
+\`\`\``,
+
+  pi: `# fleet pi
+
+Open Pi agent tabs and Pi plan documents.
+
+## Usage
+
+  fleet pi
+  fleet pi plan_open <path>
+
+## Commands
+
+  fleet pi                  Open a Pi agent tab for the current directory.
+  fleet pi plan_open <path> Open a markdown plan in Fleet's plan modal.
+
+## Examples
+
+\`\`\`bash
+fleet pi
+fleet pi plan_open docs/plans/2026-04-27-my-plan.md
 \`\`\``,
 
   annotate: `# fleet annotate
@@ -583,9 +605,29 @@ export async function runCLI(
 
   // ── Top-level "pi" command ───────────────────────────────────────────────
   if (group === 'pi') {
-    const cwd = process.cwd();
-    const command = 'pi.open';
-    const args: Record<string, unknown> = { cwd };
+    const command = action === 'plan_open' ? 'pi.plan_open' : 'pi.open';
+    const args: Record<string, unknown> = {};
+    let successMessage = 'Opening Pi agent in Fleet';
+
+    if (command === 'pi.plan_open') {
+      const rawPath = rest[0];
+      if (!rawPath) return 'Usage: fleet pi plan_open <path>';
+
+      const resolved = resolve(rawPath);
+      if (!existsSync(resolved)) return `Error: file not found: ${rawPath}`;
+      if (statSync(resolved).isDirectory()) {
+        return `Error: directories not supported, use a file path: ${rawPath}`;
+      }
+      if (isBinaryBlockedFilePath(resolved)) {
+        return `Error: unsupported binary file: ${rawPath}`;
+      }
+
+      args.path = resolved;
+      successMessage = `Opened plan in Fleet: ${resolved}`;
+    } else {
+      if (action) return `Unknown pi command: ${action}\n\nUsage: fleet pi [plan_open <path>]`;
+      args.cwd = process.cwd();
+    }
 
     const cli = new FleetCLI(sockPath);
     try {
@@ -595,7 +637,7 @@ export async function runCLI(
       if (!response.ok) {
         return `Error: ${response.error ?? 'Unknown error'}`;
       }
-      return 'Opening Pi agent in Fleet';
+      return successMessage;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('ECONNREFUSED') || msg.includes('ENOENT')) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -349,6 +349,11 @@ void app.whenReady().then(async () => {
       mainWindow.webContents.send(IPC_CHANNELS.PI_OPEN, payload);
     }
   });
+  socketSupervisor.on('pi-plan-open', (payload: unknown) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(IPC_CHANNELS.PI_PLAN_OPEN, payload);
+    }
+  });
   socketSupervisor.start().catch((err: unknown) => {
     log.error('socket-supervisor failed to start', {
       error: err instanceof Error ? err.message : String(err)
@@ -356,7 +361,8 @@ void app.whenReady().then(async () => {
   });
 
   // Start Fleet bridge for Pi agent extensions
-  fleetBridge.onRequest(async (type, payload, _paneId) => {
+  fleetBridge.onRequest(async (type, payload) => {
+    await Promise.resolve();
     switch (type) {
       case 'file.open': {
         const rawPath = typeof payload.path === 'string' ? payload.path : '';
@@ -378,6 +384,24 @@ void app.whenReady().then(async () => {
           });
         }
         return { ok: true, paneType };
+      }
+      case 'pi.plan_open': {
+        const rawPath = typeof payload.path === 'string' ? payload.path : '';
+        if (!rawPath) throw new Error('pi.plan_open requires a path');
+
+        const planPath = resolve(rawPath);
+        if (!existsSync(planPath)) throw new Error(`file not found: ${planPath}`);
+        if (statSync(planPath).isDirectory()) {
+          throw new Error(`directories not supported, use a file path: ${planPath}`);
+        }
+        if (isBinaryBlockedFilePath(planPath)) {
+          throw new Error(`unsupported binary file: ${planPath}`);
+        }
+
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(IPC_CHANNELS.PI_PLAN_OPEN, { path: planPath });
+        }
+        return { ok: true };
       }
       default:
         throw new Error(`Unknown bridge command: ${type}`);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -361,7 +361,7 @@ void app.whenReady().then(async () => {
   });
 
   // Start Fleet bridge for Pi agent extensions
-  fleetBridge.onRequest(async (type, payload) => {
+  fleetBridge.onRequest(async (type, payload, paneId) => {
     await Promise.resolve();
     switch (type) {
       case 'file.open': {
@@ -387,6 +387,7 @@ void app.whenReady().then(async () => {
       }
       case 'pi.plan_open': {
         const rawPath = typeof payload.path === 'string' ? payload.path : '';
+        const requestId = typeof payload.requestId === 'string' ? payload.requestId : undefined;
         if (!rawPath) throw new Error('pi.plan_open requires a path');
 
         const planPath = resolve(rawPath);
@@ -399,7 +400,11 @@ void app.whenReady().then(async () => {
         }
 
         if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send(IPC_CHANNELS.PI_PLAN_OPEN, { path: planPath });
+          mainWindow.webContents.send(IPC_CHANNELS.PI_PLAN_OPEN, {
+            path: planPath,
+            paneId,
+            requestId
+          });
         }
         return { ok: true };
       }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -26,7 +26,8 @@ import type {
   FileGrepRequest,
   LogEntry,
   WorktreeCreateRequest,
-  WorktreeRemoveRequest
+  WorktreeRemoveRequest,
+  PiPlanResponseRequest
 } from '../shared/ipc-api';
 import type { Workspace } from '../shared/types';
 import type { PtyManager } from './pty-manager';
@@ -547,6 +548,17 @@ export function registerIpcHandlers(
     version: piAgentManager.getVersion(),
     installed: piAgentManager.isInstalled()
   }));
+
+  ipcMain.handle(IPC_CHANNELS.PI_PLAN_RESPOND, (_event, req: PiPlanResponseRequest) => {
+    fleetBridge.sendEvent(req.paneId, {
+      type: 'pi.plan_response',
+      payload: {
+        requestId: req.requestId,
+        action: req.action,
+        feedback: req.feedback ?? ''
+      }
+    });
+  });
 
   ipcMain.handle(IPC_CHANNELS.PI_CHECK_UPDATES, async () => {
     return piAgentManager.checkForUpdates();

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -550,7 +550,7 @@ export function registerIpcHandlers(
   }));
 
   ipcMain.handle(IPC_CHANNELS.PI_PLAN_RESPOND, (_event, req: PiPlanResponseRequest) => {
-    fleetBridge.sendEvent(req.paneId, {
+    const delivered = fleetBridge.sendEvent(req.paneId, {
       type: 'pi.plan_response',
       payload: {
         requestId: req.requestId,
@@ -558,6 +558,9 @@ export function registerIpcHandlers(
         feedback: req.feedback ?? ''
       }
     });
+    if (!delivered) {
+      throw new Error('Pi plan response could not be delivered. The Pi bridge is disconnected.');
+    }
   });
 
   ipcMain.handle(IPC_CHANNELS.PI_CHECK_UPDATES, async () => {

--- a/src/main/socket-server.ts
+++ b/src/main/socket-server.ts
@@ -379,6 +379,13 @@ export class SocketServer extends EventEmitter {
         return { ok: true };
       }
 
+      case 'pi.plan_open': {
+        const planPath = typeof args.path === 'string' ? args.path : undefined;
+        if (!planPath) throw new CodedError('pi.plan_open requires a path', 'BAD_REQUEST');
+        this.emit('pi-plan-open', { path: planPath });
+        return { ok: true };
+      }
+
       default: {
         throw new CodedError(`Unknown command: ${command}`, 'NOT_FOUND');
       }

--- a/src/main/socket-supervisor.ts
+++ b/src/main/socket-supervisor.ts
@@ -101,6 +101,10 @@ export class SocketSupervisor extends EventEmitter {
       this.emit('pi-open', ...args);
     });
 
+    server.on('pi-plan-open', (...args: unknown[]) => {
+      this.emit('pi-plan-open', ...args);
+    });
+
     server.on('server-error', (err: Error) => {
       log.error('Server error detected', { error: err.message });
       this.restart().catch((e) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,7 @@ import type {
   WorktreeRemoveRequest,
   PiOpenPayload,
   PiPlanOpenPayload,
+  PiPlanResponseRequest,
   PiLaunchConfig
 } from '../shared/ipc-api';
 import type {
@@ -335,6 +336,8 @@ const fleetApi = {
       onChannel(IPC_CHANNELS.PI_OPEN, callback),
     onPlanOpen: (callback: (payload: PiPlanOpenPayload) => void): Unsubscribe =>
       onChannel(IPC_CHANNELS.PI_PLAN_OPEN, callback),
+    respondToPlan: async (req: PiPlanResponseRequest): Promise<void> =>
+      typedInvoke(IPC_CHANNELS.PI_PLAN_RESPOND, req),
     getLaunchConfig: async (paneId: string): Promise<PiLaunchConfig> =>
       typedInvoke(IPC_CHANNELS.PI_LAUNCH_CONFIG, { paneId }),
     getVersion: async (): Promise<{ version: string | null; installed: boolean }> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,7 @@ import type {
   WorktreeCreateResponse,
   WorktreeRemoveRequest,
   PiOpenPayload,
+  PiPlanOpenPayload,
   PiLaunchConfig
 } from '../shared/ipc-api';
 import type {
@@ -332,6 +333,8 @@ const fleetApi = {
   pi: {
     onOpen: (callback: (payload: PiOpenPayload) => void): Unsubscribe =>
       onChannel(IPC_CHANNELS.PI_OPEN, callback),
+    onPlanOpen: (callback: (payload: PiPlanOpenPayload) => void): Unsubscribe =>
+      onChannel(IPC_CHANNELS.PI_PLAN_OPEN, callback),
     getLaunchConfig: async (paneId: string): Promise<PiLaunchConfig> =>
       typedInvoke(IPC_CHANNELS.PI_LAUNCH_CONFIG, { paneId }),
     getVersion: async (): Promise<{ version: string | null; installed: boolean }> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,6 +28,7 @@ import { TelescopeModal } from './components/Telescope/TelescopeModal';
 import { ImageGallery } from './components/ImageGallery/ImageGallery';
 import { AnnotateTab } from './components/AnnotateTab';
 import { PiTab } from './components/PiTab';
+import { PiPlanModal } from './components/PiPlanModal';
 import { AnnotateModal } from './components/AnnotateModal';
 import { ToastContainer } from './components/ToastContainer';
 
@@ -130,6 +131,7 @@ export function App(): React.JSX.Element {
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
   const [clipboardHistoryOpen, setClipboardHistoryOpen] = useState(false);
   const [telescopeOpen, setTelescopeOpen] = useState(false);
+  const [planModalPath, setPlanModalPath] = useState<string | null>(null);
   const [updateReady, setUpdateReady] = useState(false);
 
   // Load settings on startup
@@ -260,6 +262,16 @@ export function App(): React.JSX.Element {
   useEffect(() => {
     const cleanup = window.fleet.pi.onOpen((payload) => {
       useWorkspaceStore.getState().addPiTab(payload.cwd);
+    });
+    return () => {
+      cleanup();
+    };
+  }, []);
+
+  // Open Pi plan document in modal via IPC (fleet pi plan_open / Pi extension bridge)
+  useEffect(() => {
+    const cleanup = window.fleet.pi.onPlanOpen((payload) => {
+      setPlanModalPath(payload.path);
     });
     return () => {
       cleanup();
@@ -859,6 +871,7 @@ export function App(): React.JSX.Element {
         cwd={focusedPaneCwd ?? window.fleet.homeDir}
       />
       <AnnotateModal open={false} onClose={() => {}} />
+      <PiPlanModal filePath={planModalPath} onClose={() => setPlanModalPath(null)} />
       <ToastContainer />
     </div>
   );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -31,6 +31,7 @@ import { PiTab } from './components/PiTab';
 import { PiPlanModal } from './components/PiPlanModal';
 import { AnnotateModal } from './components/AnnotateModal';
 import { ToastContainer } from './components/ToastContainer';
+import type { PiPlanOpenPayload } from '../../shared/ipc-api';
 
 function MiniSidebarTooltip({
   label,
@@ -131,7 +132,7 @@ export function App(): React.JSX.Element {
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
   const [clipboardHistoryOpen, setClipboardHistoryOpen] = useState(false);
   const [telescopeOpen, setTelescopeOpen] = useState(false);
-  const [planModalPath, setPlanModalPath] = useState<string | null>(null);
+  const [planModal, setPlanModal] = useState<PiPlanOpenPayload | null>(null);
   const [updateReady, setUpdateReady] = useState(false);
 
   // Load settings on startup
@@ -271,7 +272,7 @@ export function App(): React.JSX.Element {
   // Open Pi plan document in modal via IPC (fleet pi plan_open / Pi extension bridge)
   useEffect(() => {
     const cleanup = window.fleet.pi.onPlanOpen((payload) => {
-      setPlanModalPath(payload.path);
+      setPlanModal(payload);
     });
     return () => {
       cleanup();
@@ -871,7 +872,7 @@ export function App(): React.JSX.Element {
         cwd={focusedPaneCwd ?? window.fleet.homeDir}
       />
       <AnnotateModal open={false} onClose={() => {}} />
-      <PiPlanModal filePath={planModalPath} onClose={() => setPlanModalPath(null)} />
+      <PiPlanModal plan={planModal} onClose={() => setPlanModal(null)} />
       <ToastContainer />
     </div>
   );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -33,6 +33,8 @@ import { AnnotateModal } from './components/AnnotateModal';
 import { ToastContainer } from './components/ToastContainer';
 import type { PiPlanOpenPayload } from '../../shared/ipc-api';
 
+type PiPlanModalEntry = PiPlanOpenPayload & { modalId: string };
+
 function MiniSidebarTooltip({
   label,
   children
@@ -132,7 +134,7 @@ export function App(): React.JSX.Element {
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
   const [clipboardHistoryOpen, setClipboardHistoryOpen] = useState(false);
   const [telescopeOpen, setTelescopeOpen] = useState(false);
-  const [planModal, setPlanModal] = useState<PiPlanOpenPayload | null>(null);
+  const [planModalQueue, setPlanModalQueue] = useState<PiPlanModalEntry[]>([]);
   const [updateReady, setUpdateReady] = useState(false);
 
   // Load settings on startup
@@ -272,11 +274,16 @@ export function App(): React.JSX.Element {
   // Open Pi plan document in modal via IPC (fleet pi plan_open / Pi extension bridge)
   useEffect(() => {
     const cleanup = window.fleet.pi.onPlanOpen((payload) => {
-      setPlanModal(payload);
+      setPlanModalQueue((queue) => [...queue, { ...payload, modalId: crypto.randomUUID() }]);
     });
     return () => {
       cleanup();
     };
+  }, []);
+
+  const activePlanModal = planModalQueue[0] ?? null;
+  const closeActivePlanModal = useCallback(() => {
+    setPlanModalQueue((queue) => queue.slice(1));
   }, []);
 
   // Auto-updater
@@ -872,7 +879,11 @@ export function App(): React.JSX.Element {
         cwd={focusedPaneCwd ?? window.fleet.homeDir}
       />
       <AnnotateModal open={false} onClose={() => {}} />
-      <PiPlanModal plan={planModal} onClose={() => setPlanModal(null)} />
+      <PiPlanModal
+        plan={activePlanModal}
+        contentKey={activePlanModal ? activePlanModal.modalId : undefined}
+        onClose={closeActivePlanModal}
+      />
       <ToastContainer />
     </div>
   );

--- a/src/renderer/src/components/PiPlanModal.tsx
+++ b/src/renderer/src/components/PiPlanModal.tsx
@@ -1,32 +1,71 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ExternalLink, X } from 'lucide-react';
 import { MarkdownPane } from './MarkdownPane';
 import { useWorkspaceStore } from '../store/workspace-store';
 import { getPaneTypeForFilePath } from '../../../shared/file-open';
+import type { PiPlanAction, PiPlanOpenPayload } from '../../../shared/ipc-api';
 
 type PiPlanModalProps = {
-  filePath: string | null;
+  plan: PiPlanOpenPayload | null;
   onClose: () => void;
 };
 
-export function PiPlanModal({ filePath, onClose }: PiPlanModalProps): React.JSX.Element | null {
+export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Element | null {
   const modalRef = useRef<HTMLDivElement>(null);
   const paneIdRef = useRef(`pi-plan-modal-${crypto.randomUUID()}`);
+  const [feedback, setFeedback] = useState('');
+  const [submittingAction, setSubmittingAction] = useState<PiPlanAction | null>(null);
   const openFileInTab = useWorkspaceStore((s) => s.openFileInTab);
+
+  const filePath = plan?.path ?? null;
+  const canRespond = Boolean(plan?.paneId && plan.requestId);
 
   useEffect(() => {
     if (!filePath) return;
+    setFeedback('');
+    setSubmittingAction(null);
     modalRef.current?.focus();
-  }, [filePath]);
+  }, [filePath, plan?.requestId]);
+
+  const respond = useCallback(
+    async (action: PiPlanAction) => {
+      if (!plan?.paneId || !plan.requestId) {
+        onClose();
+        return;
+      }
+
+      setSubmittingAction(action);
+      try {
+        await window.fleet.pi.respondToPlan({
+          paneId: plan.paneId,
+          requestId: plan.requestId,
+          action,
+          feedback: feedback.trim() || undefined
+        });
+      } finally {
+        setSubmittingAction(null);
+        onClose();
+      }
+    },
+    [feedback, onClose, plan?.paneId, plan?.requestId]
+  );
+
+  const closeOrContinue = useCallback(() => {
+    if (canRespond) {
+      void respond('continue');
+      return;
+    }
+    onClose();
+  }, [canRespond, onClose, respond]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.preventDefault();
       event.stopPropagation();
-      onClose();
+      closeOrContinue();
     },
-    [onClose]
+    [closeOrContinue]
   );
 
   const handleOpenInTab = useCallback(() => {
@@ -40,13 +79,15 @@ export function PiPlanModal({ filePath, onClose }: PiPlanModalProps): React.JSX.
     ]);
   }, [filePath, openFileInTab]);
 
+  const footerHint = useMemo(() => {
+    if (!canRespond) return 'Opened from Fleet CLI. This modal is read-only.';
+    return 'Approve exits plan mode. Reject or Continue keeps Pi in plan mode with your feedback.';
+  }, [canRespond]);
+
   if (!filePath) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onMouseDown={onClose}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div
         ref={modalRef}
         tabIndex={-1}
@@ -71,7 +112,7 @@ export function PiPlanModal({ filePath, onClose }: PiPlanModalProps): React.JSX.
               Open as tab
             </button>
             <button
-              onClick={onClose}
+              onClick={closeOrContinue}
               className="p-1 text-neutral-500 hover:text-white rounded hover:bg-neutral-800 transition-colors"
               aria-label="Close plan modal"
             >
@@ -81,6 +122,42 @@ export function PiPlanModal({ filePath, onClose }: PiPlanModalProps): React.JSX.
         </div>
         <div className="flex-1 min-h-0 overflow-hidden">
           <MarkdownPane key={filePath} paneId={paneIdRef.current} filePath={filePath} />
+        </div>
+        <div className="shrink-0 border-t border-neutral-800 bg-neutral-950/90 p-3 space-y-2">
+          <div className="text-xs text-neutral-500">{footerHint}</div>
+          {canRespond && (
+            <>
+              <textarea
+                value={feedback}
+                onChange={(event) => setFeedback(event.target.value)}
+                placeholder="Optional feedback for Pi..."
+                className="w-full h-16 resize-none rounded border border-neutral-700 bg-neutral-900 px-2 py-1.5 text-sm text-neutral-200 placeholder-neutral-600 outline-none focus:border-teal-500"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => void respond('reject')}
+                  disabled={submittingAction !== null}
+                  className="px-3 py-1.5 text-sm rounded border border-red-900/60 text-red-300 hover:bg-red-950/40 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {submittingAction === 'reject' ? 'Rejecting…' : 'Reject'}
+                </button>
+                <button
+                  onClick={() => void respond('continue')}
+                  disabled={submittingAction !== null}
+                  className="px-3 py-1.5 text-sm rounded border border-neutral-700 text-neutral-300 hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {submittingAction === 'continue' ? 'Sending…' : 'Continue planning'}
+                </button>
+                <button
+                  onClick={() => void respond('approve')}
+                  disabled={submittingAction !== null}
+                  className="px-3 py-1.5 text-sm rounded bg-teal-600 text-white hover:bg-teal-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {submittingAction === 'approve' ? 'Approving…' : 'Approve'}
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/PiPlanModal.tsx
+++ b/src/renderer/src/components/PiPlanModal.tsx
@@ -7,13 +7,19 @@ import type { PiPlanAction, PiPlanOpenPayload } from '../../../shared/ipc-api';
 
 type PiPlanModalProps = {
   plan: PiPlanOpenPayload | null;
+  contentKey?: string;
   onClose: () => void;
 };
 
-export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Element | null {
+export function PiPlanModal({
+  plan,
+  contentKey,
+  onClose
+}: PiPlanModalProps): React.JSX.Element | null {
   const modalRef = useRef<HTMLDivElement>(null);
   const paneIdRef = useRef(`pi-plan-modal-${crypto.randomUUID()}`);
   const [feedback, setFeedback] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [submittingAction, setSubmittingAction] = useState<PiPlanAction | null>(null);
   const openFileInTab = useWorkspaceStore((s) => s.openFileInTab);
 
@@ -23,6 +29,7 @@ export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Elem
   useEffect(() => {
     if (!filePath) return;
     setFeedback('');
+    setSubmitError(null);
     setSubmittingAction(null);
     modalRef.current?.focus();
   }, [filePath, plan?.requestId]);
@@ -35,6 +42,7 @@ export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Elem
       }
 
       setSubmittingAction(action);
+      setSubmitError(null);
       try {
         await window.fleet.pi.respondToPlan({
           paneId: plan.paneId,
@@ -42,9 +50,11 @@ export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Elem
           action,
           feedback: feedback.trim() || undefined
         });
+        onClose();
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : String(err));
       } finally {
         setSubmittingAction(null);
-        onClose();
       }
     },
     [feedback, onClose, plan?.paneId, plan?.requestId]
@@ -121,12 +131,21 @@ export function PiPlanModal({ plan, onClose }: PiPlanModalProps): React.JSX.Elem
           </div>
         </div>
         <div className="flex-1 min-h-0 overflow-hidden">
-          <MarkdownPane key={filePath} paneId={paneIdRef.current} filePath={filePath} />
+          <MarkdownPane
+            key={`${filePath}:${plan?.requestId ?? contentKey ?? ''}`}
+            paneId={paneIdRef.current}
+            filePath={filePath}
+          />
         </div>
         <div className="shrink-0 border-t border-neutral-800 bg-neutral-950/90 p-3 space-y-2">
           <div className="text-xs text-neutral-500">{footerHint}</div>
           {canRespond && (
             <>
+              {submitError && (
+                <div className="rounded border border-red-900/60 bg-red-950/30 px-2 py-1.5 text-xs text-red-300">
+                  {submitError}
+                </div>
+              )}
               <textarea
                 value={feedback}
                 onChange={(event) => setFeedback(event.target.value)}

--- a/src/renderer/src/components/PiPlanModal.tsx
+++ b/src/renderer/src/components/PiPlanModal.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { ExternalLink, X } from 'lucide-react';
+import { MarkdownPane } from './MarkdownPane';
+import { useWorkspaceStore } from '../store/workspace-store';
+import { getPaneTypeForFilePath } from '../../../shared/file-open';
+
+type PiPlanModalProps = {
+  filePath: string | null;
+  onClose: () => void;
+};
+
+export function PiPlanModal({ filePath, onClose }: PiPlanModalProps): React.JSX.Element | null {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const paneIdRef = useRef(`pi-plan-modal-${crypto.randomUUID()}`);
+  const openFileInTab = useWorkspaceStore((s) => s.openFileInTab);
+
+  useEffect(() => {
+    if (!filePath) return;
+    modalRef.current?.focus();
+  }, [filePath]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    },
+    [onClose]
+  );
+
+  const handleOpenInTab = useCallback(() => {
+    if (!filePath) return;
+    openFileInTab([
+      {
+        path: filePath,
+        paneType: getPaneTypeForFilePath(filePath),
+        label: filePath.split('/').pop() ?? filePath
+      }
+    ]);
+  }, [filePath, openFileInTab]);
+
+  if (!filePath) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onMouseDown={onClose}
+    >
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+        className="bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl flex flex-col outline-none overflow-hidden"
+        style={{ width: 'calc(100vw - 64px)', height: 'calc(100vh - 48px)' }}
+      >
+        <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-800 shrink-0 bg-neutral-950/90">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-white">Pi Plan</div>
+            <div className="text-xs text-neutral-500 font-mono truncate" title={filePath}>
+              {filePath}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={handleOpenInTab}
+              className="inline-flex items-center gap-1.5 px-2 py-1 text-xs text-neutral-400 hover:text-white rounded hover:bg-neutral-800 transition-colors"
+            >
+              <ExternalLink size={14} />
+              Open as tab
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1 text-neutral-500 hover:text-white rounded hover:bg-neutral-800 transition-colors"
+              aria-label="Close plan modal"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <MarkdownPane key={filePath} paneId={paneIdRef.current} filePath={filePath} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/PiPlanModal.tsx
+++ b/src/renderer/src/components/PiPlanModal.tsx
@@ -61,12 +61,12 @@ export function PiPlanModal({
   );
 
   const closeOrContinue = useCallback(() => {
-    if (canRespond) {
+    if (canRespond && !submitError) {
       void respond('continue');
       return;
     }
     onClose();
-  }, [canRespond, onClose, respond]);
+  }, [canRespond, onClose, respond, submitError]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -142,8 +142,14 @@ export function PiPlanModal({
           {canRespond && (
             <>
               {submitError && (
-                <div className="rounded border border-red-900/60 bg-red-950/30 px-2 py-1.5 text-xs text-red-300">
-                  {submitError}
+                <div className="flex items-center justify-between gap-3 rounded border border-red-900/60 bg-red-950/30 px-2 py-1.5 text-xs text-red-300">
+                  <span>{submitError}</span>
+                  <button
+                    onClick={onClose}
+                    className="shrink-0 rounded px-2 py-0.5 text-red-200 hover:bg-red-900/40"
+                  >
+                    Dismiss
+                  </button>
                 </div>
               )}
               <textarea

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -26,8 +26,19 @@ export type PiOpenPayload = {
   cwd: string;
 };
 
+export type PiPlanAction = 'approve' | 'reject' | 'continue';
+
 export type PiPlanOpenPayload = {
   path: string;
+  paneId?: string;
+  requestId?: string;
+};
+
+export type PiPlanResponseRequest = {
+  paneId: string;
+  requestId: string;
+  action: PiPlanAction;
+  feedback?: string;
 };
 
 export type PiLaunchConfig = {

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -26,6 +26,10 @@ export type PiOpenPayload = {
   cwd: string;
 };
 
+export type PiPlanOpenPayload = {
+  path: string;
+};
+
 export type PiLaunchConfig = {
   cmd: string;
 };

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -93,6 +93,7 @@ export const IPC_CHANNELS = {
   ANNOTATE_DELETE: 'annotate:delete',
   // Pi Agent
   PI_OPEN: 'pi:open',
+  PI_PLAN_OPEN: 'pi:plan-open',
   PI_LAUNCH_CONFIG: 'pi:launch-config',
   PI_VERSION: 'pi:version',
   PI_CHECK_UPDATES: 'pi:check-updates',

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -94,6 +94,7 @@ export const IPC_CHANNELS = {
   // Pi Agent
   PI_OPEN: 'pi:open',
   PI_PLAN_OPEN: 'pi:plan-open',
+  PI_PLAN_RESPOND: 'pi:plan-respond',
   PI_LAUNCH_CONFIG: 'pi:launch-config',
   PI_VERSION: 'pi:version',
   PI_CHECK_UPDATES: 'pi:check-updates',


### PR DESCRIPTION
## Summary
- write Pi plan-mode output to markdown files and open them via Fleet's plan modal instead of previewing the plan in Pi stdout
- add `fleet pi plan_open <path>` plus bridge/IPC plumbing
- add a MarkdownPane-backed Pi plan modal with an "Open as tab" action

## Verification
- `npm run typecheck`
- `npm test -- --run src/main/__tests__/fleet-plan-mode-extension.test.ts src/main/__tests__/fleet-cli.test.ts`
- targeted eslint on changed files (no new errors; existing warnings remain)