### PR TITLE
feat(kanban): worktree review gate + integration actions

### DIFF
--- a/docs/superpowers/specs/2026-06-01-kanban-worktree-review-parity-design.md
+++ b/docs/superpowers/specs/2026-06-01-kanban-worktree-review-parity-design.md
@@ -1,0 +1,173 @@
+# Kanban Worktree Review & Integration — Parity Path Design
+
+**Status:** Implemented (all 3 phases) · **Date:** 2026-06-01
+
+Closes the gap between "an agent did work in a worktree" and "that work is
+preserved, reviewable, and integrated." Brings Fleet to parity with the Hermes
+`review-required` convention and the vibe-kanban review/merge UX, while solving
+the "how do child tasks build on the same feature?" problem.
+
+---
+
+## Problem
+
+Today, when an orchestrator decomposes a Triage task into children:
+
+- **Each task gets its own isolated worktree + branch** `kanban/<taskId>`, branched
+  from the repo's current HEAD — *not* from the parent's branch. Verified in
+  `workspace.ts:70-75` (`git worktree add <dir> -b kanban/<id>`, no start-point)
+  and `kanban-mcp-server.ts:471-476` (children inherit only `repoPath`). So
+  children **cannot see each other's work**, and a dependent child branches from
+  stale base, not from its prerequisite's output.
+- **No work is preserved automatically.** `kanban_complete`
+  (`kanban-mcp-server.ts:349-361`) just sets `done` — there is **no commit, no
+  diff, no PR, no merge** anywhere (`workspace.ts` only does `worktree add` /
+  `worktree remove` / `branch -D`).
+- **Archive destroys unmerged work.** The archive path
+  (`kanban-commands.ts:255-273`) force-deletes the branch (`git branch -D`) even
+  when it is unmerged — silent data loss.
+
+## The core insight
+
+Make a worktree task's terminal state **"merged into its base branch = done"**
+instead of "`kanban_complete` = done." This single change solves both halves of
+the problem:
+
+1. **Preservation** — work is committed on `kanban/<id>`, reviewable in-app, and
+   merged on explicit human approval.
+2. **Build-on-each-other** — a dependent child gates on `parent = done`, and
+   `done` now means *merged into base*. Because children branch from base HEAD,
+   the child's worktree automatically contains the parent's merged work. **No
+   stacked branches, no shared mutable worktree** — the human-merge gate
+   sequences it correctly.
+
+This is strictly less machinery than a shared/stacked feature branch, and it
+matches what Hermes (`review-required` block + diff/PR-url comment, human
+review) and vibe-kanban (To Do → In Progress → **Review** → Done, inline diff,
+PR creation) already do. The broader 2026 ecosystem consensus is the same:
+decompose into non-overlapping slices, isolate per worktree, integrate via
+PR-per-task or orchestrated sequential merge with explicit human/CI gates —
+nobody auto-builds stacked feature branches because the merge complexity is
+exactly what bites.
+
+## What exists today (verified anchors)
+
+- `TaskStatus` (`kanban-types.ts:1-9`): `triage|scheduled|todo|ready|running|blocked|done|archived` — **no review state**.
+- A partial `review-required` notion already exists, but only for *failure*:
+  exit-3 (model went quiet) → `blocked` with `result = "review-required: …"`,
+  run outcome `incomplete` (`kanban-dispatcher.ts:84-92`). Successful completion
+  has none of this.
+- `GitService.getFullStatus(cwd)` (`git-service.ts:18`) already returns
+  `{ isRepo, branch, files, diff }` — the diff-review primitive; already used by
+  `GitChangesModal.tsx`.
+- A scratch "leftovers" safety net already exists (`kanban-commands.ts:276-283`)
+  — the pattern to mirror for unmerged branches.
+- Dependency gating: promotion to `ready` requires all parents
+  `status IN ('done','archived')` (`kanban-store.ts` `promotableTodoTasks`).
+
+---
+
+## Design — three independently shippable phases
+
+### Phase 1 — Stop losing work *(safety only, no UX change)*
+
+1. **Auto-commit on run finish.** New best-effort `finalizeWorktree(task)` in
+   `workspace.ts`: `git -C <worktree> add -A && git commit -m "kanban/<id>: <title>"`
+   when there are changes. Called from the `kanban_complete` handler
+   (`kanban-mcp-server.ts:349`) **and** the review-required/exit-3 path
+   (`kanban-dispatcher.ts:84`) so both a clean finish and a quiet exit leave a
+   committed branch. Never throws.
+2. **Branch retention on archive.** In `removeWorktree()` (`workspace.ts:108`),
+   only `git branch -D` when the branch is merged into base
+   (`git branch --merged <base>`); if unmerged, keep the branch (remove only the
+   worktree dir to free disk) and emit an `unmerged_branch_kept` event —
+   mirroring the scratch-leftovers net.
+
+**Verify:** uncommitted agent edits → branch ends with a commit; archiving an
+unmerged task keeps the branch + logs a warning event.
+
+### Phase 2 — Review column + in-app diff
+
+3. **`'review'` status + column.** Add `'review'` to `TaskStatus`
+   (`kanban-types.ts:1`) and `COLUMNS` (`kanban-utils.ts`) between Running and
+   Done. No DB migration (status is TEXT). `kanban_complete` routes **worktree**
+   tasks → `review`; scratch/dir research tasks still → `done` (nothing to
+   merge). Gating stays `status IN ('done','archived')`, so `review` correctly
+   blocks dependent children until accepted.
+4. **Review metadata comment.** After the Phase-1 commit, `kanban_complete`
+   posts `review-required: N files (+x/−y) on kanban/<id>` (from
+   `getFullStatus`) and stores it in run metadata — Hermes' "structured metadata
+   in a comment first."
+5. **Diff in the drawer.** New IPC `kanban:gitStatus(taskId)` →
+   `GitService.getFullStatus(task.workspacePath)` → render changed files + diff
+   (reuse `GitChangesModal.tsx`).
+
+**Verify:** completing a worktree task lands it in **Review**; drawer shows the
+diff.
+
+### Phase 3 — Three review actions
+
+**Prereq:** track `base_branch` (repo HEAD captured at worktree creation) — one
+additive column (`schema.ts` migration). Sets the merge target and the
+child-branch base.
+
+On a Review task the drawer shows three buttons:
+
+| Button | Action | Result |
+|---|---|---|
+| **Make Pull Request** | `git push -u origin kanban/<id>` then `gh pr create --base <base> --head kanban/<id>`. Capture PR URL → comment + run metadata. Graceful error if no remote / `gh` missing. | Task → `done`; PR link in drawer. |
+| **Merge to `<base>`** | Merge `kanban/<id>` into `base_branch` locally, done conservatively so it never disturbs the user's current checkout (e.g. merge via a scratch worktree on base). On conflict: abort, stay in `review`, comment the conflict (user resolves manually or **Unblock** to re-spawn with the thread). | Clean → `done` + "merged" comment. |
+| **Do Nothing** | No git op. Marks task accepted (`done`) but preserves branch + worktree; drawer surfaces `kanban/<id>` + worktree path for manual checkout. | Task → `done`; branch untouched. |
+
+6. **Children branch from `base_branch` HEAD.** Small change to the inherit
+   logic (`kanban-mcp-server.ts:471`) + `prepareWorkspace`. This is what makes a
+   dependent child **inherit merged-parent work** without stacked branches.
+
+**Verify:** **Merge** → base contains the commit; a gated child's worktree then
+contains the parent's merged files. **PR** → branch pushed, PR URL shown.
+**Do Nothing** → branch present, task `done`, nothing merged.
+
+---
+
+## Consequence worth flagging
+
+The "children build on each other" guarantee only holds when the parent's work
+actually reaches `base_branch` HEAD **locally** before the child is claimed:
+
+- **Merge to `<base>`** → immediate; works.
+- **Make Pull Request** → only after the PR is merged on GitHub *and* the local
+  base is updated.
+- **Do Nothing** → never enters base, so a dependent child branches from clean
+  base and won't see it (expected — "Do Nothing" = "I'll handle this branch
+  myself").
+
+---
+
+## Out of scope (the autonomy path, later)
+
+Auto-merge on green CI, agents auto-fixing CI / auto-addressing review comments,
+true stacked branches. Parity = **commit + review + human-decided integration**.
+
+## Files in play
+
+`kanban-types.ts`, `kanban-utils.ts`, `workspace.ts`, `kanban-mcp-server.ts`,
+`kanban-dispatcher.ts`, `kanban-commands.ts`, `schema.ts` (base_branch
+migration), `index.ts` + preload (git IPC), `KanbanDrawer.tsx`; reuse
+`GitChangesModal.tsx` + `git-service.ts`.
+
+## Decisions locked
+
+- Dedicated **Review** column (not overloading `blocked`).
+- Three review actions: **Make Pull Request**, **Merge to `<base>`**, **Do Nothing**.
+- Phasing: 1 (safety) → 2 (review + diff) → 3 (actions + base-branch); each
+  independently shippable.
+
+## See also
+
+- `docs/kanban-hermes-parity-backlog.md` — remaining Hermes capabilities.
+- `docs/superpowers/specs/2026-05-30-kanban-board-design.md:286-293` — Hermes
+  worktree & `review-required` convention.
+- `docs/learnings/2026-06-01-kanban-headless-worker-persistence.md` — exit-3 /
+  `review-required` classification this design builds on.
+</content>
+</invoke>

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -142,6 +142,13 @@ describe('KanbanCommands status + assign', () => {
     );
   });
 
+  it('setManualStatus rejects review for a non-worktree task', () => {
+    const { store, commands } = makeCommands();
+    const t = commands.create({ title: 'x', status: 'todo', workspaceKind: 'scratch' });
+    expect(() => commands.setManualStatus(t.id, 'review')).toThrowError(/worktree/);
+    expect(store.getTask(t.id)?.status).toBe('todo');
+  });
+
   it('block sets blocked with a reason; complete sets done with a result', () => {
     const { store, commands } = makeCommands();
     const t = commands.create({ title: 'x', status: 'todo' });

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -372,7 +372,7 @@ describe('KanbanCommands archive worktree teardown', () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  it('archiving a worktree task via setManualStatus removes its worktree and branch', () => {
+  it('archiving a worktree task via setManualStatus removes its worktree and a merged branch', () => {
     const { store, commands } = makeCommands();
     const repo = makeRepo('cmd-rm1');
     const task = store.createTask({
@@ -388,7 +388,8 @@ describe('KanbanCommands archive worktree teardown', () => {
       worktreesRoot: join(TEST_DIR, 'worktrees'),
       repoPath: repo
     });
-    store.setWorkspace(task.id, wt.path, wt.branchName);
+    // Branch is at main's HEAD (no new commits) → merged → archive deletes it.
+    store.setWorkspace(task.id, wt.path, wt.branchName, wt.baseBranch);
     expect(existsSync(wt.path)).toBe(true);
 
     commands.setManualStatus(task.id, 'archived');
@@ -399,6 +400,40 @@ describe('KanbanCommands archive worktree teardown', () => {
       encoding: 'utf8'
     });
     expect(branches.trim()).toBe('');
+  });
+
+  it('archiving a worktree task keeps an unmerged branch and logs an event', () => {
+    const { store, commands } = makeCommands();
+    const repo = makeRepo('cmd-rm-keep');
+    const task = store.createTask({
+      title: 'wt task',
+      status: 'todo',
+      workspaceKind: 'worktree',
+      repoPath: repo
+    });
+    const wt = prepareWorkspace({
+      kind: 'worktree',
+      taskId: task.id,
+      workspacesRoot: TEST_DIR,
+      worktreesRoot: join(TEST_DIR, 'worktrees'),
+      repoPath: repo
+    });
+    store.setWorkspace(task.id, wt.path, wt.branchName, wt.baseBranch);
+    // Commit unmerged work on the branch so archive must preserve it.
+    writeFileSync(join(wt.path, 'feature.txt'), 'work');
+    execFileSync('git', ['-C', wt.path, 'add', '-A']);
+    execFileSync('git', ['-C', wt.path, 'commit', '-q', '-m', 'feature']);
+
+    commands.setManualStatus(task.id, 'archived');
+
+    expect(store.getTask(task.id)?.status).toBe('archived');
+    expect(existsSync(wt.path)).toBe(false); // dir freed
+    const branches = execFileSync('git', ['-C', repo, 'branch', '--list', `kanban/${task.id}`], {
+      encoding: 'utf8'
+    });
+    expect(branches.trim()).not.toBe(''); // branch preserved
+    const events = store.listEvents(task.id);
+    expect(events.some((e) => e.kind === 'unmerged_branch_kept')).toBe(true);
   });
 
   it('archiving a scratch task does not throw and just archives', () => {

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -25,23 +25,23 @@ describe('KanbanStore', () => {
 
   it('creates the db file and runs migrations', () => {
     expect(existsSync(DB_PATH)).toBe(true);
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
   });
 
-  it('fresh db is created at v7 with the new columns', () => {
+  it('fresh db is created at v8 with the new columns', () => {
     // Fresh store is already v6; assert the new columns exist and are nullable/defaulted.
     const t = store.createTask({ title: 'x' });
     expect(store.getTask(t.id)?.pendingMode).toBeNull();
     const run = store.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
   });
 
-  it('fresh db is created at v7 and persists repoPath', () => {
+  it('fresh db is created at v8 and persists repoPath', () => {
     const t = store.createTask({ title: 'wt', workspaceKind: 'worktree', repoPath: '/src/repo' });
     expect(store.getTask(t.id)?.repoPath).toBe('/src/repo');
     expect(store.getTask(t.id)?.workspaceKind).toBe('worktree');
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
   });
 
   it('repoPath defaults to null when omitted', () => {
@@ -60,7 +60,7 @@ describe('KanbanStore', () => {
     const s = new KanbanStore(v2Path);
     const t = s.createTask({ title: 'x', workspaceKind: 'worktree', repoPath: '/r' });
     expect(s.getTask(t.id)?.repoPath).toBe('/r');
-    expect(s.schemaVersion()).toBe(7);
+    expect(s.schemaVersion()).toBe(8);
     s.close();
   });
 
@@ -85,7 +85,7 @@ describe('KanbanStore', () => {
     raw.close();
 
     const s = new KanbanStore(preV5Path);
-    expect(s.schemaVersion()).toBe(7);
+    expect(s.schemaVersion()).toBe(8);
     expect(s.getTask('abc')?.boardId).toBe('default');
     expect(s.listBoards().map((b) => b.slug)).toEqual(['default']);
     s.close();
@@ -107,7 +107,7 @@ describe('KanbanStore', () => {
     expect(s.getTask(t.id)?.pendingMode).toBeNull();
     const run = s.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(s.schemaVersion()).toBe(7);
+    expect(s.schemaVersion()).toBe(8);
     s.close();
   });
 
@@ -504,7 +504,7 @@ describe('KanbanStore schema v6 migration', () => {
     raw.close();
 
     const store = new KanbanStore(dbPath, { now: () => 1000 });
-    expect(store.schemaVersion()).toBe(7);
+    expect(store.schemaVersion()).toBe(8);
     const t = store.getTask('legacy1');
     expect(t?.title).toBe('old task');
     expect(t?.scheduleKind).toBeNull();

--- a/src/main/__tests__/kanban-workspace.test.ts
+++ b/src/main/__tests__/kanban-workspace.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { prepareWorkspace, cleanupWorkspace, removeWorktree } from '../kanban/workspace';
+import {
+  prepareWorkspace,
+  cleanupWorkspace,
+  removeWorktree,
+  mergeWorktreeToBase
+} from '../kanban/workspace';
 
 const ROOT = join(tmpdir(), `fleet-kanban-ws-test-${process.pid}`);
 const WT_ROOT = join(ROOT, 'worktrees');
@@ -260,6 +265,109 @@ describe('kanban workspace', () => {
       encoding: 'utf8'
     });
     expect(branches.trim()).not.toBe(''); // branch preserved
+  });
+
+  // Commit `feat.txt` on a freshly-created worktree task branch and return its base.
+  function worktreeWithCommit(repo: string, taskId: string): { branch: string; base: string } {
+    const { path, branchName, baseBranch } = prepareWorkspace({
+      kind: 'worktree',
+      taskId,
+      workspacesRoot: ROOT,
+      worktreesRoot: WT_ROOT,
+      repoPath: repo
+    });
+    writeFileSync(join(path, 'feat.txt'), 'feature');
+    execFileSync('git', ['-C', path, 'add', '-A']);
+    execFileSync('git', ['-C', path, 'commit', '-q', '-m', 'feat']);
+    return { branch: branchName as string, base: baseBranch as string };
+  }
+
+  it('mergeWorktreeToBase merges in place when the base branch is checked out (common case)', () => {
+    const repo = makeRepo('mg1');
+    const { branch, base } = worktreeWithCommit(repo, 'm1');
+    // `main` is checked out at repo — a push would be refused; we merge in place.
+    const res = mergeWorktreeToBase({
+      repoPath: repo,
+      branchName: branch,
+      baseBranch: base,
+      worktreeParentDir: WT_ROOT,
+      taskId: 'm1',
+      title: 'feature'
+    });
+    expect(res.ok).toBe(true);
+    // Base advanced: the feature file is now in the repo's checkout.
+    expect(existsSync(join(repo, 'feat.txt'))).toBe(true);
+  });
+
+  it('mergeWorktreeToBase refuses when the checked-out base has uncommitted changes', () => {
+    const repo = makeRepo('mg2');
+    const { branch, base } = worktreeWithCommit(repo, 'm2');
+    writeFileSync(join(repo, 'dirty.txt'), 'wip'); // dirty the base checkout
+    const res = mergeWorktreeToBase({
+      repoPath: repo,
+      branchName: branch,
+      baseBranch: base,
+      worktreeParentDir: WT_ROOT,
+      taskId: 'm2',
+      title: 'feature'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/uncommitted/);
+    expect(existsSync(join(repo, 'feat.txt'))).toBe(false); // base untouched
+  });
+
+  it('mergeWorktreeToBase reports a conflict and restores the base checkout', () => {
+    const repo = makeRepo('mg3');
+    writeFileSync(join(repo, 'shared.txt'), 'base\n');
+    execFileSync('git', ['-C', repo, 'add', '-A']);
+    execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'add shared']);
+    const { path, branchName, baseBranch } = prepareWorkspace({
+      kind: 'worktree',
+      taskId: 'm3',
+      workspacesRoot: ROOT,
+      worktreesRoot: WT_ROOT,
+      repoPath: repo
+    });
+    // Task branch and main diverge on the same file → merge conflict.
+    writeFileSync(join(path, 'shared.txt'), 'feature\n');
+    execFileSync('git', ['-C', path, 'add', '-A']);
+    execFileSync('git', ['-C', path, 'commit', '-q', '-m', 'feature change']);
+    writeFileSync(join(repo, 'shared.txt'), 'mainline\n');
+    execFileSync('git', ['-C', repo, 'add', '-A']);
+    execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'main change']);
+    const res = mergeWorktreeToBase({
+      repoPath: repo,
+      branchName: branchName as string,
+      baseBranch: baseBranch as string,
+      worktreeParentDir: WT_ROOT,
+      taskId: 'm3',
+      title: 'feature'
+    });
+    expect(res.ok).toBe(false);
+    expect(res.conflict).toBe(true);
+    // The aborted merge left the base checkout clean.
+    const status = execFileSync('git', ['-C', repo, 'status', '--porcelain'], { encoding: 'utf8' });
+    expect(status.trim()).toBe('');
+  });
+
+  it('mergeWorktreeToBase pushes into base when it is not checked out anywhere', () => {
+    const repo = makeRepo('mg4');
+    const { branch, base } = worktreeWithCommit(repo, 'm4');
+    // Park the repo off main so the base ref is not checked out anywhere.
+    execFileSync('git', ['-C', repo, 'checkout', '-q', '-b', 'parking']);
+    const res = mergeWorktreeToBase({
+      repoPath: repo,
+      branchName: branch,
+      baseBranch: base,
+      worktreeParentDir: WT_ROOT,
+      taskId: 'm4',
+      title: 'feature'
+    });
+    expect(res.ok).toBe(true);
+    const tree = execFileSync('git', ['-C', repo, 'ls-tree', '--name-only', 'main'], {
+      encoding: 'utf8'
+    });
+    expect(tree).toMatch(/feat\.txt/);
   });
 
   it('removeWorktree keeps the branch when no base is known (conservative)', () => {

--- a/src/main/__tests__/kanban-workspace.test.ts
+++ b/src/main/__tests__/kanban-workspace.test.ts
@@ -172,7 +172,7 @@ describe('kanban workspace', () => {
     ).toThrow();
   });
 
-  it('removeWorktree removes the worktree dir and deletes its branch', () => {
+  it('removeWorktree removes the worktree dir and deletes a merged branch', () => {
     const repo = makeRepo('rm1');
     const { path, branchName } = prepareWorkspace({
       kind: 'worktree',
@@ -182,7 +182,14 @@ describe('kanban workspace', () => {
       repoPath: repo
     });
     expect(existsSync(path)).toBe(true);
-    removeWorktree({ repoPath: repo, workspacePath: path, branchName });
+    // Branch is at main's HEAD (no new commits) → merged → safe to delete.
+    const { branchKept } = removeWorktree({
+      repoPath: repo,
+      workspacePath: path,
+      branchName,
+      baseBranch: 'main'
+    });
+    expect(branchKept).toBe(false);
     expect(existsSync(path)).toBe(false);
     const branches = execFileSync('git', ['-C', repo, 'branch', '--list', 'kanban/r1'], {
       encoding: 'utf8'
@@ -199,8 +206,9 @@ describe('kanban workspace', () => {
       worktreesRoot: WT_ROOT,
       repoPath: repo
     });
+    // Uncommitted change is not on the branch tip, so the branch is still merged.
     writeFileSync(join(path, 'dirty.txt'), 'uncommitted');
-    removeWorktree({ repoPath: repo, workspacePath: path, branchName });
+    removeWorktree({ repoPath: repo, workspacePath: path, branchName, baseBranch: 'main' });
     expect(existsSync(path)).toBe(false);
     const branches = execFileSync('git', ['-C', repo, 'branch', '--list', 'kanban/r2'], {
       encoding: 'utf8'
@@ -208,7 +216,7 @@ describe('kanban workspace', () => {
     expect(branches.trim()).toBe('');
   });
 
-  it('removeWorktree does not throw when the dir was deleted out-of-band, and still drops the branch', () => {
+  it('removeWorktree does not throw when the dir was deleted out-of-band, and still drops a merged branch', () => {
     const repo = makeRepo('rm3');
     const { path, branchName } = prepareWorkspace({
       kind: 'worktree',
@@ -218,10 +226,56 @@ describe('kanban workspace', () => {
       repoPath: repo
     });
     rmSync(path, { recursive: true, force: true }); // simulate manual deletion
-    expect(() => removeWorktree({ repoPath: repo, workspacePath: path, branchName })).not.toThrow();
+    expect(() =>
+      removeWorktree({ repoPath: repo, workspacePath: path, branchName, baseBranch: 'main' })
+    ).not.toThrow();
     const branches = execFileSync('git', ['-C', repo, 'branch', '--list', 'kanban/r3'], {
       encoding: 'utf8'
     });
     expect(branches.trim()).toBe('');
+  });
+
+  it('removeWorktree keeps an unmerged branch (preserves the work)', () => {
+    const repo = makeRepo('rm4');
+    const { path, branchName } = prepareWorkspace({
+      kind: 'worktree',
+      taskId: 'r4',
+      workspacesRoot: ROOT,
+      worktreesRoot: WT_ROOT,
+      repoPath: repo
+    });
+    // Add a commit on the branch that is NOT in main → unmerged.
+    writeFileSync(join(path, 'feature.txt'), 'work');
+    execFileSync('git', ['-C', path, 'add', '-A']);
+    execFileSync('git', ['-C', path, 'commit', '-q', '-m', 'feature work']);
+    const { branchKept } = removeWorktree({
+      repoPath: repo,
+      workspacePath: path,
+      branchName,
+      baseBranch: 'main'
+    });
+    expect(branchKept).toBe(true);
+    expect(existsSync(path)).toBe(false); // dir still freed
+    const branches = execFileSync('git', ['-C', repo, 'branch', '--list', 'kanban/r4'], {
+      encoding: 'utf8'
+    });
+    expect(branches.trim()).not.toBe(''); // branch preserved
+  });
+
+  it('removeWorktree keeps the branch when no base is known (conservative)', () => {
+    const repo = makeRepo('rm5');
+    const { path, branchName } = prepareWorkspace({
+      kind: 'worktree',
+      taskId: 'r5',
+      workspacesRoot: ROOT,
+      worktreesRoot: WT_ROOT,
+      repoPath: repo
+    });
+    const { branchKept } = removeWorktree({ repoPath: repo, workspacePath: path, branchName });
+    expect(branchKept).toBe(true);
+    const branches = execFileSync('git', ['-C', repo, 'branch', '--list', 'kanban/r5'], {
+      encoding: 'utf8'
+    });
+    expect(branches.trim()).not.toBe('');
   });
 });

--- a/src/main/fleet-cli.ts
+++ b/src/main/fleet-cli.ts
@@ -577,7 +577,7 @@ Manage the Kanban board from the terminal. Requires the Fleet app to be running.
 
 ## Options
 
-  --status <status>   Filter list by status (triage|todo|ready|running|blocked|done|archived).
+  --status <status>   Filter list by status (triage|todo|ready|running|blocked|review|done|archived).
   --format json       Emit raw JSON instead of a table.
 
 ## Examples

--- a/src/main/git-service.ts
+++ b/src/main/git-service.ts
@@ -15,7 +15,7 @@ export class GitService {
     }
   }
 
-  async getFullStatus(cwd: string): Promise<GitStatusPayload> {
+  async getFullStatus(cwd: string, baseRef?: string): Promise<GitStatusPayload> {
     const git = this.getGit(cwd);
 
     // Check if it's a repo first
@@ -26,6 +26,12 @@ export class GitService {
       }
     } catch {
       return { isRepo: false, branch: '', files: [], diff: '' };
+    }
+
+    // When a base ref is given, show the branch's committed work (base...HEAD)
+    // rather than working-tree changes — a finalized worktree has a clean tree.
+    if (baseRef) {
+      return this.getRefDiff(git, baseRef);
     }
 
     try {
@@ -91,6 +97,62 @@ export class GitService {
         }
       }
 
+      return { isRepo: true, branch, files, diff };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { isRepo: true, branch: '', files: [], diff: '', error: message };
+    }
+  }
+
+  /** Committed diff of the current branch against `baseRef` (three-dot: base...HEAD). */
+  private async getRefDiff(git: SimpleGit, baseRef: string): Promise<GitStatusPayload> {
+    const range = `${baseRef}...HEAD`;
+    try {
+      const branchInfo = await git.branch();
+      const branch = branchInfo.current;
+      const numstatRaw = await git.raw(['diff', range, '--numstat']);
+      const nameStatusRaw = await git.raw(['diff', range, '--name-status']);
+
+      const numstatMap = new Map<string, { insertions: number; deletions: number }>();
+      for (const line of numstatRaw.split('\n')) {
+        const parts = line.split('\t');
+        if (parts.length === 3) {
+          // Renames appear as `dir/{old => new}/file` or a whole-path `old => new`
+          // in the path column; collapse to the new path so name-status lookups match.
+          let path = parts[2];
+          const brace = path.match(/^(.*)\{.* => (.*?)\}(.*)$/);
+          if (brace) path = brace[1] + brace[2] + brace[3];
+          else if (path.includes(' => ')) path = path.split(' => ')[1];
+          numstatMap.set(path, {
+            insertions: parseInt(parts[0]) || 0,
+            deletions: parseInt(parts[1]) || 0
+          });
+        }
+      }
+
+      const files: GitFileStatus[] = [];
+      for (const line of nameStatusRaw.split('\n')) {
+        if (!line.trim()) continue;
+        const parts = line.split('\t');
+        const code = parts[0]?.[0] ?? 'M';
+        const path = parts[parts.length - 1];
+        const stats = numstatMap.get(path) ?? { insertions: 0, deletions: 0 };
+        files.push({
+          path,
+          status:
+            code === 'A'
+              ? 'added'
+              : code === 'D'
+                ? 'deleted'
+                : code === 'R'
+                  ? 'renamed'
+                  : 'modified',
+          insertions: stats.insertions,
+          deletions: stats.deletions
+        });
+      }
+
+      const diff = await git.diff([range]);
       return { isRepo: true, branch, files, diff };
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -826,7 +826,10 @@ void app.whenReady().then(async () => {
         worktreesRoot: join(KANBAN_HOME, 'worktrees'),
         workspacePath: task.workspacePath ?? undefined,
         repoPath: task.repoPath ?? undefined,
-        branchName: task.branchName ?? undefined
+        branchName: task.branchName ?? undefined,
+        // A dependent child branches from its parent's base so it inherits the
+        // parent's merged work; top-level tasks fall back to the repo's HEAD.
+        startPoint: task.baseBranch ?? undefined
       });
       // Persist the workspace path for worktree AND scratch tasks so the artifact MCP handler,
       // archive warning, and reveal/discard actions all resolve the same durable path.
@@ -834,7 +837,7 @@ void app.whenReady().then(async () => {
         (task.workspaceKind === 'worktree' || task.workspaceKind === 'scratch') &&
         task.workspacePath == null
       ) {
-        kanbanStore!.setWorkspace(task.id, prepared.path, prepared.branchName);
+        kanbanStore!.setWorkspace(task.id, prepared.path, prepared.branchName, prepared.baseBranch);
       }
       return prepared.path;
     },

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -284,8 +284,8 @@ export function registerIpcHandlers(
     return gitService.checkIsRepo(cwd);
   });
 
-  ipcMain.handle(IPC_CHANNELS.GIT_STATUS, async (_event, cwd: string) => {
-    return gitService.getFullStatus(cwd);
+  ipcMain.handle(IPC_CHANNELS.GIT_STATUS, async (_event, cwd: string, baseRef?: string) => {
+    return gitService.getFullStatus(cwd, baseRef);
   });
 
   // System-level dependency check (app-wide pre-checks screen)

--- a/src/main/kanban/kanban-commands.ts
+++ b/src/main/kanban/kanban-commands.ts
@@ -24,7 +24,9 @@ import type {
 import { createSwarm as buildSwarm } from './kanban-swarm';
 import { validateSchedule, computeNextRun } from './schedule';
 import { createLogger } from '../logger';
-import { removeWorktree } from './workspace';
+import { removeWorktree, mergeWorktreeToBase, pushAndCreatePr } from './workspace';
+import { dirname } from 'path';
+import type { KanbanReviewActionResult } from '../../shared/ipc-api';
 import { removeAttachmentFile } from './attachments';
 import { deriveBoardSlug } from './board-slug';
 
@@ -36,6 +38,7 @@ export const MANUAL_STATUSES: TaskStatus[] = [
   'todo',
   'ready',
   'blocked',
+  'review',
   'done',
   'archived'
 ];
@@ -259,11 +262,17 @@ export class KanbanCommands {
       task.repoPath
     ) {
       try {
-        removeWorktree({
+        const { branchKept } = removeWorktree({
           repoPath: task.repoPath,
           workspacePath: task.workspacePath,
-          branchName: task.branchName
+          branchName: task.branchName,
+          baseBranch: task.baseBranch
         });
+        // Unmerged work is preserved (branch kept) rather than `git branch -D`'d;
+        // surface it so the user knows a dangling branch is theirs to recover.
+        if (branchKept && task.branchName) {
+          this.store.appendEvent(id, null, 'unmerged_branch_kept', { branch: task.branchName });
+        }
       } catch (err) {
         log.warn('worktree removal on archive failed', {
           taskId: id,
@@ -579,6 +588,107 @@ export class KanbanCommands {
       if (input.kind === 'once') break; // a one-shot fires exactly once
     }
     return { ok: true, next };
+  }
+
+  /** Shared validation: a review task with a complete worktree + base branch. */
+  private requireMergeableReviewTask(id: string): Task & {
+    workspacePath: string;
+    repoPath: string;
+    branchName: string;
+    baseBranch: string;
+  } {
+    const task = this.requireTask(id);
+    if (task.status !== 'review') {
+      throw new CodedError('task is not awaiting review', 'BAD_REQUEST');
+    }
+    if (
+      task.workspaceKind !== 'worktree' ||
+      !task.workspacePath ||
+      !task.repoPath ||
+      !task.branchName ||
+      !task.baseBranch
+    ) {
+      throw new CodedError('task has no worktree branch to integrate', 'BAD_REQUEST');
+    }
+    return task as Task & {
+      workspacePath: string;
+      repoPath: string;
+      branchName: string;
+      baseBranch: string;
+    };
+  }
+
+  /** Merge a review task's branch into its base, then accept it (done). */
+  mergeReviewTask(id: string): KanbanReviewActionResult {
+    const task = this.requireMergeableReviewTask(id);
+    const result = mergeWorktreeToBase({
+      repoPath: task.repoPath,
+      branchName: task.branchName,
+      baseBranch: task.baseBranch,
+      worktreeParentDir: dirname(task.workspacePath),
+      taskId: task.id,
+      title: task.title
+    });
+    if (!result.ok) {
+      const reason = result.conflict
+        ? `merge conflict against ${task.baseBranch}; resolve manually or unblock to retry`
+        : (result.error ?? 'merge failed');
+      this.store.addComment(id, 'human', `merge to ${task.baseBranch} failed: ${reason}`);
+      this.store.appendEvent(id, null, 'merge_failed', {
+        base: task.baseBranch,
+        conflict: !!result.conflict
+      });
+      return { ok: false, conflict: result.conflict, error: reason };
+    }
+    this.store.completeTask(id, task.result);
+    this.store.addComment(id, 'human', `merged ${task.branchName} into ${task.baseBranch}`);
+    this.store.appendEvent(id, null, 'merged', {
+      base: task.baseBranch,
+      branch: task.branchName
+    });
+    // Base advanced — let gated children promote without waiting for the next poll.
+    this.dispatcher.tick();
+    return { ok: true, message: `merged into ${task.baseBranch}` };
+  }
+
+  /** Push a review task's branch and open a PR, then accept it (done). */
+  createPrForTask(id: string): KanbanReviewActionResult {
+    const task = this.requireMergeableReviewTask(id);
+    const result = pushAndCreatePr({
+      workspacePath: task.workspacePath,
+      branchName: task.branchName,
+      baseBranch: task.baseBranch,
+      title: task.title,
+      body: task.body
+    });
+    if (!result.ok) {
+      this.store.addComment(id, 'human', `PR creation failed: ${result.error}`);
+      this.store.appendEvent(id, null, 'pr_failed', { error: result.error });
+      return { ok: false, error: result.error };
+    }
+    this.store.completeTask(id, task.result);
+    this.store.addComment(id, 'human', `opened pull request: ${result.url}`);
+    this.store.appendEvent(id, null, 'pr_created', { url: result.url });
+    // Task accepted (done) — promote any gated children without waiting for the poll.
+    this.dispatcher.tick();
+    return { ok: true, prUrl: result.url, message: 'pull request created' };
+  }
+
+  /** Accept a review task without integrating (Do Nothing): branch + worktree are preserved. */
+  acceptReviewTask(id: string): KanbanReviewActionResult {
+    const task = this.requireTask(id);
+    if (task.status !== 'review') {
+      throw new CodedError('task is not awaiting review', 'BAD_REQUEST');
+    }
+    this.store.completeTask(id, task.result);
+    const where = task.branchName
+      ? `${task.branchName}${task.workspacePath ? ` at ${task.workspacePath}` : ''}`
+      : 'workspace';
+    this.store.addComment(id, 'human', `accepted without integration; branch preserved: ${where}`);
+    this.store.appendEvent(id, null, 'accepted', { branch: task.branchName });
+    // Task accepted (done) — promote any gated children without waiting for the poll.
+    this.dispatcher.tick();
+    return { ok: true, message: 'accepted; branch preserved' };
   }
 
   dispatch(): void {

--- a/src/main/kanban/kanban-commands.ts
+++ b/src/main/kanban/kanban-commands.ts
@@ -243,6 +243,11 @@ export class KanbanCommands {
     if (!MANUAL_STATUSES.includes(status)) {
       throw new CodedError(`invalid status: ${status}`, 'BAD_REQUEST');
     }
+    // Review is a worktree-only lane: its drawer actions (merge/PR) assume a
+    // committed branch, so scratch/dir tasks have no business there.
+    if (status === 'review' && task.workspaceKind !== 'worktree') {
+      throw new CodedError('only worktree tasks can enter review', 'BAD_REQUEST');
+    }
     this.store.setStatus(id, status);
     this.store.appendEvent(id, null, 'status_changed', {
       from: task.status,

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../logger';
 import type { KanbanStore } from './kanban-store';
 import type { Task, RunMode } from '../../shared/kanban-types';
 import { computeNextRun, taskToScheduleInput } from './schedule';
+import { finalizeWorktree } from './workspace';
 
 const log = createLogger('kanban-dispatcher');
 
@@ -83,6 +84,15 @@ export class KanbanDispatcher {
       // so it wins even if the claim lease also happened to expire this tick.
       if (exit?.code === REVIEW_REQUIRED_EXIT_CODE) {
         const note = 'review-required: agent ended turn without completing';
+        // Preserve whatever the agent did before it went quiet: commit the
+        // worktree so the block leaves a reviewable branch, not loose edits.
+        if (task.workspaceKind === 'worktree' && task.workspacePath) {
+          finalizeWorktree({
+            workspacePath: task.workspacePath,
+            taskId: task.id,
+            title: task.title
+          });
+        }
         if (task.currentRunId != null) {
           this.store.finishRun(task.currentRunId, 'incomplete', { summary: note });
         }

--- a/src/main/kanban/kanban-ipc.ts
+++ b/src/main/kanban/kanban-ipc.ts
@@ -89,6 +89,18 @@ export function registerKanbanIpc(commands: KanbanCommands): void {
     commands.dispatch();
   });
 
+  ipcMain.handle(IPC_CHANNELS.KANBAN_MERGE_TASK, (_e, taskId: string) =>
+    commands.mergeReviewTask(taskId)
+  );
+
+  ipcMain.handle(IPC_CHANNELS.KANBAN_CREATE_PR, (_e, taskId: string) =>
+    commands.createPrForTask(taskId)
+  );
+
+  ipcMain.handle(IPC_CHANNELS.KANBAN_ACCEPT_TASK, (_e, taskId: string) =>
+    commands.acceptReviewTask(taskId)
+  );
+
   ipcMain.handle(IPC_CHANNELS.KANBAN_DECOMPOSE, (_e, taskId: string) => {
     commands.requestDecompose(taskId);
   });

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -3,9 +3,10 @@ import { URL } from 'url';
 import { z } from 'zod';
 import { createLogger } from '../logger';
 import type { KanbanStore } from './kanban-store';
-import type { RunMode, SwarmInput, SwarmCreated } from '../../shared/kanban-types';
+import type { RunMode, SwarmInput, SwarmCreated, Task } from '../../shared/kanban-types';
 import type { WorkerProfile } from '../../shared/types';
 import { latestBlackboard, postBlackboardUpdate, isSwarmRoot } from './kanban-swarm';
+import { finalizeWorktree, reviewStat } from './workspace';
 
 const log = createLogger('kanban-mcp');
 
@@ -315,6 +316,27 @@ export class KanbanMcpServer {
     this.rpcResult(res, id, { content: [{ type: 'text', text: message }] });
   }
 
+  /**
+   * Workspace fields a child / swarm worker inherits from its parent task: a
+   * worktree parent gives each child its own worktree branched from the parent's
+   * base (so it inherits merged work); a 'dir' parent shares its folder. Without
+   * this a child falls back to an empty scratch sandbox.
+   */
+  private inheritWorkspace(task: Task): {
+    workspaceKind?: 'worktree' | 'dir';
+    repoPath?: string;
+    baseBranch?: string | null;
+    workspacePath?: string;
+  } {
+    if (task.workspaceKind === 'worktree' && task.repoPath) {
+      return { workspaceKind: 'worktree', repoPath: task.repoPath, baseBranch: task.baseBranch };
+    }
+    if (task.workspaceKind === 'dir' && task.workspacePath) {
+      return { workspaceKind: 'dir', workspacePath: task.workspacePath };
+    }
+    return {};
+  }
+
   private handleToolCall(res: ServerResponse, rpcReq: JsonRpcRequest, token: string): void {
     const scope = this.runs.get(token);
     if (!scope) return this.rpcError(res, rpcReq.id, 'unknown or missing run token');
@@ -350,6 +372,33 @@ export class KanbanMcpServer {
           const a = z
             .object({ summary: z.string(), metadata: z.record(z.string(), z.unknown()).optional() })
             .parse(args);
+          // Worktree tasks don't go straight to done: commit the work, land it in
+          // the human review gate, and record what changed. Scratch/dir tasks have
+          // nothing to merge, so they complete as before.
+          if (task.workspaceKind === 'worktree' && task.workspacePath) {
+            finalizeWorktree({
+              workspacePath: task.workspacePath,
+              taskId: task.id,
+              title: task.title
+            });
+            const stat = reviewStat({
+              workspacePath: task.workspacePath,
+              baseBranch: task.baseBranch
+            });
+            this.store.reviewTask(task.id, a.summary);
+            this.store.finishRun(scope.runId, 'completed', {
+              summary: a.summary,
+              metadata: { ...a.metadata, review: stat ?? undefined }
+            });
+            this.store.appendEvent(task.id, scope.runId, 'completed', { summary: a.summary });
+            const where = task.branchName ?? `kanban/${task.id}`;
+            const statText = stat
+              ? `${stat.files} file${stat.files === 1 ? '' : 's'} (+${stat.insertions}/−${stat.deletions})`
+              : 'changes committed';
+            this.store.addComment(task.id, author, `review-required: ${statText} on ${where}`);
+            this.unregisterRun(token);
+            return this.text(res, rpcReq.id, `Task ${task.id} ready for review.`);
+          }
           this.store.completeTask(task.id, a.summary);
           this.store.finishRun(scope.runId, 'completed', {
             summary: a.summary,
@@ -462,18 +511,7 @@ export class KanbanMcpServer {
               `unknown worker profile "${assignee}". Valid profiles: ${workerNames.join(', ')}`
             );
           }
-          // Children inherit the parent's workspace so they can see its files:
-          // a worktree parent gives each child its own kanban/<childId> worktree
-          // (gate on a truthy repoPath — store.createTask bypasses the create()
-          // repoPath guard, so a worktree task without a repo would fail at claim
-          // time), and a 'dir' parent shares its folder directly. Without this a
-          // child falls back to an empty scratch sandbox.
-          const inherit =
-            task.workspaceKind === 'worktree' && task.repoPath
-              ? { workspaceKind: 'worktree' as const, repoPath: task.repoPath }
-              : task.workspaceKind === 'dir' && task.workspacePath
-                ? { workspaceKind: 'dir' as const, workspacePath: task.workspacePath }
-                : {};
+          const inherit = this.inheritWorkspace(task);
           const child = this.store.createTask({
             title: a.title,
             body: a.body ?? '',
@@ -526,12 +564,7 @@ export class KanbanMcpServer {
               synthesizer: z.string()
             })
             .parse(args);
-          const inheritRepo =
-            task.workspaceKind === 'worktree' && task.repoPath
-              ? { workspaceKind: 'worktree' as const, repoPath: task.repoPath }
-              : task.workspaceKind === 'dir' && task.workspacePath
-                ? { workspaceKind: 'dir' as const, workspacePath: task.workspacePath }
-                : {};
+          const inheritRepo = this.inheritWorkspace(task);
           const created = this.swarmHandler({
             goal: a.goal,
             workers: a.workers.map((w) => ({

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -950,7 +950,8 @@ export class KanbanStore {
           removeWorktree({
             repoPath: t.repoPath,
             workspacePath: t.workspacePath,
-            branchName: t.branchName
+            branchName: t.branchName,
+            baseBranch: t.baseBranch
           });
         } else if (t.workspacePath) {
           cleanupWorkspace({ kind: t.workspaceKind, path: t.workspacePath });

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -105,6 +105,10 @@ export class KanbanStore {
       this.addColumnIfMissing('tasks', 'schedule_paused', 'INTEGER NOT NULL DEFAULT 0');
       this.addColumnIfMissing('tasks', 'scheduled_from', 'TEXT');
     }
+    if (current < 8) {
+      // Additive: DBs created before v8 lack the worktree merge-target column.
+      this.addColumnIfMissing('tasks', 'base_branch', 'TEXT');
+    }
     // Seed the permanent default board (idempotent: fresh and existing DBs).
     const ts = this.now();
     this.db
@@ -147,6 +151,7 @@ export class KanbanStore {
       workspacePath: (r.workspace_path as string | null) ?? null,
       repoPath: (r.repo_path as string | null) ?? null,
       branchName: (r.branch_name as string | null) ?? null,
+      baseBranch: (r.base_branch as string | null) ?? null,
       modelOverride: (r.model_override as string | null) ?? null,
       skills: JSON.parse(String(r.skills ?? '[]')) as string[],
       boardId: String(r.board_id ?? 'default'),
@@ -179,10 +184,10 @@ export class KanbanStore {
     this.db
       .prepare(
         `INSERT INTO tasks (id, title, body, assignee, status, priority, tenant,
-          workspace_kind, workspace_path, repo_path, branch_name, model_override, skills, board_id, idempotency_key,
+          workspace_kind, workspace_path, repo_path, branch_name, base_branch, model_override, skills, board_id, idempotency_key,
           scheduled_from, max_runtime_seconds, max_retries, created_at, updated_at)
          VALUES (@id, @title, @body, @assignee, @status, @priority, @tenant,
-          @workspace_kind, @workspace_path, @repo_path, @branch_name, @model_override, @skills, @board_id, @idempotency_key,
+          @workspace_kind, @workspace_path, @repo_path, @branch_name, @base_branch, @model_override, @skills, @board_id, @idempotency_key,
           @scheduled_from, @max_runtime_seconds, @max_retries, @created_at, @updated_at)`
       )
       .run({
@@ -197,6 +202,7 @@ export class KanbanStore {
         workspace_path: input.workspacePath ?? null,
         repo_path: input.repoPath ?? null,
         branch_name: input.branchName ?? null,
+        base_branch: input.baseBranch ?? null,
         model_override: input.modelOverride ?? null,
         skills: JSON.stringify(input.skills ?? []),
         board_id: input.boardId ?? 'default',
@@ -791,6 +797,22 @@ export class KanbanStore {
       .run(result, ts, taskId);
   }
 
+  /**
+   * Land a worktree task in the human review gate: same claim-clearing as
+   * completeTask, but status='review' (not 'done'), so the work is preserved and
+   * dependent children stay gated until a human picks an integration action.
+   */
+  reviewTask(taskId: string, result: string | null): void {
+    const ts = this.now();
+    this.db
+      .prepare(
+        `UPDATE tasks SET status='review', result=?, claim_lock=NULL, claim_expires=NULL,
+          worker_pid=NULL, current_run_id=NULL, consecutive_failures=0, last_failure_error=NULL, updated_at=?
+         WHERE id=?`
+      )
+      .run(result, ts, taskId);
+  }
+
   blockTask(taskId: string, reason: string): void {
     const ts = this.now();
     this.db
@@ -1008,10 +1030,17 @@ export class KanbanStore {
     this.db.prepare('UPDATE task_runs SET worker_pid=? WHERE id=?').run(pid, runId);
   }
 
-  setWorkspace(taskId: string, path: string, branchName: string | null): void {
+  setWorkspace(
+    taskId: string,
+    path: string,
+    branchName: string | null,
+    baseBranch: string | null = null
+  ): void {
     this.db
-      .prepare('UPDATE tasks SET workspace_path=?, branch_name=?, updated_at=? WHERE id=?')
-      .run(path, branchName, this.now(), taskId);
+      .prepare(
+        'UPDATE tasks SET workspace_path=?, branch_name=?, base_branch=?, updated_at=? WHERE id=?'
+      )
+      .run(path, branchName, baseBranch, this.now(), taskId);
   }
 
   setPendingMode(taskId: string, mode: PendingMode | null): void {

--- a/src/main/kanban/kanban-swarm.ts
+++ b/src/main/kanban/kanban-swarm.ts
@@ -126,6 +126,9 @@ export function createSwarm(store: SwarmStore, input: SwarmInput): SwarmCreated 
     tenant: input.tenant ?? null,
     workspaceKind,
     repoPath: input.repoPath,
+    // Worktree workers branch from the orchestrator's base so they inherit its
+    // merged work (matches kanban_create's child inheritance).
+    baseBranch: input.baseBranch ?? null,
     // 'dir' swarms run every node directly in the shared folder; carry the path
     // so it survives onto each task instead of falling back to a scratch sandbox.
     workspacePath: input.workspacePath ?? undefined,

--- a/src/main/kanban/schema.ts
+++ b/src/main/kanban/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS tasks (
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   workspace_path TEXT,
   repo_path TEXT,
   branch_name TEXT,
+  base_branch TEXT,
   model_override TEXT,
   skills TEXT NOT NULL DEFAULT '[]',
   board_id TEXT NOT NULL DEFAULT 'default',

--- a/src/main/kanban/workspace.ts
+++ b/src/main/kanban/workspace.ts
@@ -16,11 +16,18 @@ export interface PrepareWorkspaceInput {
   repoPath?: string;
   /** Current persisted branch (worktree reuse). */
   branchName?: string;
+  /**
+   * Explicit start-point for a new worktree branch (a dependent child branches
+   * from its prerequisite's merge target). Defaults to the repo's current HEAD.
+   */
+  startPoint?: string;
 }
 
 export interface PreparedWorkspace {
   path: string;
   branchName: string | null;
+  /** Repo HEAD at worktree-creation time (the merge target). Null for scratch/dir/reuse. */
+  baseBranch: string | null;
 }
 
 function isGitRepo(repoPath: string): boolean {
@@ -30,6 +37,24 @@ function isGitRepo(repoPath: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** The repo's current branch, or null if detached/unknown. */
+function currentBranch(repoPath: string): string | null {
+  try {
+    const out = execFileSync('git', ['-C', repoPath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8'
+    }).trim();
+    return out && out !== 'HEAD' ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** stderr text from a failed execFileSync, falling back to the error message. */
+function gitStderr(err: unknown): string {
+  const e = err as { stderr?: Buffer };
+  return e.stderr?.toString().trim() || (err as Error).message;
 }
 
 // taskId is a generated id (no glob metacharacters), so `git branch --list <branch>`
@@ -46,19 +71,19 @@ export function prepareWorkspace(input: PrepareWorkspaceInput): PreparedWorkspac
   if (input.kind === 'scratch') {
     const path = join(input.workspacesRoot, input.taskId);
     mkdirSync(path, { recursive: true });
-    return { path, branchName: null };
+    return { path, branchName: null, baseBranch: null };
   }
 
   if (input.kind === 'dir') {
     if (!input.workspacePath) {
       throw new Error("prepareWorkspace: kind 'dir' requires an explicit workspacePath");
     }
-    return { path: input.workspacePath, branchName: null };
+    return { path: input.workspacePath, branchName: null, baseBranch: null };
   }
 
   // worktree
   if (input.workspacePath && existsSync(input.workspacePath)) {
-    return { path: input.workspacePath, branchName: input.branchName ?? null };
+    return { path: input.workspacePath, branchName: input.branchName ?? null, baseBranch: null };
   }
   if (!input.repoPath) {
     throw new Error("prepareWorkspace: kind 'worktree' requires repoPath");
@@ -70,9 +95,15 @@ export function prepareWorkspace(input: PrepareWorkspaceInput): PreparedWorkspac
   const branch = `kanban/${input.taskId}`;
   const dir = join(input.worktreesRoot, input.taskId);
   mkdirSync(input.worktreesRoot, { recursive: true });
+  // Capture the repo's current branch up-front: it is the merge target and the
+  // base a dependent child branches from. Fall back to the explicit start-point
+  // when the child was told one (worktree create below honours the same).
+  const base = input.startPoint ?? currentBranch(repo);
   const addArgs = branchExists(repo, branch)
     ? ['-C', repo, 'worktree', 'add', dir, branch]
-    : ['-C', repo, 'worktree', 'add', dir, '-b', branch];
+    : input.startPoint
+      ? ['-C', repo, 'worktree', 'add', dir, '-b', branch, input.startPoint]
+      : ['-C', repo, 'worktree', 'add', dir, '-b', branch];
   try {
     execFileSync('git', addArgs, { stdio: ['ignore', 'ignore', 'pipe'] });
   } catch (err) {
@@ -89,7 +120,7 @@ export function prepareWorkspace(input: PrepareWorkspaceInput): PreparedWorkspac
       `prepareWorkspace: git worktree add failed: ${stderr || (err as Error).message}`
     );
   }
-  return { path: dir, branchName: branch };
+  return { path: dir, branchName: branch, baseBranch: base };
 }
 
 export function cleanupWorkspace(input: { kind: WorkspaceKind; path: string }): void {
@@ -99,17 +130,36 @@ export function cleanupWorkspace(input: { kind: WorkspaceKind; path: string }): 
   }
 }
 
+/** True when `branchName` is already contained in `baseBranch` (no unmerged work). */
+export function isBranchMerged(input: {
+  repoPath: string;
+  branchName: string;
+  baseBranch: string;
+}): boolean {
+  try {
+    execFileSync(
+      'git',
+      ['-C', input.repoPath, 'merge-base', '--is-ancestor', input.branchName, input.baseBranch],
+      { stdio: 'ignore' }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Best-effort teardown of a worktree-kind workspace: remove the worktree dir
- * and delete its branch. Never throws — archival must not be blocked by a git
- * failure. Directory cleanup is independent of the git calls, so a moved or
- * deleted repoPath does not leak the worktree dir.
+ * Best-effort teardown of a worktree-kind workspace: always remove the worktree
+ * dir (free disk), but only delete the branch when it is already merged into
+ * `baseBranch`. An unmerged branch is kept so archival never silently destroys
+ * work — the returned `branchKept` lets the caller warn. Never throws.
  */
 export function removeWorktree(input: {
   repoPath: string;
   workspacePath: string;
   branchName: string | null;
-}): void {
+  baseBranch?: string | null;
+}): { branchKept: boolean } {
   try {
     execFileSync(
       'git',
@@ -130,13 +180,226 @@ export function removeWorktree(input: {
       // best-effort
     }
   }
-  if (input.branchName) {
+  if (!input.branchName) return { branchKept: false };
+  // Only `git branch -D` when the work is preserved elsewhere (merged into base).
+  // Without a known base we cannot prove it is safe, so keep the branch.
+  const merged = input.baseBranch
+    ? isBranchMerged({
+        repoPath: input.repoPath,
+        branchName: input.branchName,
+        baseBranch: input.baseBranch
+      })
+    : false;
+  if (!merged) return { branchKept: true };
+  try {
+    execFileSync('git', ['-C', input.repoPath, 'branch', '-D', input.branchName], {
+      stdio: 'ignore'
+    });
+  } catch {
+    // branch already gone or never created
+  }
+  return { branchKept: false };
+}
+
+const COMMIT_IDENTITY = ['-c', 'user.name=Fleet', '-c', 'user.email=fleet@localhost'];
+
+/**
+ * Commit any uncommitted changes in a worktree so a run never leaves work only
+ * in the working tree. Returns true when a commit was created. Never throws —
+ * preservation is best-effort.
+ */
+export function finalizeWorktree(input: {
+  workspacePath: string;
+  taskId: string;
+  title: string;
+}): boolean {
+  const { workspacePath, taskId, title } = input;
+  try {
+    execFileSync('git', ['-C', workspacePath, 'add', '-A'], { stdio: 'ignore' });
+    // `git diff --cached --quiet` exits non-zero exactly when something is staged.
+    let hasChanges = false;
     try {
-      execFileSync('git', ['-C', input.repoPath, 'branch', '-D', input.branchName], {
+      execFileSync('git', ['-C', workspacePath, 'diff', '--cached', '--quiet'], {
         stdio: 'ignore'
       });
     } catch {
-      // branch already gone or never created
+      hasChanges = true;
     }
+    if (!hasChanges) return false;
+    const msg = `kanban/${taskId}: ${title}`.slice(0, 200);
+    try {
+      execFileSync('git', ['-C', workspacePath, 'commit', '-m', msg], { stdio: 'ignore' });
+    } catch {
+      // No git identity configured: commit with a Fleet fallback so work is still preserved.
+      execFileSync('git', ['-C', workspacePath, ...COMMIT_IDENTITY, 'commit', '-m', msg], {
+        stdio: 'ignore'
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ReviewStat {
+  files: number;
+  insertions: number;
+  deletions: number;
+}
+
+function parseShortstat(s: string): ReviewStat {
+  const files = /(\d+) files? changed/.exec(s);
+  const ins = /(\d+) insertions?\(\+\)/.exec(s);
+  const del = /(\d+) deletions?\(-\)/.exec(s);
+  return {
+    files: files ? Number(files[1]) : 0,
+    insertions: ins ? Number(ins[1]) : 0,
+    deletions: del ? Number(del[1]) : 0
+  };
+}
+
+/** Diff stat of a worktree's branch against its base, or null if unavailable. */
+export function reviewStat(input: {
+  workspacePath: string;
+  baseBranch: string | null;
+}): ReviewStat | null {
+  if (!input.baseBranch) return null;
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', input.workspacePath, 'diff', '--shortstat', `${input.baseBranch}...HEAD`],
+      { encoding: 'utf8' }
+    );
+    return parseShortstat(out);
+  } catch {
+    return null;
+  }
+}
+
+function cleanupTempWorktree(repoPath: string, tmp: string): void {
+  try {
+    execFileSync('git', ['-C', repoPath, 'worktree', 'remove', '--force', tmp], {
+      stdio: 'ignore'
+    });
+  } catch {
+    try {
+      rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+    try {
+      execFileSync('git', ['-C', repoPath, 'worktree', 'prune'], { stdio: 'ignore' });
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Merge `branchName` into `baseBranch` without disturbing the user's checkout:
+ * the merge happens in a throwaway detached worktree, then the result is pushed
+ * into the repo's base ref. `git push` refuses to update a branch checked out in
+ * any worktree, so the user's working tree is never clobbered.
+ */
+export function mergeWorktreeToBase(input: {
+  repoPath: string;
+  branchName: string;
+  baseBranch: string;
+  worktreeParentDir: string;
+  taskId: string;
+  title: string;
+}): { ok: boolean; conflict?: boolean; error?: string } {
+  const { repoPath, branchName, baseBranch, worktreeParentDir, taskId, title } = input;
+  const tmp = join(worktreeParentDir, `.merge-${taskId}`);
+  cleanupTempWorktree(repoPath, tmp);
+  try {
+    execFileSync('git', ['-C', repoPath, 'worktree', 'add', '--detach', tmp, baseBranch], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+  } catch (err) {
+    return { ok: false, error: `could not create merge worktree: ${gitStderr(err)}` };
+  }
+  try {
+    const msg = `kanban/${taskId}: merge ${title}`.slice(0, 200);
+    execFileSync(
+      'git',
+      ['-C', tmp, ...COMMIT_IDENTITY, 'merge', '--no-ff', '-m', msg, branchName],
+      {
+        stdio: ['ignore', 'ignore', 'pipe']
+      }
+    );
+  } catch {
+    try {
+      execFileSync('git', ['-C', tmp, 'merge', '--abort'], { stdio: 'ignore' });
+    } catch {
+      // nothing to abort
+    }
+    cleanupTempWorktree(repoPath, tmp);
+    return { ok: false, conflict: true };
+  }
+  try {
+    execFileSync('git', ['-C', tmp, 'push', repoPath, `HEAD:refs/heads/${baseBranch}`], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+  } catch (err) {
+    cleanupTempWorktree(repoPath, tmp);
+    return {
+      ok: false,
+      error: `merged cleanly but could not update ${baseBranch} (is it checked out?): ${gitStderr(err)}`
+    };
+  }
+  cleanupTempWorktree(repoPath, tmp);
+  return { ok: true };
+}
+
+/**
+ * Push the worktree's branch to origin and open a PR via the `gh` CLI. Returns
+ * the PR URL on success, or a graceful error when there is no remote / `gh` is
+ * missing / the PR cannot be created.
+ */
+export function pushAndCreatePr(input: {
+  workspacePath: string;
+  branchName: string;
+  baseBranch: string;
+  title: string;
+  body: string;
+}): { ok: boolean; url?: string; error?: string } {
+  const { workspacePath, branchName, baseBranch, title, body } = input;
+  try {
+    execFileSync('git', ['-C', workspacePath, 'push', '-u', 'origin', branchName], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+  } catch (err) {
+    return { ok: false, error: `git push failed (no 'origin' remote?): ${gitStderr(err)}` };
+  }
+  try {
+    const out = execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--base',
+        baseBranch,
+        '--head',
+        branchName,
+        '--title',
+        title,
+        '--body',
+        body || title
+      ],
+      { cwd: workspacePath, encoding: 'utf8' }
+    );
+    const url = out.match(/https?:\/\/\S+/)?.[0] ?? out.trim();
+    return { ok: true, url };
+  } catch (err) {
+    const e = err as { code?: string; stderr?: Buffer; stdout?: Buffer };
+    if (e.code === 'ENOENT') {
+      return { ok: false, error: 'gh CLI not found. Install GitHub CLI to create PRs.' };
+    }
+    const msg = (e.stderr?.toString() || e.stdout?.toString() || (err as Error).message).trim();
+    // `gh` reports an existing PR (with its URL) as an error — treat that as success.
+    const existing = msg.match(/https?:\/\/\S+/)?.[0];
+    if (existing) return { ok: true, url: existing };
+    return { ok: false, error: `gh pr create failed: ${msg}` };
   }
 }

--- a/src/main/kanban/workspace.ts
+++ b/src/main/kanban/workspace.ts
@@ -276,6 +276,36 @@ export function reviewStat(input: {
   }
 }
 
+/** Path of the worktree that currently has `branch` checked out, or null. */
+function findBranchWorktree(repoPath: string, branch: string): string | null {
+  let out: string;
+  try {
+    out = execFileSync('git', ['-C', repoPath, 'worktree', 'list', '--porcelain'], {
+      encoding: 'utf8'
+    });
+  } catch {
+    return null;
+  }
+  let current: string | null = null;
+  for (const line of out.split('\n')) {
+    if (line.startsWith('worktree ')) current = line.slice('worktree '.length).trim();
+    else if (line === `branch refs/heads/${branch}`) return current;
+  }
+  return null;
+}
+
+/** True when a worktree has no staged/unstaged/untracked changes. */
+function isClean(worktreePath: string): boolean {
+  try {
+    const out = execFileSync('git', ['-C', worktreePath, 'status', '--porcelain'], {
+      encoding: 'utf8'
+    });
+    return out.trim().length === 0;
+  } catch {
+    return false;
+  }
+}
+
 function cleanupTempWorktree(repoPath: string, tmp: string): void {
   try {
     execFileSync('git', ['-C', repoPath, 'worktree', 'remove', '--force', tmp], {
@@ -296,10 +326,17 @@ function cleanupTempWorktree(repoPath: string, tmp: string): void {
 }
 
 /**
- * Merge `branchName` into `baseBranch` without disturbing the user's checkout:
- * the merge happens in a throwaway detached worktree, then the result is pushed
- * into the repo's base ref. `git push` refuses to update a branch checked out in
- * any worktree, so the user's working tree is never clobbered.
+ * Merge `branchName` into `baseBranch`. `git push` refuses to update a branch
+ * checked out in a non-bare repo, which is the common case (the base branch is
+ * usually the user's own checkout), so the strategy depends on where base lives:
+ *
+ * - Base checked out somewhere → merge in place there, but only when that
+ *   working tree is clean (a clean tree stays clean — the merge just advances
+ *   it). If it is dirty we refuse rather than clobber uncommitted work.
+ * - Base not checked out anywhere → merge in a throwaway detached worktree and
+ *   push the result into the base ref, leaving every checkout untouched.
+ *
+ * A conflicting merge is aborted (restoring the working tree) and reported.
  */
 export function mergeWorktreeToBase(input: {
   repoPath: string;
@@ -310,6 +347,33 @@ export function mergeWorktreeToBase(input: {
   title: string;
 }): { ok: boolean; conflict?: boolean; error?: string } {
   const { repoPath, branchName, baseBranch, worktreeParentDir, taskId, title } = input;
+  const msg = `kanban/${taskId}: merge ${title}`.slice(0, 200);
+
+  const baseCheckout = findBranchWorktree(repoPath, baseBranch);
+  if (baseCheckout) {
+    if (!isClean(baseCheckout)) {
+      return {
+        ok: false,
+        error: `${baseBranch} is checked out with uncommitted changes at ${baseCheckout}; commit or stash them, then retry.`
+      };
+    }
+    try {
+      execFileSync(
+        'git',
+        ['-C', baseCheckout, ...COMMIT_IDENTITY, 'merge', '--no-ff', '-m', msg, branchName],
+        { stdio: ['ignore', 'ignore', 'pipe'] }
+      );
+    } catch {
+      try {
+        execFileSync('git', ['-C', baseCheckout, 'merge', '--abort'], { stdio: 'ignore' });
+      } catch {
+        // nothing to abort
+      }
+      return { ok: false, conflict: true };
+    }
+    return { ok: true };
+  }
+
   const tmp = join(worktreeParentDir, `.merge-${taskId}`);
   cleanupTempWorktree(repoPath, tmp);
   try {
@@ -320,7 +384,6 @@ export function mergeWorktreeToBase(input: {
     return { ok: false, error: `could not create merge worktree: ${gitStderr(err)}` };
   }
   try {
-    const msg = `kanban/${taskId}: merge ${title}`.slice(0, 200);
     execFileSync(
       'git',
       ['-C', tmp, ...COMMIT_IDENTITY, 'merge', '--no-ff', '-m', msg, branchName],
@@ -345,7 +408,7 @@ export function mergeWorktreeToBase(input: {
     cleanupTempWorktree(repoPath, tmp);
     return {
       ok: false,
-      error: `merged cleanly but could not update ${baseBranch} (is it checked out?): ${gitStderr(err)}`
+      error: `merged cleanly but could not update ${baseBranch}: ${gitStderr(err)}`
     };
   }
   cleanupTempWorktree(repoPath, tmp);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -50,7 +50,8 @@ import type {
   KanbanArtifactPreviewResponse,
   KanbanReuseArtifactRequest,
   KanbanCreateTaskFromArtifactRequest,
-  KanbanCreateSwarmFromArtifactRequest
+  KanbanCreateSwarmFromArtifactRequest,
+  KanbanReviewActionResult
 } from '../shared/ipc-api';
 import type {
   Board,
@@ -198,8 +199,8 @@ const fleetApi = {
   git: {
     isRepo: async (cwd: string): Promise<GitIsRepoPayload> =>
       typedInvoke(IPC_CHANNELS.GIT_IS_REPO, cwd),
-    getStatus: async (cwd: string): Promise<GitStatusPayload> =>
-      typedInvoke(IPC_CHANNELS.GIT_STATUS, cwd)
+    getStatus: async (cwd: string, baseRef?: string): Promise<GitStatusPayload> =>
+      typedInvoke(IPC_CHANNELS.GIT_STATUS, cwd, baseRef)
   },
   worktree: {
     create: async (req: WorktreeCreateRequest): Promise<WorktreeCreateResponse> =>
@@ -464,6 +465,12 @@ const fleetApi = {
     removeLink: async (req: KanbanLinkRequest): Promise<void> =>
       typedInvoke<void>(IPC_CHANNELS.KANBAN_REMOVE_LINK, req),
     nudge: async (): Promise<void> => typedInvoke<void>(IPC_CHANNELS.KANBAN_NUDGE),
+    mergeTask: async (taskId: string): Promise<KanbanReviewActionResult> =>
+      typedInvoke<KanbanReviewActionResult>(IPC_CHANNELS.KANBAN_MERGE_TASK, taskId),
+    createPr: async (taskId: string): Promise<KanbanReviewActionResult> =>
+      typedInvoke<KanbanReviewActionResult>(IPC_CHANNELS.KANBAN_CREATE_PR, taskId),
+    acceptTask: async (taskId: string): Promise<KanbanReviewActionResult> =>
+      typedInvoke<KanbanReviewActionResult>(IPC_CHANNELS.KANBAN_ACCEPT_TASK, taskId),
     decompose: async (taskId: string): Promise<void> =>
       typedInvoke<void>(IPC_CHANNELS.KANBAN_DECOMPOSE, taskId),
     specify: async (taskId: string): Promise<void> =>

--- a/src/renderer/src/components/GitChangesModal.tsx
+++ b/src/renderer/src/components/GitChangesModal.tsx
@@ -26,12 +26,15 @@ type GitChangesModalProps = {
   isOpen: boolean;
   onClose: () => void;
   cwd: string | undefined;
+  /** When set, show committed changes against this ref (base...HEAD) instead of the working tree. */
+  compareRef?: string | null;
 };
 
 export function GitChangesModal({
   isOpen,
   onClose,
-  cwd
+  cwd,
+  compareRef
 }: GitChangesModalProps): React.JSX.Element | null {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<GitStatusPayload | null>(null);
@@ -59,7 +62,7 @@ export function GitChangesModal({
     setFilterText('');
     setActiveFileIndex(0);
     window.fleet.git
-      .getStatus(cwd)
+      .getStatus(cwd, compareRef ?? undefined)
       .then((result) => {
         setData(result);
         setLoading(false);
@@ -69,7 +72,7 @@ export function GitChangesModal({
         setData({ isRepo: true, branch: '', files: [], diff: '', error: String(err) });
         setLoading(false);
       });
-  }, [isOpen, cwd]);
+  }, [isOpen, cwd, compareRef]);
 
   // Filter files
   const filteredFiles = useMemo(() => {

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -457,7 +457,10 @@ export function KanbanBoard(): React.JSX.Element {
                   draggingId.current = null;
                   if (!id) return;
                   const card = cards.find((c) => c.id === id);
-                  if (card && card.status !== status) void setStatus(id, status);
+                  if (!card || card.status === status) return;
+                  // Review is worktree-only (the command layer rejects it too).
+                  if (status === 'review' && card.workspaceKind !== 'worktree') return;
+                  void setStatus(id, status);
                 }}
               />
             ))}

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -42,6 +42,8 @@ export function KanbanBoard(): React.JSX.Element {
   const [newMode, setNewMode] = useState<'scratch' | 'project'>('scratch');
   const [newFolder, setNewFolder] = useState('');
   const [newIsolated, setNewIsolated] = useState(true);
+  // null = not applicable / still checking; true/false = the picked folder's git-repo status.
+  const [folderIsRepo, setFolderIsRepo] = useState<boolean | null>(null);
   const draggingId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -84,11 +86,42 @@ export function KanbanBoard(): React.JSX.Element {
     if (path) setNewFolder(path);
   }
 
+  // An "isolated copy" (worktree) needs a git repo. Verify the picked folder up
+  // front so the form catches it, instead of failing later at claim time.
+  useEffect(() => {
+    const folder = newFolder.trim();
+    if (newMode !== 'project' || !newIsolated || !folder) {
+      setFolderIsRepo(null);
+      return;
+    }
+    let cancelled = false;
+    setFolderIsRepo(null); // checking…
+    window.fleet.git
+      .isRepo(folder)
+      .then((r) => {
+        if (!cancelled) setFolderIsRepo(r.isRepo);
+      })
+      .catch(() => {
+        if (!cancelled) setFolderIsRepo(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [newFolder, newMode, newIsolated]);
+
   async function handleCreate(): Promise<void> {
     const title = newTitle.trim();
     if (!title) return;
     const folder = newFolder.trim();
     if (newMode === 'project' && !folder) return;
+    // Block an isolated-copy task on a non-repo folder before it can fail at claim time.
+    if (newMode === 'project' && newIsolated) {
+      const { isRepo } = await window.fleet.git.isRepo(folder);
+      if (!isRepo) {
+        setFolderIsRepo(false);
+        return;
+      }
+    }
     const workspace =
       newMode === 'scratch'
         ? { workspaceKind: 'scratch' as const }
@@ -371,12 +404,24 @@ export function KanbanBoard(): React.JSX.Element {
                       </span>
                     </span>
                   </label>
+                  {newIsolated && newFolder.trim() !== '' && folderIsRepo === false && (
+                    <p className="text-[10px] text-red-400">
+                      Not a git repository — an isolated copy needs a git repo. Uncheck to work in
+                      the folder directly, or pick a repo.
+                    </p>
+                  )}
                 </div>
               )}
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => void handleCreate()}
-                  className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500"
+                  disabled={
+                    newMode === 'project' &&
+                    newIsolated &&
+                    newFolder.trim() !== '' &&
+                    folderIsRepo !== true
+                  }
+                  className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Create
                 </button>

--- a/src/renderer/src/components/kanban/KanbanDrawer.tsx
+++ b/src/renderer/src/components/kanban/KanbanDrawer.tsx
@@ -2,11 +2,21 @@ import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
-import { X, Paperclip, Download, Clock, FolderGit2 } from 'lucide-react';
+import {
+  X,
+  Paperclip,
+  Download,
+  Clock,
+  FolderGit2,
+  GitMerge,
+  GitPullRequest,
+  Check
+} from 'lucide-react';
 import { useKanbanStore } from '../../store/kanban-store';
 import { useSettingsStore } from '../../store/settings-store';
 import { CommentThread } from './CommentThread';
 import { OutputsSection } from './KanbanArtifacts';
+import { GitChangesModal } from '../GitChangesModal';
 import {
   relativeTime,
   formatDuration,
@@ -36,6 +46,9 @@ export function KanbanDrawer(): React.JSX.Element | null {
     replyAndResume,
     addLink,
     removeLink,
+    mergeTask,
+    createPr,
+    acceptTask,
     decompose,
     specify,
     uploadAttachments,
@@ -56,6 +69,10 @@ export function KanbanDrawer(): React.JSX.Element | null {
   const [linkId, setLinkId] = useState('');
   const [dragging, setDragging] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
+  const [showDiff, setShowDiff] = useState(false);
+  const [reviewBusy, setReviewBusy] = useState<'merge' | 'pr' | 'accept' | null>(null);
+  const [reviewMsg, setReviewMsg] = useState<string | null>(null);
+  const [reviewErr, setReviewErr] = useState<string | null>(null);
   const dragCounter = useRef(0);
   const seededIdRef = useRef<string | null>(null);
   const [schedKind, setSchedKind] = useState<'once' | 'interval' | 'cron'>('interval');
@@ -74,6 +91,10 @@ export function KanbanDrawer(): React.JSX.Element | null {
       setAssignee(detail.task.assignee ?? '');
       setPriority(detail.task.priority);
       setTenant(detail.task.tenant ?? '');
+      setShowDiff(false);
+      setReviewBusy(null);
+      setReviewMsg(null);
+      setReviewErr(null);
       setSchedKind('interval');
       setSchedAt('');
       setSchedEveryN(1);
@@ -96,6 +117,26 @@ export function KanbanDrawer(): React.JSX.Element | null {
       priority,
       tenant: tenant.trim() === '' ? null : tenant.trim()
     });
+  }
+
+  async function runReview(action: 'merge' | 'pr' | 'accept'): Promise<void> {
+    setReviewBusy(action);
+    setReviewErr(null);
+    setReviewMsg(null);
+    try {
+      const res =
+        action === 'merge'
+          ? await mergeTask(t.id)
+          : action === 'pr'
+            ? await createPr(t.id)
+            : await acceptTask(t.id);
+      if (res.ok) setReviewMsg(res.prUrl ?? res.message ?? 'Done');
+      else setReviewErr(res.error ?? 'Action failed');
+    } catch (err) {
+      setReviewErr(err instanceof Error ? err.message : 'Action failed');
+    } finally {
+      setReviewBusy(null);
+    }
   }
 
   function buildScheduleInput(): ScheduleInput | null {
@@ -281,18 +322,31 @@ export function KanbanDrawer(): React.JSX.Element | null {
             {t.workspaceKind === 'scratch' ? (
               <span className="text-neutral-400">Scratch (ephemeral)</span>
             ) : t.workspaceKind === 'worktree' ? (
-              <span className="text-neutral-300">
-                Worktree ·{' '}
-                <span className="font-mono text-[11px] text-neutral-400">
-                  {t.repoPath ?? '(repo unset)'}
+              <div className="space-y-1">
+                <span className="text-neutral-300">
+                  Worktree ·{' '}
+                  <span className="font-mono text-[11px] text-neutral-400">
+                    {t.repoPath ?? '(repo unset)'}
+                  </span>
+                  {t.branchName && (
+                    <>
+                      {' @ '}
+                      <span className="font-mono text-[11px] text-emerald-400">{t.branchName}</span>
+                    </>
+                  )}
+                  {t.baseBranch && (
+                    <span className="text-[10px] text-neutral-500"> → {t.baseBranch}</span>
+                  )}
                 </span>
-                {t.branchName && (
-                  <>
-                    {' @ '}
-                    <span className="font-mono text-[11px] text-emerald-400">{t.branchName}</span>
-                  </>
+                {t.workspacePath && t.branchName && (
+                  <button
+                    onClick={() => setShowDiff(true)}
+                    className="block rounded border border-neutral-700 px-2 py-1 text-neutral-300 hover:bg-neutral-800"
+                  >
+                    View changes
+                  </button>
                 )}
-              </span>
+              </div>
             ) : (
               <span className="text-neutral-300">
                 Dir ·{' '}
@@ -303,6 +357,65 @@ export function KanbanDrawer(): React.JSX.Element | null {
             )}
           </div>
         </section>
+
+        {/* Review actions — integrate a finished worktree task */}
+        {t.status === 'review' && (
+          <section>
+            <h3 className="mb-1 font-semibold text-neutral-400">Review &amp; integrate</h3>
+            <div className="space-y-2 rounded border border-neutral-800 bg-neutral-950 p-2">
+              <p className="text-[10px] text-neutral-500">
+                Work is committed on{' '}
+                <span className="font-mono text-emerald-400">
+                  {t.branchName ?? '(unknown branch)'}
+                </span>
+                . Pick how to integrate it.
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {/* Merge / PR need a worktree branch + base; otherwise only "Do Nothing" applies. */}
+                {t.workspaceKind === 'worktree' && t.branchName && t.baseBranch && (
+                  <>
+                    <button
+                      onClick={() => void runReview('merge')}
+                      disabled={reviewBusy !== null}
+                      className="inline-flex items-center gap-1 rounded bg-emerald-700 px-2 py-1 font-medium text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <GitMerge size={12} />
+                      {reviewBusy === 'merge' ? 'Merging…' : `Merge to ${t.baseBranch}`}
+                    </button>
+                    <button
+                      onClick={() => void runReview('pr')}
+                      disabled={reviewBusy !== null}
+                      className="inline-flex items-center gap-1 rounded border border-sky-700 px-2 py-1 text-sky-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <GitPullRequest size={12} />
+                      {reviewBusy === 'pr' ? 'Opening…' : 'Make Pull Request'}
+                    </button>
+                  </>
+                )}
+                <button
+                  onClick={() => void runReview('accept')}
+                  disabled={reviewBusy !== null}
+                  className="inline-flex items-center gap-1 rounded border border-neutral-700 px-2 py-1 text-neutral-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Check size={12} />
+                  {reviewBusy === 'accept' ? 'Accepting…' : 'Do Nothing'}
+                </button>
+              </div>
+              {reviewMsg && (
+                <p className="break-all text-[10px] text-emerald-400">
+                  {reviewMsg.startsWith('http') ? (
+                    <a href={reviewMsg} target="_blank" rel="noreferrer" className="underline">
+                      {reviewMsg}
+                    </a>
+                  ) : (
+                    reviewMsg
+                  )}
+                </p>
+              )}
+              {reviewErr && <p className="text-[10px] text-red-400">{reviewErr}</p>}
+            </div>
+          </section>
+        )}
 
         {/* Result / body preview (for blocked cards this holds the agent's question) */}
         {t.result && (
@@ -617,6 +730,13 @@ export function KanbanDrawer(): React.JSX.Element | null {
           Created {relativeTime(t.createdAt)} · Updated {relativeTime(t.updatedAt)}
         </p>
       </div>
+
+      <GitChangesModal
+        isOpen={showDiff}
+        onClose={() => setShowDiff(false)}
+        cwd={t.workspacePath ?? undefined}
+        compareRef={t.baseBranch}
+      />
     </div>
   );
 }

--- a/src/renderer/src/components/kanban/kanban-utils.ts
+++ b/src/renderer/src/components/kanban/kanban-utils.ts
@@ -7,11 +7,12 @@ export const COLUMNS: Array<{ status: TaskStatus; label: string }> = [
   { status: 'ready', label: 'Ready' },
   { status: 'running', label: 'Running' },
   { status: 'blocked', label: 'Blocked' },
+  { status: 'review', label: 'Review' },
   { status: 'done', label: 'Done' }
 ];
 
 // Manual drag targets exclude 'running' (dispatcher-owned) and 'archived'.
-export const DRAG_TARGETS: TaskStatus[] = ['triage', 'todo', 'ready', 'blocked', 'done'];
+export const DRAG_TARGETS: TaskStatus[] = ['triage', 'todo', 'ready', 'blocked', 'review', 'done'];
 
 export function relativeTime(epochMs: number): string {
   const diff = Date.now() - epochMs;

--- a/src/renderer/src/store/kanban-store.ts
+++ b/src/renderer/src/store/kanban-store.ts
@@ -11,7 +11,10 @@ import type {
   SwarmCreated,
   Task
 } from '../../../shared/kanban-types';
-import type { KanbanArtifactPreviewResponse } from '../../../shared/ipc-api';
+import type {
+  KanbanArtifactPreviewResponse,
+  KanbanReviewActionResult
+} from '../../../shared/ipc-api';
 
 /** A pending "use artifact as input" request, consumed by the board's create form / swarm modal. */
 export type ArtifactSeed = {
@@ -44,6 +47,9 @@ type KanbanState = {
   addLink: (parentId: string, childId: string) => Promise<void>;
   removeLink: (parentId: string, childId: string) => Promise<void>;
   nudge: () => Promise<void>;
+  mergeTask: (id: string) => Promise<KanbanReviewActionResult>;
+  createPr: (id: string) => Promise<KanbanReviewActionResult>;
+  acceptTask: (id: string) => Promise<KanbanReviewActionResult>;
   decompose: (id: string) => Promise<void>;
   specify: (id: string) => Promise<void>;
   setSchedule: (taskId: string, input: ScheduleInput) => Promise<void>;
@@ -169,6 +175,24 @@ export const useKanbanStore = create<KanbanState>((set, get) => ({
   },
   nudge: async () => {
     await window.fleet.kanban.nudge();
+  },
+  mergeTask: async (id) => {
+    const result = await window.fleet.kanban.mergeTask(id);
+    await get().loadBoard();
+    await get().refreshDetail();
+    return result;
+  },
+  createPr: async (id) => {
+    const result = await window.fleet.kanban.createPr(id);
+    await get().loadBoard();
+    await get().refreshDetail();
+    return result;
+  },
+  acceptTask: async (id) => {
+    const result = await window.fleet.kanban.acceptTask(id);
+    await get().loadBoard();
+    await get().refreshDetail();
+    return result;
   },
   decompose: async (id) => {
     await window.fleet.kanban.decompose(id);

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -280,6 +280,19 @@ export type KanbanReplyAndResumeRequest = {
   body: string;
 };
 
+/** Outcome of a review integration action (merge / PR / accept). */
+export type KanbanReviewActionResult = {
+  ok: boolean;
+  /** PR URL when a pull request was created. */
+  prUrl?: string;
+  /** True when a merge failed due to conflicts (vs a setup/remote error). */
+  conflict?: boolean;
+  /** Human-readable failure reason when ok is false. */
+  error?: string;
+  /** Human-readable success note when ok is true. */
+  message?: string;
+};
+
 export type KanbanAddAttachmentRequest = {
   taskId: string;
   sourcePath: string;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -162,5 +162,8 @@ export const IPC_CHANNELS = {
   KANBAN_RESUME_SCHEDULE: 'kanban:resume-schedule',
   KANBAN_PREVIEW_SCHEDULE: 'kanban:preview-schedule',
   KANBAN_FOCUS_TASK: 'kanban:focus-task',
-  KANBAN_CREATE_SWARM: 'kanban:create-swarm'
+  KANBAN_CREATE_SWARM: 'kanban:create-swarm',
+  KANBAN_MERGE_TASK: 'kanban:merge-task',
+  KANBAN_CREATE_PR: 'kanban:create-pr',
+  KANBAN_ACCEPT_TASK: 'kanban:accept-task'
 } as const;

--- a/src/shared/kanban-types.ts
+++ b/src/shared/kanban-types.ts
@@ -5,6 +5,7 @@ export type TaskStatus =
   | 'ready'
   | 'running'
   | 'blocked'
+  | 'review'
   | 'done'
   | 'archived';
 
@@ -44,6 +45,8 @@ export interface Task {
   workspacePath: string | null;
   repoPath: string | null;
   branchName: string | null;
+  /** Repo HEAD captured when a worktree was created: the merge target and child-branch base. */
+  baseBranch: string | null;
   modelOverride: string | null;
   skills: string[];
   boardId: string;
@@ -164,6 +167,8 @@ export interface CreateTaskInput {
   repoPath?: string;
   workspacePath?: string;
   branchName?: string | null;
+  /** Start-point/merge-target a worktree child inherits from its parent. */
+  baseBranch?: string | null;
   modelOverride?: string | null;
   skills?: string[];
   boardId?: string;
@@ -221,6 +226,8 @@ export interface SwarmInput {
   workspaceKind?: WorkspaceKind;
   repoPath?: string;
   workspacePath?: string | null;
+  /** Start-point/merge-target worktree workers inherit (a worktree orchestrator's base). */
+  baseBranch?: string | null;
   maxRuntimeSeconds?: number | null;
   rootTitle?: string;
   verifierTitle?: string;


### PR DESCRIPTION
## Summary

Brings kanban **worktree** tasks to review/merge parity. A worktree task's `kanban_complete` no longer means *done* — the work is committed, the card lands in a new **Review** column, and you pick one of three drawer actions: **Merge to `<base>`**, **Make Pull Request**, or **Do Nothing** (accept + keep branch). `done` = accepted. This also lets dependent children inherit merged-parent work (they branch from base) without stacked branches.

Scratch/dir tasks and non-git repos are unaffected — the whole feature is gated on `workspaceKind === 'worktree'`.

## Phases

**1 — Safety**
- `finalizeWorktree` commits uncommitted work on a clean finish *and* on exit-3, so a run never leaves loose edits.
- `removeWorktree` only `git branch -D`s a branch merged into base; unmerged branches are kept on archive (emits `unmerged_branch_kept`).
- `base_branch` captured at worktree creation (schema **v7 → v8**, additive column).

**2 — Review column + diff**
- New `'review'` `TaskStatus` + column; `kanban_complete` routes worktree tasks → `review` with a `review-required: N files (+x/−y)` comment. Gating (`done`/`archived`) correctly keeps `review` parents blocking children.
- Diff reuses `GitChangesModal` via a new `compareRef` prop → `git.getStatus(cwd, baseRef)` shows committed `base...HEAD` (new `GitService.getRefDiff`), since the tree is clean after finalize.

**3 — Three actions**
- **Merge**: detached temp worktree + push to the base ref so the user's checkout is never disturbed (conflict → stays in review with a comment).
- **PR**: `git push` + `gh pr create`, graceful errors when no remote / `gh` missing.
- **Do Nothing**: accept, preserve branch + worktree.
- Children/swarm workers inherit the parent's `base_branch` and branch from it.

## Also
- Create-form validation: an "isolated copy" (worktree) task is blocked up front when the selected folder isn't a git repo, instead of failing at claim time.

## Verification
- `npm run typecheck` ✓ · `npm run build` ✓ · `npx vitest run` → **836 passed** (updated workspace/store/commands tests for the new branch-retention contract; added retention + unmerged-kept coverage).
- Reviewed by 3 parallel agents; applied 5 fixes + a DRY cleanup, and rejected 2 high-confidence findings that would have been regressions (review-gating SQL was already correct; `update-ref` merge would disturb the user's checkout).

Design spec: `docs/superpowers/specs/2026-06-01-kanban-worktree-review-parity-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)