### PR TITLE
feat(env-sync): editable bucket/region, scan-to-add targets, delivery dropdown

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -778,9 +778,13 @@ export function registerIpcHandlers(
 
   ipcMain.handle(IPC_CHANNELS.ENV_SYNC_DISCOVER, (_e, cwd: string) => findNearestConfig(cwd));
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_WRITE_CONFIG, (_e, repoDir: string, config: EnvSyncConfig) => {
-    writeConfig(repoDir, config);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_SYNC_WRITE_CONFIG,
+    (_e, repoDir: string, config: EnvSyncConfig) => {
+      writeConfig(repoDir, config);
+      envSyncManager.clearInjectCache(); // bucket/region/target/objectKey edits invalidate cached injected env
+    }
+  );
 
   ipcMain.handle(IPC_CHANNELS.ENV_SYNC_SCAN, (_e, repoDir: string) => scanCandidates(repoDir));
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -788,21 +788,29 @@ export function registerIpcHandlers(
 
   ipcMain.handle(IPC_CHANNELS.ENV_SYNC_SCAN, (_e, repoDir: string) => scanCandidates(repoDir));
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_STATUS, (_e, repoDir: string) => envSyncManager.status(repoDir));
-
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_PULL, (_e, repoDir: string, envFile: string, force: boolean) =>
-    envSyncManager.pull(repoDir, repoDir, envFile, { force })
+  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_STATUS, async (_e, repoDir: string) =>
+    envSyncManager.status(repoDir)
   );
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_PUSH, (_e, repoDir: string, envFile: string, force: boolean) =>
-    envSyncManager.push(repoDir, repoDir, envFile, { force })
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_SYNC_PULL,
+    async (_e, repoDir: string, envFile: string, force: boolean) =>
+      envSyncManager.pull(repoDir, repoDir, envFile, { force })
   );
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_RESOLVE, (_e, repoDir: string, envFile: string, choice: ConflictChoice) =>
-    envSyncManager.resolveConflict(repoDir, envFile, choice)
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_SYNC_PUSH,
+    async (_e, repoDir: string, envFile: string, force: boolean) =>
+      envSyncManager.push(repoDir, repoDir, envFile, { force })
   );
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_DIFF, (_e, repoDir: string, envFile: string) =>
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_SYNC_RESOLVE,
+    async (_e, repoDir: string, envFile: string, choice: ConflictChoice) =>
+      envSyncManager.resolveConflict(repoDir, envFile, choice)
+  );
+
+  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_DIFF, async (_e, repoDir: string, envFile: string) =>
     envSyncManager.diff(repoDir, envFile)
   );
 
@@ -814,11 +822,14 @@ export function registerIpcHandlers(
     envSyncManager.clearInjectCache(); // decrypted-with-old-passphrase vars are now stale
   });
 
-  ipcMain.handle(IPC_CHANNELS.ENV_SYNC_CLEAR_PASSPHRASE, (_e, req: EnvSyncClearPassphraseRequest) => {
-    if (req.id) envSyncSecrets.clearRepoPassphrase(req.id);
-    else envSyncSecrets.clearGlobalPassphrase();
-    envSyncManager.clearInjectCache();
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_SYNC_CLEAR_PASSPHRASE,
+    (_e, req: EnvSyncClearPassphraseRequest) => {
+      if (req.id) envSyncSecrets.clearRepoPassphrase(req.id);
+      else envSyncSecrets.clearGlobalPassphrase();
+      envSyncManager.clearInjectCache();
+    }
+  );
 
   ipcMain.handle(IPC_CHANNELS.ENV_SYNC_SET_AUTH, (_e, req: EnvSyncSetAuthRequest) => {
     if (req.id) envSyncSecrets.setRepoAuth(req.id, req.auth);

--- a/src/renderer/src/components/settings/EnvSyncSection.tsx
+++ b/src/renderer/src/components/settings/EnvSyncSection.tsx
@@ -9,7 +9,9 @@ import type {
   RedactedEnvSyncSecrets,
   RedactedEnvSyncAuth,
   EnvSyncAuthMode,
-  EnvSyncAuthInput
+  EnvSyncAuthInput,
+  EnvSyncConfig,
+  EnvSyncTarget
 } from '../../../../shared/env-sync-types';
 
 const STATUS_LABEL: Record<TargetSyncState, string> = {
@@ -207,6 +209,244 @@ function AuthControl({
   );
 }
 
+function RepoCard({
+  repo,
+  statuses,
+  encAvailable,
+  secrets,
+  onChanged,
+  onSecretsChanged,
+  doSync
+}: {
+  repo: DiscoveredRepo;
+  statuses: TargetStatus[];
+  encAvailable: boolean;
+  secrets: RedactedEnvSyncSecrets;
+  onChanged: () => Promise<void>;
+  onSecretsChanged: () => Promise<void>;
+  doSync: (repoDir: string, envFile: string, dir: 'pull' | 'push') => Promise<void>;
+}): React.JSX.Element {
+  const showToast = useToastStore((s) => s.show);
+  const { repoDir, config } = repo;
+
+  const [editing, setEditing] = useState(false);
+  const [bucketDraft, setBucketDraft] = useState(config.bucket);
+  const [regionDraft, setRegionDraft] = useState(config.region);
+  // null = scan panel closed; an array (possibly empty) = panel open with results.
+  const [candidates, setCandidates] = useState<string[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const saveConfig = async (next: EnvSyncConfig): Promise<boolean> => {
+    try {
+      await window.fleet.envSync.writeConfig(repoDir, next);
+      await onChanged();
+      return true;
+    } catch (err) {
+      showToast(`Could not save config: ${err instanceof Error ? err.message : 'unknown'}`, {
+        duration: 6000
+      });
+      return false;
+    }
+  };
+
+  const startEdit = (): void => {
+    setBucketDraft(config.bucket);
+    setRegionDraft(config.region);
+    setEditing(true);
+  };
+
+  const saveBucketRegion = async (): Promise<void> => {
+    const bucket = bucketDraft.trim();
+    const region = regionDraft.trim();
+    if (!bucket || !region) {
+      showToast('Bucket and region are required', { duration: 4000 });
+      return;
+    }
+    if (await saveConfig({ ...config, bucket, region })) {
+      setEditing(false);
+      showToast('Saved bucket/region');
+    }
+  };
+
+  const runScan = async (): Promise<void> => {
+    const found = await window.fleet.envSync.scan(repoDir);
+    const existing = new Set(config.targets.map((t) => t.envFile));
+    const fresh = found.filter((f) => !existing.has(f));
+    setCandidates(fresh);
+    setSelected(new Set(fresh));
+  };
+
+  const toggleCandidate = (path: string): void => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const closeScan = (): void => {
+    setCandidates(null);
+    setSelected(new Set());
+  };
+
+  const addSelected = async (): Promise<void> => {
+    const additions: EnvSyncTarget[] = Array.from(selected).map((envFile) => ({
+      envFile,
+      delivery: 'file'
+    }));
+    if (additions.length === 0) return;
+    if (await saveConfig({ ...config, targets: [...config.targets, ...additions] })) {
+      closeScan();
+      showToast(`Added ${additions.length} target${additions.length === 1 ? '' : 's'}`);
+    }
+  };
+
+  const changeDelivery = async (envFile: string, delivery: 'file' | 'inject'): Promise<void> => {
+    const targets = config.targets.map((t) => (t.envFile === envFile ? { ...t, delivery } : t));
+    await saveConfig({ ...config, targets });
+  };
+
+  return (
+    <div className="rounded border border-neutral-800 p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-neutral-200">{config.id}</span>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <input
+              value={bucketDraft}
+              onChange={(e) => setBucketDraft(e.target.value)}
+              placeholder="Bucket"
+              className={`${inputCls} w-36`}
+            />
+            <input
+              value={regionDraft}
+              onChange={(e) => setRegionDraft(e.target.value)}
+              placeholder="Region"
+              className={`${inputCls} w-28`}
+            />
+            <button className="text-xs text-blue-400" onClick={() => void saveBucketRegion()}>
+              Save
+            </button>
+            <button className="text-xs text-neutral-400" onClick={() => setEditing(false)}>
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-neutral-500">
+              {config.bucket} · {config.region}
+            </span>
+            <button className="text-xs text-blue-400" onClick={startEdit}>
+              Edit
+            </button>
+          </div>
+        )}
+      </div>
+
+      <table className="mt-2 w-full text-xs">
+        <tbody>
+          {statuses.map((t) => (
+            <tr key={t.envFile} className="border-t border-neutral-800">
+              <td className="py-1 text-neutral-300">{t.envFile}</td>
+              <td className="py-1">
+                <select
+                  value={t.delivery}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === 'file' || v === 'inject') void changeDelivery(t.envFile, v);
+                  }}
+                  className="rounded border border-neutral-700 bg-neutral-800 px-1 py-0.5 text-neutral-400"
+                >
+                  <option value="file">file</option>
+                  <option value="inject">inject</option>
+                </select>
+              </td>
+              <td className="py-1 text-neutral-400">{STATUS_LABEL[t.state]}</td>
+              <td className="py-1 text-right">
+                <button
+                  className="text-xs text-blue-400 mr-2"
+                  onClick={() => void doSync(repoDir, t.envFile, 'pull')}
+                >
+                  Pull
+                </button>
+                <button
+                  className="text-xs text-blue-400"
+                  onClick={() => void doSync(repoDir, t.envFile, 'push')}
+                >
+                  Push
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="mt-2">
+        {candidates === null ? (
+          <button className="text-xs text-blue-400" onClick={() => void runScan()}>
+            Scan for env files
+          </button>
+        ) : (
+          <div className="rounded border border-neutral-800 p-2">
+            {candidates.length === 0 ? (
+              <p className="text-xs text-neutral-500">No new env files found.</p>
+            ) : (
+              <div className="space-y-1">
+                {candidates.map((path) => (
+                  <label key={path} className="flex items-center gap-2 text-xs text-neutral-300">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(path)}
+                      onChange={() => toggleCandidate(path)}
+                    />
+                    {path}
+                  </label>
+                ))}
+              </div>
+            )}
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                disabled={selected.size === 0}
+                className="text-xs bg-neutral-700 rounded px-2 py-1 disabled:text-neutral-500"
+                onClick={() => void addSelected()}
+              >
+                Add selected
+              </button>
+              <button className="text-xs text-neutral-400" onClick={closeScan}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 space-y-2 border-t border-neutral-800 pt-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="w-32 text-xs text-neutral-500">Passphrase override</span>
+          <PassphraseControl
+            id={config.id}
+            present={Boolean(secrets.repoOverrides[config.id]?.present)}
+            encAvailable={encAvailable}
+            clearLabel="Use global"
+            onChanged={onSecretsChanged}
+          />
+        </div>
+        <div className="flex items-start justify-between gap-2">
+          <span className="w-32 pt-1 text-xs text-neutral-500">AWS auth override</span>
+          <AuthControl
+            id={config.id}
+            redacted={secrets.authRepoOverrides[config.id]}
+            encAvailable={encAvailable}
+            resetLabel="Use global default"
+            onChanged={onSecretsChanged}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function EnvSyncSection(): React.JSX.Element {
   const showToast = useToastStore((s) => s.show);
   const [encAvailable, setEncAvailable] = useState(true);
@@ -317,62 +557,16 @@ export function EnvSyncSection(): React.JSX.Element {
           </p>
         )}
         {repos.map((repo) => (
-          <div key={repo.repoDir} className="rounded border border-neutral-800 p-3">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-neutral-200">{repo.config.id}</span>
-              <span className="text-xs text-neutral-500">
-                {repo.config.bucket} · {repo.config.region}
-              </span>
-            </div>
-            <table className="mt-2 w-full text-xs">
-              <tbody>
-                {(statuses[repo.repoDir] ?? []).map((t) => (
-                  <tr key={t.envFile} className="border-t border-neutral-800">
-                    <td className="py-1 text-neutral-300">{t.envFile}</td>
-                    <td className="py-1 text-neutral-500">{t.delivery}</td>
-                    <td className="py-1 text-neutral-400">{STATUS_LABEL[t.state]}</td>
-                    <td className="py-1 text-right">
-                      <button
-                        className="text-xs text-blue-400 mr-2"
-                        onClick={() => void doSync(repo.repoDir, t.envFile, 'pull')}
-                      >
-                        Pull
-                      </button>
-                      <button
-                        className="text-xs text-blue-400"
-                        onClick={() => void doSync(repo.repoDir, t.envFile, 'push')}
-                      >
-                        Push
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-
-            <div className="mt-3 space-y-2 border-t border-neutral-800 pt-2">
-              <div className="flex items-center justify-between gap-2">
-                <span className="w-32 text-xs text-neutral-500">Passphrase override</span>
-                <PassphraseControl
-                  id={repo.config.id}
-                  present={Boolean(secrets.repoOverrides[repo.config.id]?.present)}
-                  encAvailable={encAvailable}
-                  clearLabel="Use global"
-                  onChanged={onSecretsChanged}
-                />
-              </div>
-              <div className="flex items-start justify-between gap-2">
-                <span className="w-32 pt-1 text-xs text-neutral-500">AWS auth override</span>
-                <AuthControl
-                  id={repo.config.id}
-                  redacted={secrets.authRepoOverrides[repo.config.id]}
-                  encAvailable={encAvailable}
-                  resetLabel="Use global default"
-                  onChanged={onSecretsChanged}
-                />
-              </div>
-            </div>
-          </div>
+          <RepoCard
+            key={repo.repoDir}
+            repo={repo}
+            statuses={statuses[repo.repoDir] ?? []}
+            encAvailable={encAvailable}
+            secrets={secrets}
+            onChanged={refreshRepos}
+            onSecretsChanged={onSecretsChanged}
+            doSync={doSync}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
Fills in the per-repo config-editing UI that was deferred from the initial S3 env-sync feature (PR #213, spec §7). All renderer-side — the IPC was already wired.

## Changes
- **Bucket/region editing** — each repo card has an **Edit** toggle → bucket + region inputs → **Save** (writes `ENV_SYNC_WRITE_CONFIG`, refreshes). Required-field validation + toast feedback.
- **Scan-to-add-targets** — **Scan for env files** calls `ENV_SYNC_SCAN`, filters out already-configured files, and shows new candidates as a pre-checked checklist; **Add selected** appends them as `file`-delivery targets.
- **Delivery dropdown** — the targets table delivery column is now an editable `file`/`inject` `<select>` (was render-only text), persisted on change.
- **Correctness fix** — `ENV_SYNC_WRITE_CONFIG` now clears the manager's inject cache. This UI is the first thing to edit config at runtime, so a bucket/region/target change must invalidate cached injected env.

Extracted a `RepoCard` component in `EnvSyncSection.tsx` to hold the per-repo edit/scan state.

## Decision
`id` is shown but **not** editable: it's the passphrase-override key and the S3 object-key namespace, so changing it would orphan stored secrets and remote objects. The deferred item was "bucket/region editing"; a guarded rename can be added later if wanted.

## Verification
- `npm run typecheck` — 0 errors
- `npm run build` — succeeds
- env-sync tests — 15/15 pass (only renderer + IPC wiring changed)

Based on `feat/s3-env-sync` so the diff is just the follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)