### PR TITLE
fix(kanban): run work tasks under a worker profile, not orchestrator

### DIFF
--- a/docs/learnings/2026-05-31-kanban-orchestrator-work-mode-give-up.md
+++ b/docs/learnings/2026-05-31-kanban-orchestrator-work-mode-give-up.md
@@ -1,0 +1,60 @@
+# Kanban: orchestrator-assigned work tasks die and "give up"
+
+## Symptom
+
+A rune worker is spawned for a task, exits almost immediately, gets respawned, and
+after 2 attempts the dispatcher logs `task gave up {failures:2}` and the task lands in
+`blocked`. Reported as "the file attachments system broke the worker" — attachments were
+a red herring; they were just what was being tested.
+
+```
+09:35:03 [kanban-spawn] spawned rune worker {taskId:024a1988, pid:544435}
+09:35:37 [kanban-spawn] spawned rune worker {taskId:024a1988, pid:544449}
+09:36:10 [kanban-dispatcher] task gave up {taskId:024a1988, failures:2}
+```
+
+## Root cause
+
+`rune --prompt <text>` runs **one turn and exits**. For a `work` run to count as
+successful, the agent must call `kanban_complete` (or `kanban_block`) during that turn —
+otherwise `KanbanDispatcher.reclaim()` sees the exited pid (`isAlive` false, no recent
+heartbeat), records a failure, and after `failureLimit` (2) calls `giveUp`, which sets
+status `blocked`.
+
+The instruction to call `kanban_complete` comes **only from a worker-role profile
+persona** (`src/shared/constants.ts` default `default`/worker profile). The work-mode
+prompt in `spawn-worker.ts` `buildPrompt` does *not* include it — unlike `decompose`
+("call kanban_complete with a one-line summary") and `specify` ("call kanban_update").
+
+The failing task was assigned to the **`orchestrator`** profile but dispatched in
+**`work`** mode (`claimAndSpawn` hardcodes `mode: 'work'`; a task only runs in decompose
+mode if armed with a `pendingMode`). The orchestrator persona says *"do not implement the
+work yourself"* and never mentions `kanban_complete`, so the worker answered and exited
+without completing → reclaimed as a dead worker → gave up.
+
+Confirmed against the runtime DB: `work` + `default` profile → `completed`; `work` +
+`orchestrator` profile → `reclaimed`/`gave_up`; `decompose` + `orchestrator` →
+`completed`.
+
+## Fix
+
+`resolveWorkProfile(profiles, assignee)` in `spawn-worker.ts`: a work run uses the
+assigned profile only if its role is `worker`; otherwise it falls back to the first
+worker-role profile so the `kanban_complete` instruction always reaches the agent.
+`index.ts` calls it in the `work` branch and `log.warn`s when it overrides an explicit
+assignee.
+
+Subtleties caught in review:
+- The fallback must be **role-filtered**. An earlier `?? find(p => p.name === 'default')`
+  clause was only reachable when no worker-role profile existed, so it could *only*
+  return a non-worker `default` and re-introduce the bug. Removed it — `find(role ===
+  'worker')` already matches a worker named `default`.
+- `fellBack` keys off `assignee != null`, not the resolved profile, so a typo'd/deleted
+  assignee name still logs the substitution warning.
+
+## Known limitation (not fixed)
+
+If the user deletes *all* worker-role profiles, `resolveWorkProfile` returns `null` and
+`buildWorkerInvocation` still passes `--profile <original-assignee>` to rune. The shipped
+defaults always include a worker profile, so this only occurs in a deliberately broken
+config.

--- a/src/main/__tests__/kanban-spawn-worker.test.ts
+++ b/src/main/__tests__/kanban-spawn-worker.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { buildWorkerInvocation } from '../kanban/spawn-worker';
+import { buildWorkerInvocation, resolveWorkProfile } from '../kanban/spawn-worker';
+import type { WorkerProfile } from '../../shared/types';
 
 const ROOT = join(tmpdir(), `fleet-kanban-spawn-test-${Date.now()}`);
 
@@ -219,6 +220,66 @@ describe('buildWorkerInvocation', () => {
     });
     const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
     expect(prompt).not.toContain('attached by the user');
+  });
+
+  describe('resolveWorkProfile', () => {
+    const worker: WorkerProfile = {
+      name: 'default',
+      role: 'worker',
+      model: '',
+      skills: [],
+      instructions: 'call kanban_complete'
+    };
+    const orchestrator: WorkerProfile = {
+      name: 'orchestrator',
+      role: 'orchestrator',
+      model: '',
+      skills: [],
+      instructions: 'do not implement the work yourself'
+    };
+    const coder: WorkerProfile = { ...worker, name: 'coder' };
+
+    it('keeps a worker-role assignee as-is', () => {
+      const r = resolveWorkProfile([worker, coder, orchestrator], 'coder');
+      expect(r.profile).toBe(coder);
+      expect(r.fellBack).toBe(false);
+    });
+
+    it('falls back to a worker profile when the assignee is an orchestrator', () => {
+      const r = resolveWorkProfile([worker, orchestrator], 'orchestrator');
+      expect(r.profile?.role).toBe('worker');
+      expect(r.fellBack).toBe(true);
+    });
+
+    it('uses a worker profile (no fallback flag) when there is no assignee', () => {
+      const r = resolveWorkProfile([worker, orchestrator], null);
+      expect(r.profile).toBe(worker);
+      expect(r.fellBack).toBe(false);
+    });
+
+    it('falls back (with flag) when the assignee names a non-existent profile', () => {
+      const r = resolveWorkProfile([worker, orchestrator], 'ghost');
+      expect(r.profile).toBe(worker);
+      expect(r.fellBack).toBe(true);
+    });
+
+    it('picks the first worker-role profile as the fallback', () => {
+      const r = resolveWorkProfile([orchestrator, worker, coder], 'orchestrator');
+      expect(r.profile).toBe(worker);
+    });
+
+    it('never returns a non-worker profile even when one is named "default"', () => {
+      const orchestratorDefault: WorkerProfile = { ...orchestrator, name: 'default' };
+      const r = resolveWorkProfile([orchestratorDefault, orchestrator], 'orchestrator');
+      expect(r.profile).toBeNull();
+      expect(r.fellBack).toBe(true);
+    });
+
+    it('returns null when no worker profile exists at all', () => {
+      const r = resolveWorkProfile([orchestrator], 'orchestrator');
+      expect(r.profile).toBeNull();
+      expect(r.fellBack).toBe(true);
+    });
   });
 
   it('does not include attachments in decompose mode', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,7 +50,7 @@ import type { DispatcherConfig } from './kanban/kanban-dispatcher';
 import { setKanbanSettingsApplier } from './kanban/kanban-settings-bridge';
 import { KanbanMcpServer } from './kanban/kanban-mcp-server';
 import { prepareWorkspace } from './kanban/workspace';
-import { spawnRuneWorker } from './kanban/spawn-worker';
+import { spawnRuneWorker, resolveWorkProfile } from './kanban/spawn-worker';
 import { registerKanbanIpc } from './kanban/kanban-ipc';
 import { KanbanCommands } from './kanban/kanban-commands';
 import pkg from 'electron-updater';
@@ -805,7 +805,15 @@ void app.whenReady().then(async () => {
       let profile: WorkerProfile | null;
       let roster: Array<{ name: string; description: string }> | undefined;
       if (mode === 'work') {
-        profile = task.assignee ? (profiles.find((p) => p.name === task.assignee) ?? null) : null;
+        const resolved = resolveWorkProfile(profiles, task.assignee);
+        profile = resolved.profile;
+        if (resolved.fellBack) {
+          log.warn('kanban: non-worker profile assigned to work task; using worker fallback', {
+            taskId: task.id,
+            assignee: task.assignee,
+            fallback: profile?.name ?? null
+          });
+        }
       } else {
         // decompose/specify: run as an orchestrator profile; offer the worker roster.
         profile =

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -69,6 +69,27 @@ function buildPrompt(input: BuildWorkerInput): string {
   return `work kanban task ${task.id}: ${task.title}\n\n${task.body}` + attachmentsSection(input);
 }
 
+/**
+ * Picks the profile for a `work` run. Work runs must use a worker-role persona — it's
+ * the one instructed to call kanban_complete when done. An orchestrator persona ("do not
+ * implement the work yourself") would do the work, exit without completing, and get
+ * reclaimed as a dead worker, looping until the task is given up. When the assignee is an
+ * orchestrator (or doesn't resolve to a worker), fall back to the first worker-role
+ * profile so the run can actually complete. `fellBack` is true whenever an explicit
+ * assignee was overridden (a non-worker role, or a name with no matching profile).
+ */
+export function resolveWorkProfile(
+  profiles: WorkerProfile[],
+  assignee: string | null
+): { profile: WorkerProfile | null; fellBack: boolean } {
+  const assigned = assignee ? (profiles.find((p) => p.name === assignee) ?? null) : null;
+  if (assigned?.role === 'worker') return { profile: assigned, fellBack: false };
+  // Role-filter the fallback: a profile *named* "default" but with an orchestrator role
+  // must not slip through, or we'd re-introduce the very bug this guards against.
+  const profile = profiles.find((p) => p.role === 'worker') ?? null;
+  return { profile, fellBack: assignee != null };
+}
+
 /** Computes the rune invocation and writes the scoped mcp.json into the workspace. */
 export function buildWorkerInvocation(input: BuildWorkerInput): WorkerInvocation {
   const runeDir = join(input.workspace, '.rune');


### PR DESCRIPTION
## Problem

A kanban task assigned to the **`orchestrator`** profile but dispatched in **`work`** mode caused the rune worker to spawn, exit, respawn, and after 2 attempts `task gave up` → status `blocked`. Originally reported as an attachments bug, but attachments were a red herring (just what was being tested).

### Root cause

`rune --prompt` runs **one turn and exits**. A `work` run only succeeds if the agent calls `kanban_complete` during that turn — otherwise `KanbanDispatcher.reclaim()` sees the dead pid, records a failure, and after `failureLimit` (2) calls `giveUp`.

That instruction comes **only from a worker-role profile persona**. The work-mode prompt (unlike decompose/specify) doesn't include it. The orchestrator persona says *"do not implement the work yourself"* and never mentions `kanban_complete`, so an orchestrator-assigned work task always died.

Confirmed against the runtime DB:

| mode | profile | outcome |
|------|---------|---------|
| work | default | ✅ completed |
| work | **orchestrator** | reclaimed → gave up (`blocked`) |
| decompose | orchestrator | ✅ completed |

## Fix

`resolveWorkProfile(profiles, assignee)` in `spawn-worker.ts`: a work run keeps the assigned profile only if its role is `worker`; otherwise it falls back to the first worker-role profile so the `kanban_complete` instruction always reaches the agent. `index.ts` calls it in the work branch and `log.warn`s when an explicit assignee is overridden. Decompose/specify paths untouched.

The fallback is **role-filtered** so a profile *named* `default` but with an orchestrator role can't slip through and re-introduce the bug.

## Validation

Reviewed by 3 parallel agents (blast-radius, logical soundness, conventions). Two real findings from review were folded in: the role-unguarded fallback clause (removed) and the `fellBack` warn gap for typo'd assignees (fixed).

- `kanban-spawn-worker.test.ts`: **18 pass** (7 new `resolveWorkProfile` cases incl. orchestrator-named-`default` and non-existent assignee)
- Full suite: **495 pass** · `npm run typecheck` clean · lint clean on changed files
- Documented in `docs/learnings/2026-05-31-kanban-orchestrator-work-mode-give-up.md`

## Known limitation (documented, not fixed)

If *all* worker-role profiles are deleted, the fallback is `null` and rune still gets `--profile <assignee>`. Shipped defaults always include a worker profile, so this only occurs in a deliberately broken config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)