### PR TITLE
feat(ui): add motion layer — overlay/toast animations and press feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
         "sharp": "^0.34.5",
         "tailwindcss": "^4.2.1",
         "tsx": "^4.21.0",
+        "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
         "vite": "^7.2.6",
         "vitest": "^4.1.0",
@@ -16365,6 +16366,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^4.2.1",
     "tsx": "^4.21.0",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.2.6",
     "vitest": "^4.1.0",

--- a/src/renderer/copilot/src/index.css
+++ b/src/renderer/copilot/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
 
 /* Pixel art rendering */
 .pixelated {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import { ToastContainer } from './components/ToastContainer';
 import type { PiPlanOpenPayload } from '../../shared/ipc-api';
 import { useKanbanAttention } from './hooks/useKanbanAttention';
 import { getAccentCssVars } from './lib/theme';
+import { tooltipAnim, popperAnim } from './lib/motion';
 import { useAppThemeVars } from './hooks/use-app-theme';
 
 type PiPlanModalEntry = PiPlanOpenPayload & { modalId: string };
@@ -58,7 +59,7 @@ function MiniSidebarTooltip({
           <Tooltip.Content
             side="right"
             sideOffset={8}
-            className="px-2 py-1 text-xs text-fleet-text bg-fleet-surface-2 border border-fleet-border-strong rounded shadow-lg z-50"
+            className={`px-2 py-1 text-xs text-fleet-text bg-fleet-surface-2 border border-fleet-border-strong rounded shadow-lg z-50 ${tooltipAnim}`}
           >
             {label}
             <Tooltip.Arrow className="fill-fleet-surface-2" />
@@ -787,7 +788,7 @@ export function App(): React.JSX.Element {
                 <Popover.Content
                   side="right"
                   sideOffset={8}
-                  className="min-w-[180px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg py-1 z-50"
+                  className={`min-w-[180px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg py-1 z-50 ${popperAnim}`}
                 >
                   <div className="px-3 py-1.5 text-[10px] text-fleet-text-subtle uppercase tracking-wider">
                     Current: {workspace.label}
@@ -912,20 +913,20 @@ export function App(): React.JSX.Element {
             )}
             {/* Undo close tab toast (NNG: undo > confirmation dialogs for divided-attention UX) */}
             {showUndoToast && lastClosedTab && (
-              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 px-4 py-2 bg-fleet-surface-2 border border-fleet-border-strong rounded-lg shadow-lg text-sm">
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 px-4 py-2 bg-fleet-surface-2 border border-fleet-border-strong rounded-lg shadow-lg text-sm duration-150 animate-in fade-in-0 slide-in-from-bottom-2">
                 <span className="text-fleet-text-secondary">
                   {lastClosedTab.tab.worktreePath ? 'Removing worktree' : 'Closed'} {'"'}
                   {lastClosedTab.tab.label}
                   {'"'}
                 </span>
                 <button
-                  className="text-blue-400 hover:text-blue-300 font-medium"
+                  className="text-blue-400 hover:text-blue-300 font-medium transition active:scale-95"
                   onClick={handleUndo}
                 >
                   Undo
                 </button>
                 <button
-                  className="text-fleet-text-subtle hover:text-fleet-text-secondary"
+                  className="text-fleet-text-subtle hover:text-fleet-text-secondary transition active:scale-90"
                   onClick={() => {
                     setShowUndoToast(false);
                     if (undoTimerRef.current) clearTimeout(undoTimerRef.current);

--- a/src/renderer/src/components/ClipboardHistoryOverlay.tsx
+++ b/src/renderer/src/components/ClipboardHistoryOverlay.tsx
@@ -3,6 +3,7 @@ import { Clipboard } from 'lucide-react';
 import { useWorkspaceStore } from '../store/workspace-store';
 import { bracketedPaste } from '../lib/shell-utils';
 import type { ClipboardEntry } from '../../../shared/ipc-api';
+import { Overlay } from './Overlay';
 
 type ClipboardHistoryOverlayProps = {
   isOpen: boolean;
@@ -108,85 +109,81 @@ export function ClipboardHistoryOverlay({
     }
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
-      <div
-        className="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="px-3 py-2 border-b border-neutral-800 flex items-center gap-2">
-          <Clipboard size={14} className="text-neutral-500 shrink-0" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Filter clipboard history..."
-            className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500"
-          />
-          <span className="text-[10px] text-neutral-600">{filtered.length} items</span>
-        </div>
-
-        {/* Entries list */}
-        <div ref={listRef} className="overflow-y-auto py-1">
-          {filtered.length === 0 ? (
-            <div className="px-3 py-4 text-sm text-neutral-500 text-center">
-              {entries.length === 0 ? 'Clipboard history is empty' : 'No matching entries'}
-            </div>
-          ) : (
-            filtered.map((entry, i) => (
-              <button
-                key={entry.id}
-                className={`w-full flex flex-col gap-0.5 px-3 py-2 text-left transition-colors ${
-                  i === selectedIndex
-                    ? 'bg-neutral-700 text-white'
-                    : 'text-neutral-300 hover:bg-neutral-800'
-                }`}
-                onMouseEnter={() => setSelectedIndex(i)}
-                onClick={() => handlePaste(entry)}
-              >
-                <pre className="text-sm font-mono whitespace-pre-wrap break-all line-clamp-3">
-                  {truncateLines(entry.preview, 3)}
-                </pre>
-                <div className="flex items-center gap-2 text-[10px] text-neutral-600">
-                  <span>{formatTimestamp(entry.timestamp)}</span>
-                  <span>{entry.charCount} chars</span>
-                  {entry.lineCount > 1 && <span>{entry.lineCount} lines</span>}
-                </div>
-              </button>
-            ))
-          )}
-        </div>
-
-        {/* Preview pane for selected entry */}
-        {filtered[selectedIndex] && filtered[selectedIndex].text.length > 200 && (
-          <div className="border-t border-neutral-800 px-3 py-2 max-h-[20vh] overflow-y-auto">
-            <div className="text-[10px] text-neutral-600 uppercase tracking-wider mb-1">
-              Preview
-            </div>
-            <pre className="text-xs font-mono text-neutral-400 whitespace-pre-wrap break-all">
-              {filtered[selectedIndex].text}
-            </pre>
-          </div>
-        )}
-
-        {/* Footer */}
-        <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
-          {!targetPaneId ? (
-            <span className="text-amber-500/80">No active terminal</span>
-          ) : (
-            <>
-              <span>↑↓ navigate</span>
-              <span>↵ paste to terminal</span>
-              <span>esc dismiss</span>
-            </>
-          )}
-        </div>
+    <Overlay
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="justify-center"
+      panelClassName="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
+    >
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-neutral-800 flex items-center gap-2">
+        <Clipboard size={14} className="text-neutral-500 shrink-0" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Filter clipboard history..."
+          className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500"
+        />
+        <span className="text-[10px] text-neutral-600">{filtered.length} items</span>
       </div>
-    </div>
+
+      {/* Entries list */}
+      <div ref={listRef} className="overflow-y-auto py-1">
+        {filtered.length === 0 ? (
+          <div className="px-3 py-4 text-sm text-neutral-500 text-center">
+            {entries.length === 0 ? 'Clipboard history is empty' : 'No matching entries'}
+          </div>
+        ) : (
+          filtered.map((entry, i) => (
+            <button
+              key={entry.id}
+              className={`w-full flex flex-col gap-0.5 px-3 py-2 text-left transition-colors ${
+                i === selectedIndex
+                  ? 'bg-neutral-700 text-white'
+                  : 'text-neutral-300 hover:bg-neutral-800'
+              }`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onClick={() => handlePaste(entry)}
+            >
+              <pre className="text-sm font-mono whitespace-pre-wrap break-all line-clamp-3">
+                {truncateLines(entry.preview, 3)}
+              </pre>
+              <div className="flex items-center gap-2 text-[10px] text-neutral-600">
+                <span>{formatTimestamp(entry.timestamp)}</span>
+                <span>{entry.charCount} chars</span>
+                {entry.lineCount > 1 && <span>{entry.lineCount} lines</span>}
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+
+      {/* Preview pane for selected entry */}
+      {filtered[selectedIndex] && filtered[selectedIndex].text.length > 200 && (
+        <div className="border-t border-neutral-800 px-3 py-2 max-h-[20vh] overflow-y-auto">
+          <div className="text-[10px] text-neutral-600 uppercase tracking-wider mb-1">Preview</div>
+          <pre className="text-xs font-mono text-neutral-400 whitespace-pre-wrap break-all">
+            {filtered[selectedIndex].text}
+          </pre>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
+        {!targetPaneId ? (
+          <span className="text-amber-500/80">No active terminal</span>
+        ) : (
+          <>
+            <span>↑↓ navigate</span>
+            <span>↵ paste to terminal</span>
+            <span>esc dismiss</span>
+          </>
+        )}
+      </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { createCommandRegistry, fuzzyMatch, formatCommandShortcut } from '../lib/commands';
+import { Overlay } from './Overlay';
 
 type CommandPaletteProps = {
   isOpen: boolean;
@@ -30,8 +31,6 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps): React.
     setSelectedIndex(0);
   }, [query]);
 
-  if (!isOpen) return null;
-
   const executeSelected = (): void => {
     const cmd = filtered[selectedIndex];
     if (cmd) {
@@ -57,56 +56,54 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps): React.
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
-      <div
-        className="mt-[15vh] w-[480px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="px-3 py-2 border-b border-neutral-800">
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Type a command..."
-            className="w-full bg-transparent text-sm text-white outline-none placeholder-neutral-500"
-          />
-        </div>
-        <div className="overflow-y-auto py-1">
-          {filtered.length === 0 ? (
-            <div className="px-3 py-4 text-sm text-neutral-500 text-center">
-              No matching commands
-            </div>
-          ) : (
-            filtered.map((cmd, i) => {
-              const shortcutLabel = formatCommandShortcut(cmd);
-              return (
-                <button
-                  key={cmd.id}
-                  className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left transition-colors ${
-                    i === selectedIndex
-                      ? 'bg-neutral-700 text-white'
-                      : 'text-neutral-300 hover:bg-neutral-800'
-                  }`}
-                  onMouseEnter={() => setSelectedIndex(i)}
-                  onClick={() => {
-                    onClose();
-                    cmd.execute();
-                  }}
-                >
-                  <span>{cmd.label}</span>
-                  {shortcutLabel && (
-                    <kbd className="text-xs text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-700">
-                      {shortcutLabel}
-                    </kbd>
-                  )}
-                </button>
-              );
-            })
-          )}
-        </div>
+    <Overlay
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="justify-center"
+      panelClassName="mt-[15vh] w-[480px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
+    >
+      <div className="px-3 py-2 border-b border-neutral-800">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a command..."
+          className="w-full bg-transparent text-sm text-white outline-none placeholder-neutral-500"
+        />
       </div>
-    </div>
+      <div className="overflow-y-auto py-1">
+        {filtered.length === 0 ? (
+          <div className="px-3 py-4 text-sm text-neutral-500 text-center">No matching commands</div>
+        ) : (
+          filtered.map((cmd, i) => {
+            const shortcutLabel = formatCommandShortcut(cmd);
+            return (
+              <button
+                key={cmd.id}
+                className={`w-full flex items-center justify-between px-3 py-2 text-sm text-left transition-colors ${
+                  i === selectedIndex
+                    ? 'bg-neutral-700 text-white'
+                    : 'text-neutral-300 hover:bg-neutral-800'
+                }`}
+                onMouseEnter={() => setSelectedIndex(i)}
+                onClick={() => {
+                  onClose();
+                  cmd.execute();
+                }}
+              >
+                <span>{cmd.label}</span>
+                {shortcutLabel && (
+                  <kbd className="text-xs text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-700">
+                    {shortcutLabel}
+                  </kbd>
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/FileSearchOverlay.tsx
+++ b/src/renderer/src/components/FileSearchOverlay.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Search, ArrowDownAZ, Clock, HardDrive, Image, FolderOpen, Layers } from 'lucide-react';
+import { Overlay } from './Overlay';
 import { createLogger } from '../logger';
 const log = createLogger('overlay:file-search');
 import { useWorkspaceStore } from '../store/workspace-store';
@@ -438,8 +439,6 @@ export function FileSearchOverlay({
     }
   };
 
-  if (!isOpen) return null;
-
   const placeholder =
     scope === 'generated'
       ? 'Search generated images...'
@@ -651,95 +650,96 @@ export function FileSearchOverlay({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-center bg-fleet-bg/60" onClick={onClose}>
-      <div
-        className="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Search input */}
-        <div className="px-3 py-2 border-b border-fleet-border flex items-center gap-2">
-          <Search size={14} className="text-fleet-text-subtle shrink-0" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className="flex-1 bg-transparent text-sm text-fleet-text outline-none placeholder-fleet-text-subtle"
-          />
-          {isLoading && <span className="text-xs text-fleet-text-subtle">Searching...</span>}
-        </div>
+    <Overlay
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="justify-center"
+      backdropClassName="bg-fleet-bg/60"
+      panelClassName="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl overflow-hidden"
+    >
+      {/* Search input */}
+      <div className="px-3 py-2 border-b border-fleet-border flex items-center gap-2">
+        <Search size={14} className="text-fleet-text-subtle shrink-0" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="flex-1 bg-transparent text-sm text-fleet-text outline-none placeholder-fleet-text-subtle"
+        />
+        {isLoading && <span className="text-xs text-fleet-text-subtle">Searching...</span>}
+      </div>
 
-        {/* Scope tabs */}
-        <div className="px-3 py-1.5 border-b border-fleet-border flex items-center gap-1">
-          {SCOPE_OPTIONS.map(({ id, label, icon: Icon }) => {
-            const count =
-              id === 'generated'
-                ? generatedResultCount
-                : id === 'files'
-                  ? fileResultCount
-                  : undefined;
-            return (
+      {/* Scope tabs */}
+      <div className="px-3 py-1.5 border-b border-fleet-border flex items-center gap-1">
+        {SCOPE_OPTIONS.map(({ id, label, icon: Icon }) => {
+          const count =
+            id === 'generated'
+              ? generatedResultCount
+              : id === 'files'
+                ? fileResultCount
+                : undefined;
+          return (
+            <button
+              key={id}
+              onClick={() => setScope(id)}
+              className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded transition-colors ${
+                scope === id
+                  ? 'bg-fleet-surface-3 text-fleet-text'
+                  : 'text-fleet-text-subtle hover:text-fleet-text-secondary hover:bg-fleet-surface-2'
+              }`}
+            >
+              <Icon size={11} />
+              {label}
+              {count !== undefined && count > 0 && (
+                <span className="text-[10px] text-fleet-text-subtle ml-0.5">({count})</span>
+              )}
+            </button>
+          );
+        })}
+        {/* Sort controls (only for file-based scopes) */}
+        {scope !== 'generated' && results.length > 0 && (
+          <div className="ml-auto flex items-center gap-1">
+            <span className="text-[10px] text-fleet-text-subtle mr-1">Sort:</span>
+            {SORT_OPTIONS.map(({ id, label, icon: Icon }) => (
               <button
                 key={id}
-                onClick={() => setScope(id)}
-                className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded transition-colors ${
-                  scope === id
+                onClick={() => setSort(id)}
+                className={`flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded transition-colors ${
+                  sort === id
                     ? 'bg-fleet-surface-3 text-fleet-text'
                     : 'text-fleet-text-subtle hover:text-fleet-text-secondary hover:bg-fleet-surface-2'
                 }`}
               >
-                <Icon size={11} />
+                <Icon size={10} />
                 {label}
-                {count !== undefined && count > 0 && (
-                  <span className="text-[10px] text-fleet-text-subtle ml-0.5">({count})</span>
-                )}
               </button>
-            );
-          })}
-          {/* Sort controls (only for file-based scopes) */}
-          {scope !== 'generated' && results.length > 0 && (
-            <div className="ml-auto flex items-center gap-1">
-              <span className="text-[10px] text-fleet-text-subtle mr-1">Sort:</span>
-              {SORT_OPTIONS.map(({ id, label, icon: Icon }) => (
-                <button
-                  key={id}
-                  onClick={() => setSort(id)}
-                  className={`flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded transition-colors ${
-                    sort === id
-                      ? 'bg-fleet-surface-3 text-fleet-text'
-                      : 'text-fleet-text-subtle hover:text-fleet-text-secondary hover:bg-fleet-surface-2'
-                  }`}
-                >
-                  <Icon size={10} />
-                  {label}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Results */}
-        <div ref={listRef} className="overflow-y-auto py-1">
-          {scope === 'generated' && renderGeneratedScope()}
-          {scope === 'files' && renderFileResults()}
-          {scope === 'all' && renderAllScope()}
-        </div>
-
-        {/* Footer */}
-        <div className="px-3 py-1.5 border-t border-fleet-border flex items-center gap-3 text-xs text-fleet-text-subtle">
-          {!targetPaneId ? (
-            <span className="text-amber-500/80">No active terminal</span>
-          ) : (
-            <>
-              <span>↑↓ navigate</span>
-              <span>↵ paste</span>
-              <span>esc dismiss</span>
-            </>
-          )}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
-    </div>
+
+      {/* Results */}
+      <div ref={listRef} className="overflow-y-auto py-1">
+        {scope === 'generated' && renderGeneratedScope()}
+        {scope === 'files' && renderFileResults()}
+        {scope === 'all' && renderAllScope()}
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 py-1.5 border-t border-fleet-border flex items-center gap-3 text-xs text-fleet-text-subtle">
+        {!targetPaneId ? (
+          <span className="text-amber-500/80">No active terminal</span>
+        ) : (
+          <>
+            <span>↑↓ navigate</span>
+            <span>↵ paste</span>
+            <span>esc dismiss</span>
+          </>
+        )}
+      </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/GitChangesModal.tsx
+++ b/src/renderer/src/components/GitChangesModal.tsx
@@ -5,6 +5,7 @@ import { DiffView, DiffModeEnum, DiffFile, type DiffHighlighter } from '@git-dif
 import '@git-diff-view/react/styles/diff-view.css';
 import type { GitStatusPayload, GitFileStatus } from '../../../shared/ipc-api';
 import { getLanguageForPath } from '../../../shared/languages';
+import { Overlay } from './Overlay';
 
 type DiffHighlighterInstance = Omit<DiffHighlighter, 'getHighlighterEngine'> | undefined;
 
@@ -161,11 +162,9 @@ export function GitChangesModal({
     [onClose, filteredFiles, activeFileIndex, scrollToFile]
   );
 
-  if (!isOpen) return null;
-
   if (!cwd) {
     return (
-      <ModalShell onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
+      <ModalShell open={isOpen} onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
         <StateMessage
           icon={<AlertCircle size={32} />}
           message="Working directory not available"
@@ -177,7 +176,7 @@ export function GitChangesModal({
 
   if (loading) {
     return (
-      <ModalShell onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
+      <ModalShell open={isOpen} onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
         <StateMessage
           icon={<Loader2 size={32} className="animate-spin" />}
           message="Loading changes..."
@@ -188,7 +187,7 @@ export function GitChangesModal({
 
   if (data?.error) {
     return (
-      <ModalShell onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
+      <ModalShell open={isOpen} onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
         <StateMessage
           icon={<AlertCircle size={32} className="text-red-400" />}
           message={data.error}
@@ -200,7 +199,7 @@ export function GitChangesModal({
 
   if (data && !data.isRepo) {
     return (
-      <ModalShell onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
+      <ModalShell open={isOpen} onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
         <StateMessage
           icon={<GitBranch size={32} />}
           message="Not a git repository"
@@ -212,7 +211,7 @@ export function GitChangesModal({
 
   if (data?.files.length === 0) {
     return (
-      <ModalShell onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
+      <ModalShell open={isOpen} onClose={onClose} onKeyDown={handleKeyDown} modalRef={modalRef}>
         <StateMessage icon={<GitBranch size={32} />} message="No changes" onClose={onClose} />
       </ModalShell>
     );
@@ -223,6 +222,7 @@ export function GitChangesModal({
 
   return (
     <ModalShell
+      open={isOpen}
       onClose={onClose}
       onKeyDown={handleKeyDown}
       modalRef={modalRef}
@@ -250,11 +250,14 @@ export function GitChangesModal({
                 diffMode === DiffModeEnum.Unified ? DiffModeEnum.Split : DiffModeEnum.Unified
               )
             }
-            className="px-2 py-1 text-xs text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+            className="px-2 py-1 text-xs text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-[0.97]"
           >
             {diffMode === DiffModeEnum.Unified ? 'Split' : 'Unified'}
           </button>
-          <button onClick={onClose} className="p-1 text-neutral-500 hover:text-white">
+          <button
+            onClick={onClose}
+            className="p-1 text-neutral-500 hover:text-white transition active:scale-90"
+          >
             <X size={16} />
           </button>
         </div>
@@ -315,12 +318,14 @@ export function GitChangesModal({
 // --- Sub-components ---
 
 function ModalShell({
+  open,
   children,
   onClose,
   onKeyDown,
   modalRef,
   showCloseButton = true
 }: {
+  open: boolean;
   children: React.ReactNode;
   onClose: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
@@ -328,33 +333,29 @@ function ModalShell({
   showCloseButton?: boolean;
 }): React.JSX.Element {
   useEffect(() => {
-    modalRef.current?.focus();
-  }, [modalRef]);
+    if (open) modalRef.current?.focus();
+  }, [open, modalRef]);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-    >
+    <Overlay open={open} onClose={onClose}>
       <div
         ref={modalRef}
         tabIndex={-1}
         onKeyDown={onKeyDown}
-        onClick={(e) => e.stopPropagation()}
         className="relative bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl flex flex-col outline-none"
         style={{ width: 'calc(100vw - 64px)', height: 'calc(100vh - 48px)' }}
       >
         {showCloseButton && (
           <button
             onClick={onClose}
-            className="absolute top-3 right-3 z-10 p-1 text-neutral-500 hover:text-white"
+            className="absolute top-3 right-3 z-10 p-1 text-neutral-500 hover:text-white transition active:scale-90"
           >
             <X size={16} />
           </button>
         )}
         {children}
       </div>
-    </div>
+    </Overlay>
   );
 }
 
@@ -372,7 +373,10 @@ function StateMessage({
       {icon}
       <span className="text-sm">{message}</span>
       {onClose && (
-        <button onClick={onClose} className="text-xs text-neutral-600 hover:text-white mt-2">
+        <button
+          onClick={onClose}
+          className="text-xs text-neutral-600 hover:text-white mt-2 transition active:scale-[0.97]"
+        >
           Close
         </button>
       )}

--- a/src/renderer/src/components/Overlay.tsx
+++ b/src/renderer/src/components/Overlay.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import { usePresence } from '../hooks/use-presence';
+
+type OverlayProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Panel content. The panel box (background/border/sizing) is yours via `panelClassName`. */
+  children: React.ReactNode;
+  /** Classes for the panel box — background, border, sizing, layout. */
+  panelClassName?: string;
+  /** Flex alignment for the panel within the viewport. Default centers both axes. */
+  containerClassName?: string;
+  /** Close when the Escape key is pressed. Default true. */
+  closeOnEscape?: boolean;
+  /** Backdrop tint classes. Default `bg-black/60`. */
+  backdropClassName?: string;
+};
+
+const ENTER_EXIT_MS = 150;
+
+/**
+ * Shared modal/overlay shell: a backdrop that fades and a panel that scales +
+ * slides on enter/exit. Centralizes backdrop-click-to-close and Escape so the
+ * individual overlays only describe their panel. Exit animations work because
+ * {@link usePresence} keeps the tree mounted for the duration of the close.
+ */
+export function Overlay({
+  open,
+  onClose,
+  children,
+  panelClassName = '',
+  containerClassName = 'items-center justify-center',
+  closeOnEscape = true,
+  backdropClassName = 'bg-black/60'
+}: OverlayProps): React.JSX.Element | null {
+  const { mounted, state } = usePresence(open, ENTER_EXIT_MS);
+
+  useEffect(() => {
+    if (!open || !closeOnEscape) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, closeOnEscape, onClose]);
+
+  if (!mounted) return null;
+
+  return (
+    <div
+      data-state={state}
+      onClick={onClose}
+      className={`fixed inset-0 z-50 flex ${containerClassName} ${backdropClassName} duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0`}
+    >
+      <div
+        data-state={state}
+        onClick={(e) => e.stopPropagation()}
+        className={`duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-bottom-2 ${panelClassName}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/PaneToolbar.tsx
+++ b/src/renderer/src/components/PaneToolbar.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
+import { tooltipAnim } from '../lib/motion';
 
 function shortcutLabel(id: string): string {
   const def = getShortcut(id);
@@ -33,7 +34,7 @@ function ToolbarTooltip({
         <Tooltip.Content
           side="bottom"
           sideOffset={6}
-          className="px-2 py-1 text-xs text-white bg-neutral-800 border border-neutral-700 rounded shadow-lg z-50"
+          className={`px-2 py-1 text-xs text-white bg-neutral-800 border border-neutral-700 rounded shadow-lg z-50 ${tooltipAnim}`}
         >
           {label}
           <Tooltip.Arrow className="fill-neutral-800" />
@@ -87,7 +88,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onSplitHorizontal();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <Columns2 size={14} />
             </button>
@@ -100,7 +101,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onSplitVertical();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <Rows2 size={14} />
             </button>
@@ -113,7 +114,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onGitChanges();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <GitBranch size={14} />
             </button>
@@ -126,7 +127,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onFileSearch();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <FileSearch size={14} />
             </button>
@@ -139,7 +140,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onClipboardHistory();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <Clipboard size={14} />
             </button>
@@ -152,7 +153,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onInjectSkills();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <BookOpen size={14} />
             </button>
@@ -165,7 +166,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onAnnotate();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <Crosshair size={14} />
             </button>
@@ -178,7 +179,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onTelescope();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <Telescope size={14} />
             </button>
@@ -191,7 +192,7 @@ export function PaneToolbar({
                 e.stopPropagation();
                 onEnvSync();
               }}
-              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+              className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
             >
               <FolderSync size={14} />
             </button>
@@ -203,7 +204,7 @@ export function PaneToolbar({
               e.stopPropagation();
               onSearch();
             }}
-            className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+            className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
           >
             <Search size={14} />
           </button>
@@ -214,7 +215,7 @@ export function PaneToolbar({
               e.stopPropagation();
               onClose();
             }}
-            className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition-colors"
+            className="p-1 text-neutral-400 hover:text-white rounded hover:bg-neutral-700 transition active:scale-90"
           >
             <X size={14} />
           </button>

--- a/src/renderer/src/components/QuickOpenOverlay.tsx
+++ b/src/renderer/src/components/QuickOpenOverlay.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { Overlay } from './Overlay';
 import { useWorkspaceStore } from '../store/workspace-store';
 import { fuzzyMatch } from '../lib/commands';
 import { getFileIcon } from '../lib/file-icons';
@@ -123,86 +124,84 @@ export function QuickOpenOverlay({
     }
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
-      <div
-        className="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Search input */}
-        <div className="px-3 py-2 border-b border-neutral-800 flex items-center gap-2">
-          <svg
-            className="text-neutral-500 shrink-0"
-            width="14"
-            height="14"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-          >
-            <circle cx="6.5" cy="6.5" r="4.5" />
-            <line x1="10.5" y1="10.5" x2="14" y2="14" />
-          </svg>
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Search files..."
-            className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500"
-          />
-          {isLoading && <span className="text-xs text-neutral-500">Loading...</span>}
-        </div>
+    <Overlay
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="justify-center"
+      panelClassName="mt-[15vh] w-[560px] max-h-[60vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden"
+    >
+      {/* Search input */}
+      <div className="px-3 py-2 border-b border-neutral-800 flex items-center gap-2">
+        <svg
+          className="text-neutral-500 shrink-0"
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        >
+          <circle cx="6.5" cy="6.5" r="4.5" />
+          <line x1="10.5" y1="10.5" x2="14" y2="14" />
+        </svg>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search files..."
+          className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500"
+        />
+        {isLoading && <span className="text-xs text-neutral-500">Loading...</span>}
+      </div>
 
-        {/* Results */}
-        <div ref={listRef} className="overflow-y-auto py-1">
-          {results.length === 0 && !isLoading ? (
-            <div className="px-3 py-4 text-sm text-neutral-500 text-center">
-              {query ? 'No matching files' : 'No recent files'}
-            </div>
-          ) : (
-            results.map((file, i) => (
-              <button
-                key={file.path}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
-                  i === selectedIndex
-                    ? 'bg-neutral-700 text-white'
-                    : 'text-neutral-300 hover:bg-neutral-800'
-                }`}
-                onMouseEnter={() => setSelectedIndex(i)}
-                onClick={() => handleSelect(file)}
-              >
-                <span className="text-neutral-500 shrink-0">{getFileIcon(file.name)}</span>
-                <div className="flex flex-col min-w-0">
-                  <span className="truncate font-medium">
-                    <HighlightedText text={file.name} query={query} />
-                  </span>
-                  {file.relativePath !== file.name && (
-                    <span className="truncate text-xs text-neutral-600">
-                      {file.relativePath.includes('/')
-                        ? file.relativePath.split('/').slice(0, -1).join('/')
-                        : file.relativePath}
-                    </span>
-                  )}
-                </div>
-              </button>
-            ))
-          )}
-        </div>
-
-        {/* Footer hint */}
-        {results.length > 0 && (
-          <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
-            <span>↑↓ navigate</span>
-            <span>↵ open</span>
-            <span>esc dismiss</span>
+      {/* Results */}
+      <div ref={listRef} className="overflow-y-auto py-1">
+        {results.length === 0 && !isLoading ? (
+          <div className="px-3 py-4 text-sm text-neutral-500 text-center">
+            {query ? 'No matching files' : 'No recent files'}
           </div>
+        ) : (
+          results.map((file, i) => (
+            <button
+              key={file.path}
+              className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
+                i === selectedIndex
+                  ? 'bg-neutral-700 text-white'
+                  : 'text-neutral-300 hover:bg-neutral-800'
+              }`}
+              onMouseEnter={() => setSelectedIndex(i)}
+              onClick={() => handleSelect(file)}
+            >
+              <span className="text-neutral-500 shrink-0">{getFileIcon(file.name)}</span>
+              <div className="flex flex-col min-w-0">
+                <span className="truncate font-medium">
+                  <HighlightedText text={file.name} query={query} />
+                </span>
+                {file.relativePath !== file.name && (
+                  <span className="truncate text-xs text-neutral-600">
+                    {file.relativePath.includes('/')
+                      ? file.relativePath.split('/').slice(0, -1).join('/')
+                      : file.relativePath}
+                  </span>
+                )}
+              </div>
+            </button>
+          ))
         )}
       </div>
-    </div>
+
+      {/* Footer hint */}
+      {results.length > 0 && (
+        <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc dismiss</span>
+        </div>
+      )}
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import { serializePane } from '../hooks/use-terminal';
 import { injectLiveCwd, getFirstPaneLiveCwd } from '../lib/workspace-utils';
 import { formatShortcut, getShortcut } from '../lib/shortcuts';
 import { getFileSave } from '../lib/file-save-registry';
+import { popperAnim, dialogFadeAnim } from '../lib/motion';
 import type { Workspace, PaneLeaf, Tab } from '../../../shared/types';
 import { SidebarResizeHandle } from './SidebarResizeHandle';
 import { DEFAULT_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH_RATIO } from './sidebar-constants';
@@ -147,7 +148,7 @@ function GroupHeader({
               <span className="text-[10px] text-fleet-text-subtle">{tabCount} tabs</span>
             )}
             <button
-              className="opacity-60 group-hover/header:opacity-100 text-fleet-text-muted hover:text-fleet-text w-5 h-5 flex items-center justify-center text-sm rounded border border-fleet-border-strong hover:border-fleet-border-strong hover:bg-fleet-surface-3 transition-all cursor-pointer"
+              className="opacity-60 group-hover/header:opacity-100 text-fleet-text-muted hover:text-fleet-text w-5 h-5 flex items-center justify-center text-sm rounded border border-fleet-border-strong hover:border-fleet-border-strong hover:bg-fleet-surface-3 transition active:scale-90 cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation();
                 onAddWorktree();
@@ -160,7 +161,9 @@ function GroupHeader({
         </div>
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
-        <ContextMenu.Content className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+        <ContextMenu.Content
+          className={`min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50 ${popperAnim}`}
+        >
           <ContextMenu.Item
             className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
             onSelect={() => {
@@ -1119,7 +1122,9 @@ export function Sidebar({
                 </span>
               </ContextMenu.Trigger>
               <ContextMenu.Portal>
-                <ContextMenu.Content className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+                <ContextMenu.Content
+                  className={`min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50 ${popperAnim}`}
+                >
                   <ContextMenu.Item
                     className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
                     onSelect={() => {
@@ -1143,14 +1148,14 @@ export function Sidebar({
           )}
           {/* Add tab button */}
           <button
-            className="text-fleet-text-subtle hover:text-fleet-text text-lg leading-none px-1 rounded hover:bg-fleet-surface-2 transition-colors"
+            className="text-fleet-text-subtle hover:text-fleet-text text-lg leading-none px-1 rounded hover:bg-fleet-surface-2 transition active:scale-90"
             onClick={() => addTab(undefined, window.fleet.homeDir)}
             title={`New Tab (${formatShortcut(getShortcut('new-tab')!)})`}
           >
             +
           </button>
           <button
-            className="text-fleet-text-subtle hover:text-fleet-text px-1 rounded hover:bg-fleet-surface-2 transition-colors"
+            className="text-fleet-text-subtle hover:text-fleet-text px-1 rounded hover:bg-fleet-surface-2 transition active:scale-90"
             onClick={onCollapse}
             title="Collapse sidebar"
           >
@@ -1404,7 +1409,7 @@ export function Sidebar({
             Workspaces
           </span>
           <button
-            className="text-fleet-text-subtle hover:text-fleet-text text-sm leading-none px-1 rounded hover:bg-fleet-surface-2 transition-colors"
+            className="text-fleet-text-subtle hover:text-fleet-text text-sm leading-none px-1 rounded hover:bg-fleet-surface-2 transition active:scale-90"
             onClick={() => {
               setShowNewWsInput(true);
               setNewWsName('');
@@ -1449,7 +1454,7 @@ export function Sidebar({
                   <span className="text-red-400">Delete this workspace?</span>
                   <div className="flex gap-2">
                     <button
-                      className="px-2 py-0.5 bg-red-600 hover:bg-red-500 text-white rounded transition-colors"
+                      className="px-2 py-0.5 bg-red-600 hover:bg-red-500 text-white rounded transition active:scale-[0.97]"
                       onClick={() => {
                         void handleDeleteWorkspace(ws.id);
                       }}
@@ -1457,7 +1462,7 @@ export function Sidebar({
                       Delete
                     </button>
                     <button
-                      className="px-2 py-0.5 bg-fleet-surface-3 hover:bg-fleet-surface-3 text-fleet-text-secondary rounded transition-colors"
+                      className="px-2 py-0.5 bg-fleet-surface-3 hover:bg-fleet-surface-3 text-fleet-text-secondary rounded transition active:scale-[0.97]"
                       onClick={() => setDeleteConfirmId(null)}
                     >
                       Cancel
@@ -1485,7 +1490,7 @@ export function Sidebar({
                 <ContextMenu.Root>
                   <ContextMenu.Trigger asChild>
                     <button
-                      className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded-md transition-colors"
+                      className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded-md transition active:scale-[0.97]"
                       onClick={() => handleSwitchWorkspace(ws.id)}
                       title={`Switch to ${ws.label}`}
                     >
@@ -1496,7 +1501,9 @@ export function Sidebar({
                     </button>
                   </ContextMenu.Trigger>
                   <ContextMenu.Portal>
-                    <ContextMenu.Content className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+                    <ContextMenu.Content
+                      className={`min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50 ${popperAnim}`}
+                    >
                       <ContextMenu.Item
                         className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
                         onSelect={() => {
@@ -1529,7 +1536,7 @@ export function Sidebar({
           );
           return (
             <button
-              className={`w-full flex items-center gap-2 px-2 py-1.5 text-xs rounded-md transition-colors ${
+              className={`w-full flex items-center gap-2 px-2 py-1.5 text-xs rounded-md transition active:scale-[0.97] ${
                 isSettingsActive
                   ? 'text-fleet-text bg-fleet-surface-3 ring-1 ring-fleet-border-strong'
                   : 'text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2'
@@ -1555,8 +1562,10 @@ export function Sidebar({
         }}
       >
         <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 bg-fleet-bg/60 z-50" />
-          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl p-5 w-80 text-sm">
+          <Dialog.Overlay className={`fixed inset-0 bg-fleet-bg/60 z-50 ${dialogFadeAnim}`} />
+          <Dialog.Content
+            className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl p-5 w-80 text-sm ${dialogFadeAnim}`}
+          >
             <Dialog.Title className="text-base font-semibold text-fleet-text mb-1">
               Save changes to &ldquo;{fileCloseConfirm?.label}&rdquo;?
             </Dialog.Title>
@@ -1565,7 +1574,7 @@ export function Sidebar({
             </Dialog.Description>
             <div className="flex justify-end gap-2">
               <button
-                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition-colors"
+                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition active:scale-[0.97]"
                 onClick={() => {
                   if (fileCloseConfirm) doCloseTab(fileCloseConfirm.tabId);
                   setFileCloseConfirm(null);
@@ -1574,14 +1583,14 @@ export function Sidebar({
                 Don&apos;t Save
               </button>
               <button
-                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition-colors"
+                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition active:scale-[0.97]"
                 onClick={() => setFileCloseConfirm(null)}
               >
                 Cancel
               </button>
               <button
                 disabled={fileSaving}
-                className="px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition-colors font-medium"
+                className="px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition active:scale-[0.97] disabled:active:scale-100 font-medium"
                 onClick={() => {
                   if (!fileCloseConfirm) return;
                   setFileSaving(true);
@@ -1614,8 +1623,10 @@ export function Sidebar({
         }}
       >
         <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 bg-fleet-bg/60 z-50" />
-          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl p-5 w-80 text-sm">
+          <Dialog.Overlay className={`fixed inset-0 bg-fleet-bg/60 z-50 ${dialogFadeAnim}`} />
+          <Dialog.Content
+            className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-fleet-surface border border-fleet-border-strong rounded-lg shadow-xl p-5 w-80 text-sm ${dialogFadeAnim}`}
+          >
             <Dialog.Title className="text-base font-semibold text-fleet-text mb-1">
               Remove worktree &ldquo;{worktreeCloseConfirm?.label}&rdquo;?
             </Dialog.Title>
@@ -1625,13 +1636,13 @@ export function Sidebar({
             </Dialog.Description>
             <div className="flex justify-end gap-2">
               <button
-                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition-colors"
+                className="px-3 py-1.5 text-xs text-fleet-text-muted hover:text-fleet-text hover:bg-fleet-surface-2 rounded transition active:scale-[0.97]"
                 onClick={() => setWorktreeCloseConfirm(null)}
               >
                 Cancel
               </button>
               <button
-                className="px-3 py-1.5 text-xs bg-red-600 hover:bg-red-500 text-white rounded transition-colors font-medium"
+                className="px-3 py-1.5 text-xs bg-red-600 hover:bg-red-500 text-white rounded transition active:scale-[0.97] font-medium"
                 onClick={confirmWorktreeClose}
               >
                 Remove

--- a/src/renderer/src/components/TabItem.tsx
+++ b/src/renderer/src/components/TabItem.tsx
@@ -10,6 +10,7 @@ import { cwdBasename } from '../store/workspace-store';
 import { useCwdStore } from '../store/cwd-store';
 import { useNotificationStore } from '../store/notification-store';
 import { shortenPath } from '../lib/shorten-path';
+import { popperAnim } from '../lib/motion';
 
 type TabItemProps = {
   id: string;
@@ -281,7 +282,9 @@ export function TabItem({
         </div>
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
-        <ContextMenu.Content className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+        <ContextMenu.Content
+          className={`min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50 ${popperAnim}`}
+        >
           {onDuplicate && (
             <ContextMenu.Item
               className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"

--- a/src/renderer/src/components/Telescope/TelescopeModal.tsx
+++ b/src/renderer/src/components/Telescope/TelescopeModal.tsx
@@ -9,6 +9,8 @@ import { createBrowseMode } from './modes/browse-mode';
 import { createPanesMode } from './modes/panes-mode';
 import type { TelescopeMode, TelescopeItem } from './types';
 import { ShikiPreview } from './ShikiPreview';
+import { Overlay } from '../Overlay';
+import { tooltipAnim } from '../../lib/motion';
 
 const IMAGE_EXTENSIONS = new Set([
   'png',
@@ -284,8 +286,6 @@ export function TelescopeModal({
     [results, selectedIndex, activeMode, activeModeId, query, modeList, onClose]
   );
 
-  if (!isOpen) return null;
-
   const browseBreadcrumbs = activeModeId === 'browse' && activeMode?.breadcrumbs;
 
   const renderBreadcrumbs = (): React.JSX.Element | null => {
@@ -361,138 +361,138 @@ export function TelescopeModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-center bg-black/60" onClick={onClose}>
-      <div
-        className="mt-[10vh] w-[800px] h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header: search input + mode tabs */}
-        <div className="flex items-center border-b border-neutral-700">
-          {/* Search input */}
-          <div className="flex items-center gap-2 px-3 py-2 flex-1 min-w-0">
-            <Search size={14} className="text-neutral-500 shrink-0" />
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={activeMode?.placeholder ?? 'Search...'}
-              className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500 min-w-0"
-            />
-          </div>
-
-          {/* Mode tabs */}
-          <div className="flex items-center gap-0.5 px-2 py-1.5 border-l border-neutral-700 shrink-0">
-            <Tooltip.Provider delayDuration={500}>
-              {modeList.map((mode, i) => {
-                const Icon = mode.icon;
-                const shortcut = `${modKey}${i + 1}`;
-                const isActive = mode.id === activeModeId;
-                return (
-                  <Tooltip.Root key={mode.id}>
-                    <Tooltip.Trigger asChild>
-                      <button
-                        onClick={() => {
-                          setActiveModeId(mode.id);
-                          setQuery('');
-                          inputRef.current?.focus();
-                        }}
-                        className={`flex items-center gap-1.5 px-2 py-1 text-[11px] rounded transition-colors ${
-                          isActive
-                            ? 'bg-neutral-700 text-neutral-200'
-                            : 'text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800'
-                        }`}
-                      >
-                        <Icon size={12} />
-                        {mode.label}
-                      </button>
-                    </Tooltip.Trigger>
-                    <Tooltip.Portal>
-                      <Tooltip.Content
-                        side="bottom"
-                        className="z-50 rounded bg-neutral-800 border border-neutral-700 px-2 py-1 text-[11px] text-neutral-300 shadow-md"
-                        sideOffset={4}
-                      >
-                        {shortcut}
-                        <Tooltip.Arrow className="fill-neutral-800" />
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  </Tooltip.Root>
-                );
-              })}
-            </Tooltip.Provider>
-          </div>
+    <Overlay
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="justify-center"
+      panelClassName="mt-[10vh] w-[800px] h-[70vh] flex flex-col bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl overflow-hidden self-start"
+    >
+      {/* Header: search input + mode tabs */}
+      <div className="flex items-center border-b border-neutral-700">
+        {/* Search input */}
+        <div className="flex items-center gap-2 px-3 py-2 flex-1 min-w-0">
+          <Search size={14} className="text-neutral-500 shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={activeMode?.placeholder ?? 'Search...'}
+            className="flex-1 bg-transparent text-sm text-white outline-none placeholder-neutral-500 min-w-0"
+          />
         </div>
 
-        {/* Breadcrumbs (browse mode only) */}
-        {renderBreadcrumbs()}
-
-        {/* Body */}
-        <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-          {/* Results column */}
-          <div ref={listRef} className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1">
-            {results.length === 0 ? (
-              <div className="px-3 py-4 text-xs text-neutral-600 text-center italic">
-                {query ? 'No results' : 'Type to search'}
-              </div>
-            ) : (
-              results.map((item, i) => {
-                const isSelected = i === selectedIndex;
-                return (
-                  <button
-                    key={item.id}
-                    data-result-index={i}
-                    className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
-                      isSelected
-                        ? 'bg-neutral-700 text-white'
-                        : item.data?.isIgnored
-                          ? 'text-neutral-600 hover:bg-neutral-800'
-                          : 'text-neutral-300 hover:bg-neutral-800'
-                    }`}
-                    onMouseEnter={() => setSelectedIndex(i)}
-                    onClick={() => {
-                      if (!activeMode) return;
-                      const isDirectory = item.data?.isDirectory;
-                      if (activeModeId === 'browse' && isDirectory === true) {
-                        activeMode.onSelect(item);
+        {/* Mode tabs */}
+        <div className="flex items-center gap-0.5 px-2 py-1.5 border-l border-neutral-700 shrink-0">
+          <Tooltip.Provider delayDuration={500}>
+            {modeList.map((mode, i) => {
+              const Icon = mode.icon;
+              const shortcut = `${modKey}${i + 1}`;
+              const isActive = mode.id === activeModeId;
+              return (
+                <Tooltip.Root key={mode.id}>
+                  <Tooltip.Trigger asChild>
+                    <button
+                      onClick={() => {
+                        setActiveModeId(mode.id);
                         setQuery('');
-                        setSelectedIndex(0);
-                      } else {
-                        activeMode.onSelect(item);
-                        onClose();
-                      }
-                    }}
-                  >
-                    <span className="text-neutral-500 shrink-0 flex items-center">{item.icon}</span>
-                    <div className="flex flex-col min-w-0 flex-1">
-                      <span className="truncate text-sm font-medium">{item.title}</span>
-                      {item.subtitle && (
-                        <span className="truncate text-xs text-neutral-500">{item.subtitle}</span>
-                      )}
-                    </div>
-                    {item.meta && (
-                      <span className="text-[10px] text-neutral-600 shrink-0">{item.meta}</span>
-                    )}
-                  </button>
-                );
-              })
-            )}
-          </div>
-
-          {/* Preview column */}
-          <div className="w-[60%] overflow-auto p-3">{renderPreviewPanel()}</div>
-        </div>
-
-        {/* Footer */}
-        <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
-          <span>↑↓ navigate</span>
-          <span>↵ open/focus</span>
-          {activeModeId !== 'panes' && <span>⇧↵ paste path</span>}
-          {activeModeId === 'browse' && <span>⌫ up dir</span>}
-          <span>esc dismiss</span>
+                        inputRef.current?.focus();
+                      }}
+                      className={`flex items-center gap-1.5 px-2 py-1 text-[11px] rounded transition-colors ${
+                        isActive
+                          ? 'bg-neutral-700 text-neutral-200'
+                          : 'text-neutral-500 hover:text-neutral-300 hover:bg-neutral-800'
+                      }`}
+                    >
+                      <Icon size={12} />
+                      {mode.label}
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Portal>
+                    <Tooltip.Content
+                      side="bottom"
+                      className={`z-50 rounded bg-neutral-800 border border-neutral-700 px-2 py-1 text-[11px] text-neutral-300 shadow-md ${tooltipAnim}`}
+                      sideOffset={4}
+                    >
+                      {shortcut}
+                      <Tooltip.Arrow className="fill-neutral-800" />
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
+                </Tooltip.Root>
+              );
+            })}
+          </Tooltip.Provider>
         </div>
       </div>
-    </div>
+
+      {/* Breadcrumbs (browse mode only) */}
+      {renderBreadcrumbs()}
+
+      {/* Body */}
+      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+        {/* Results column */}
+        <div ref={listRef} className="w-[40%] overflow-y-auto border-r border-neutral-800 py-1">
+          {results.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-neutral-600 text-center italic">
+              {query ? 'No results' : 'Type to search'}
+            </div>
+          ) : (
+            results.map((item, i) => {
+              const isSelected = i === selectedIndex;
+              return (
+                <button
+                  key={item.id}
+                  data-result-index={i}
+                  className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
+                    isSelected
+                      ? 'bg-neutral-700 text-white'
+                      : item.data?.isIgnored
+                        ? 'text-neutral-600 hover:bg-neutral-800'
+                        : 'text-neutral-300 hover:bg-neutral-800'
+                  }`}
+                  onMouseEnter={() => setSelectedIndex(i)}
+                  onClick={() => {
+                    if (!activeMode) return;
+                    const isDirectory = item.data?.isDirectory;
+                    if (activeModeId === 'browse' && isDirectory === true) {
+                      activeMode.onSelect(item);
+                      setQuery('');
+                      setSelectedIndex(0);
+                    } else {
+                      activeMode.onSelect(item);
+                      onClose();
+                    }
+                  }}
+                >
+                  <span className="text-neutral-500 shrink-0 flex items-center">{item.icon}</span>
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <span className="truncate text-sm font-medium">{item.title}</span>
+                    {item.subtitle && (
+                      <span className="truncate text-xs text-neutral-500">{item.subtitle}</span>
+                    )}
+                  </div>
+                  {item.meta && (
+                    <span className="text-[10px] text-neutral-600 shrink-0">{item.meta}</span>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* Preview column */}
+        <div className="w-[60%] overflow-auto p-3">{renderPreviewPanel()}</div>
+      </div>
+
+      {/* Footer */}
+      <div className="px-3 py-1.5 border-t border-neutral-800 flex items-center gap-3 text-xs text-neutral-600">
+        <span>↑↓ navigate</span>
+        <span>↵ open/focus</span>
+        {activeModeId !== 'panes' && <span>⇧↵ paste path</span>}
+        {activeModeId === 'browse' && <span>⌫ up dir</span>}
+        <span>esc dismiss</span>
+      </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/ToastContainer.tsx
+++ b/src/renderer/src/components/ToastContainer.tsx
@@ -1,5 +1,10 @@
 import { useToastStore } from '../store/toast-store';
 
+// Slide up + fade on enter, reverse on exit. `closing` drives the data-state;
+// the store keeps the toast mounted long enough for the exit to play.
+const toastAnim =
+  'duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-2';
+
 export function ToastContainer(): React.JSX.Element | null {
   const toasts = useToastStore((s) => s.toasts);
   const dismiss = useToastStore((s) => s.dismiss);
@@ -11,12 +16,13 @@ export function ToastContainer(): React.JSX.Element | null {
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className="pointer-events-auto flex items-center gap-3 px-4 py-2 bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg text-sm"
+          data-state={toast.closing ? 'closed' : 'open'}
+          className={`pointer-events-auto flex items-center gap-3 px-4 py-2 bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg text-sm ${toastAnim}`}
         >
           <span className="text-neutral-300">{toast.message}</span>
           {toast.action && (
             <button
-              className="text-blue-400 hover:text-blue-300 font-medium whitespace-nowrap"
+              className="text-blue-400 hover:text-blue-300 font-medium whitespace-nowrap transition active:scale-95"
               onClick={() => {
                 toast.action?.onClick();
                 dismiss(toast.id);
@@ -26,7 +32,7 @@ export function ToastContainer(): React.JSX.Element | null {
             </button>
           )}
           <button
-            className="text-neutral-500 hover:text-neutral-300"
+            className="text-neutral-500 hover:text-neutral-300 transition active:scale-90"
             onClick={() => dismiss(toast.id)}
           >
             ×

--- a/src/renderer/src/components/env-sync/EnvSyncModal.tsx
+++ b/src/renderer/src/components/env-sync/EnvSyncModal.tsx
@@ -2,6 +2,8 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronRight, KeyRound, Loader2, MoreHorizontal, X } from 'lucide-react';
 import { useToastStore } from '../../store/toast-store';
+import { primaryBtn, neutralBtn } from '../../lib/button-styles';
+import { Overlay } from '../Overlay';
 import type {
   EnvSyncConfig,
   EnvSyncTarget,
@@ -56,13 +58,6 @@ function primaryAction(state: TargetSyncState): { dir: 'pull' | 'push'; label: s
 
 const inputCls =
   'w-full bg-neutral-800 text-sm text-neutral-200 rounded-md px-3 py-2 border border-neutral-700 transition-colors focus:border-neutral-500 focus:outline-none';
-
-const primaryBtn =
-  'inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition active:scale-[0.97] hover:bg-blue-500 disabled:bg-neutral-700 disabled:text-neutral-500 disabled:active:scale-100';
-
-// Small neutral pill button (Save / Add selected etc.).
-const neutralBtn =
-  'inline-flex items-center justify-center gap-2 rounded-md bg-neutral-700 px-3 py-2 text-sm text-neutral-100 transition active:scale-[0.97] hover:bg-neutral-600 disabled:text-neutral-500 disabled:active:scale-100';
 
 const SPIN = <Loader2 size={14} className="animate-spin" />;
 
@@ -938,8 +933,6 @@ export function EnvSyncModal({
     }
   };
 
-  if (!isOpen) return null;
-
   const globalSummary = `${secrets.globalPresent ? 'Passphrase set' : 'No passphrase'} · ${authSummary(secrets.globalAuth)}`;
 
   // Effective AWS auth for the active repo: a per-repo override wins, else global.
@@ -948,10 +941,7 @@ export function EnvSyncModal({
   const authIsOverride = Boolean(repoAuthOverride);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-    >
+    <Overlay open={isOpen} onClose={onClose}>
       <div
         ref={panelRef}
         tabIndex={-1}
@@ -961,7 +951,6 @@ export function EnvSyncModal({
             onClose();
           }
         }}
-        onClick={(e) => e.stopPropagation()}
         className="flex max-h-[85vh] w-[600px] flex-col overflow-hidden rounded-xl border border-neutral-700 bg-neutral-900 shadow-2xl"
       >
         <div className="flex items-center justify-between border-b border-neutral-800 px-6 py-4">
@@ -1075,6 +1064,6 @@ export function EnvSyncModal({
           )}
         </div>
       </div>
-    </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -288,7 +288,7 @@ export function KanbanBoard(): React.JSX.Element {
                 setBoardEditor({ mode: 'rename' });
               }}
               disabled={activeBoardSlug === 'default'}
-              className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800 disabled:opacity-40"
+              className="rounded px-2 py-1 text-xs text-neutral-400 transition active:scale-[0.97] hover:bg-neutral-800 disabled:opacity-40 disabled:active:scale-100"
               title="Rename board"
             >
               Rename
@@ -308,7 +308,7 @@ export function KanbanBoard(): React.JSX.Element {
                 }
               }}
               disabled={activeBoardSlug === 'default'}
-              className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-red-900/40 disabled:opacity-40"
+              className="rounded px-2 py-1 text-xs text-neutral-400 transition active:scale-[0.97] hover:bg-red-900/40 disabled:opacity-40 disabled:active:scale-100"
               title="Delete board"
             >
               Delete
@@ -352,14 +352,14 @@ export function KanbanBoard(): React.JSX.Element {
             </button>
             <button
               onClick={() => setSwarming(true)}
-              className="inline-flex items-center gap-1 rounded bg-purple-600 px-2 py-1 text-xs text-white hover:bg-purple-500"
+              className="inline-flex items-center gap-1 rounded bg-purple-600 px-2 py-1 text-xs text-white transition active:scale-[0.97] hover:bg-purple-500"
               title="Create a swarm: workers → verifier → synthesizer"
             >
               <Network size={12} /> Swarm
             </button>
             <button
               onClick={() => setCreating(true)}
-              className="inline-flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500"
+              className="inline-flex items-center gap-1 rounded bg-blue-600 px-2 py-1 text-xs text-white transition active:scale-[0.97] hover:bg-blue-500"
             >
               <Plus size={12} /> New Task
             </button>
@@ -380,13 +380,13 @@ export function KanbanBoard(): React.JSX.Element {
               />
               <button
                 onClick={() => void handleBoardSubmit()}
-                className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-xs text-white transition active:scale-[0.97] hover:bg-blue-500"
               >
                 {boardEditor.mode === 'new' ? 'Create' : 'Save'}
               </button>
               <button
                 onClick={() => setBoardEditor(null)}
-                className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
+                className="rounded px-2 py-1 text-xs text-neutral-400 transition active:scale-[0.97] hover:bg-neutral-800"
               >
                 Cancel
               </button>
@@ -508,7 +508,7 @@ export function KanbanBoard(): React.JSX.Element {
                     newFolder.trim() !== '' &&
                     folderIsRepo !== true
                   }
-                  className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded bg-blue-600 px-2 py-1 text-xs text-white transition active:scale-[0.97] hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100"
                 >
                   Create
                 </button>
@@ -517,7 +517,7 @@ export function KanbanBoard(): React.JSX.Element {
                     setCreating(false);
                     clearSeed();
                   }}
-                  className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
+                  className="rounded px-2 py-1 text-xs text-neutral-400 transition active:scale-[0.97] hover:bg-neutral-800"
                 >
                   Cancel
                 </button>

--- a/src/renderer/src/components/kanban/KanbanDrawer.tsx
+++ b/src/renderer/src/components/kanban/KanbanDrawer.tsx
@@ -232,7 +232,10 @@ export function KanbanDrawer(): React.JSX.Element | null {
         <span className="font-mono text-xs text-neutral-500">
           {t.id} · {t.status}
         </span>
-        <button onClick={closeTask} className="rounded p-1 text-neutral-400 hover:bg-neutral-800">
+        <button
+          onClick={closeTask}
+          className="rounded p-1 text-neutral-400 transition active:scale-90 hover:bg-neutral-800"
+        >
           <X size={14} />
         </button>
       </div>
@@ -494,7 +497,7 @@ export function KanbanDrawer(): React.JSX.Element | null {
                     <button
                       onClick={() => void runReview('merge')}
                       disabled={reviewBusy !== null}
-                      className="inline-flex items-center gap-1 rounded bg-emerald-700 px-2 py-1 font-medium text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center gap-1 rounded bg-emerald-700 px-2 py-1 font-medium text-white transition active:scale-[0.97] hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100"
                     >
                       <GitMerge size={12} />
                       {reviewBusy === 'merge' ? 'Merging…' : `Merge to ${t.baseBranch}`}
@@ -502,7 +505,7 @@ export function KanbanDrawer(): React.JSX.Element | null {
                     <button
                       onClick={() => void runReview('pr')}
                       disabled={reviewBusy !== null}
-                      className="inline-flex items-center gap-1 rounded border border-sky-700 px-2 py-1 text-sky-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center gap-1 rounded border border-sky-700 px-2 py-1 text-sky-300 transition active:scale-[0.97] hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100"
                     >
                       <GitPullRequest size={12} />
                       {reviewBusy === 'pr' ? 'Opening…' : 'Make Pull Request'}
@@ -512,7 +515,7 @@ export function KanbanDrawer(): React.JSX.Element | null {
                 <button
                   onClick={() => void runReview('accept')}
                   disabled={reviewBusy !== null}
-                  className="inline-flex items-center gap-1 rounded border border-neutral-700 px-2 py-1 text-neutral-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex items-center gap-1 rounded border border-neutral-700 px-2 py-1 text-neutral-300 transition active:scale-[0.97] hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100"
                 >
                   <Check size={12} />
                   {reviewBusy === 'accept' ? 'Accepting…' : 'Do Nothing'}
@@ -899,7 +902,7 @@ function BlockedReply({
           <button
             onClick={resume}
             disabled={resuming}
-            className="rounded bg-blue-600 px-2 py-1 font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded bg-blue-600 px-2 py-1 font-medium text-white transition active:scale-[0.97] hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60 disabled:active:scale-100"
           >
             {resuming ? 'Resuming…' : 'Reply & Resume ▶'}
           </button>

--- a/src/renderer/src/components/kanban/SwarmModal.tsx
+++ b/src/renderer/src/components/kanban/SwarmModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useKanbanStore } from '../../store/kanban-store';
 import { useSettingsStore } from '../../store/settings-store';
 import type { SwarmWorkerSpec } from '../../../../shared/kanban-types';
+import { Overlay } from '../Overlay';
 
 export interface WorkerRow {
   profile: string;
@@ -88,175 +89,171 @@ export function SwarmModal({ onClose }: { onClose: () => void }): React.JSX.Elem
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
+    <Overlay
+      open
+      onClose={onClose}
+      panelClassName="w-[560px] max-h-[80vh] overflow-y-auto rounded-lg border border-neutral-800 bg-neutral-900 p-4"
     >
-      <div
-        className="w-[560px] max-h-[80vh] overflow-y-auto rounded-lg border border-neutral-800 bg-neutral-900 p-4"
-        onClick={(e) => e.stopPropagation()}
+      <h2 className="mb-3 text-sm font-semibold text-neutral-100">New Swarm</h2>
+      {seed?.target === 'swarm' && (
+        <div className="mb-3 flex items-center gap-1 rounded bg-purple-950/40 px-2 py-1 text-[11px] text-purple-300">
+          📦 Seeding root task with <span className="font-medium">{seed.artifact.filename}</span>
+        </div>
+      )}
+      <textarea
+        value={goal}
+        onChange={(e) => setGoal(e.target.value)}
+        placeholder="Swarm goal / final outcome…"
+        className="mb-3 w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
+        rows={2}
+      />
+      <div className="mb-2 text-xs font-medium text-neutral-300">Workers</div>
+      {rows.map((row, i) => (
+        <div key={i} className="mb-2 flex items-center gap-2">
+          <select
+            value={row.profile}
+            onChange={(e) =>
+              setRows(rows.map((r, j) => (j === i ? { ...r, profile: e.target.value } : r)))
+            }
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
+          >
+            {workerProfiles.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <input
+            value={row.title}
+            onChange={(e) =>
+              setRows(rows.map((r, j) => (j === i ? { ...r, title: e.target.value } : r)))
+            }
+            placeholder="Task title…"
+            className="flex-1 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
+          />
+          <input
+            value={row.skills}
+            onChange={(e) =>
+              setRows(rows.map((r, j) => (j === i ? { ...r, skills: e.target.value } : r)))
+            }
+            placeholder="skills (comma)"
+            className="w-28 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
+          />
+          <button
+            onClick={() => setRows(rows.filter((_, j) => j !== i))}
+            className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
+            disabled={rows.length === 1}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={() => setRows([...rows, { profile: firstWorker, title: '', skills: '' }])}
+        className="mb-3 rounded px-2 py-1 text-xs text-blue-400 hover:bg-neutral-800"
       >
-        <h2 className="mb-3 text-sm font-semibold text-neutral-100">New Swarm</h2>
-        {seed?.target === 'swarm' && (
-          <div className="mb-3 flex items-center gap-1 rounded bg-purple-950/40 px-2 py-1 text-[11px] text-purple-300">
-            📦 Seeding root task with <span className="font-medium">{seed.artifact.filename}</span>
-          </div>
-        )}
-        <textarea
-          value={goal}
-          onChange={(e) => setGoal(e.target.value)}
-          placeholder="Swarm goal / final outcome…"
-          className="mb-3 w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
-          rows={2}
+        + Add worker
+      </button>
+      <div className="mb-3 flex gap-3">
+        <label className="flex-1 text-xs text-neutral-300">
+          Verifier
+          <select
+            value={verifier}
+            onChange={(e) => setVerifier(e.target.value)}
+            className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
+          >
+            {workerProfiles.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex-1 text-xs text-neutral-300">
+          Synthesizer
+          <select
+            value={synthesizer}
+            onChange={(e) => setSynthesizer(e.target.value)}
+            className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
+          >
+            {workerProfiles.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="mb-1 text-[11px] font-medium text-neutral-400">
+        Where should the swarm work?
+      </div>
+      <label className="mb-1 flex items-center gap-2 text-xs text-neutral-300">
+        <input
+          type="radio"
+          name="swarm-ws-mode"
+          checked={mode === 'scratch'}
+          onChange={() => setMode('scratch')}
         />
-        <div className="mb-2 text-xs font-medium text-neutral-300">Workers</div>
-        {rows.map((row, i) => (
-          <div key={i} className="mb-2 flex items-center gap-2">
-            <select
-              value={row.profile}
-              onChange={(e) =>
-                setRows(rows.map((r, j) => (j === i ? { ...r, profile: e.target.value } : r)))
-              }
-              className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
-            >
-              {workerProfiles.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
+        Empty sandbox{' '}
+        <span className="text-neutral-500">(no project — a fresh, empty folder per task)</span>
+      </label>
+      <label className="mb-1 flex items-center gap-2 text-xs text-neutral-300">
+        <input
+          type="radio"
+          name="swarm-ws-mode"
+          checked={mode === 'project'}
+          onChange={() => setMode('project')}
+        />
+        A project folder
+      </label>
+      {mode === 'project' && (
+        <div className="mb-2 flex flex-col gap-2 pl-6">
+          <div className="flex items-center gap-2">
             <input
-              value={row.title}
-              onChange={(e) =>
-                setRows(rows.map((r, j) => (j === i ? { ...r, title: e.target.value } : r)))
-              }
-              placeholder="Task title…"
+              value={folder}
+              onChange={(e) => setFolder(e.target.value)}
+              placeholder="No folder selected…"
               className="flex-1 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
             />
-            <input
-              value={row.skills}
-              onChange={(e) =>
-                setRows(rows.map((r, j) => (j === i ? { ...r, skills: e.target.value } : r)))
-              }
-              placeholder="skills (comma)"
-              className="w-28 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
-            />
             <button
-              onClick={() => setRows(rows.filter((_, j) => j !== i))}
-              className="rounded px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
-              disabled={rows.length === 1}
+              onClick={() => void pickFolder()}
+              className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
             >
-              ×
+              Browse…
             </button>
           </div>
-        ))}
-        <button
-          onClick={() => setRows([...rows, { profile: firstWorker, title: '', skills: '' }])}
-          className="mb-3 rounded px-2 py-1 text-xs text-blue-400 hover:bg-neutral-800"
-        >
-          + Add worker
-        </button>
-        <div className="mb-3 flex gap-3">
-          <label className="flex-1 text-xs text-neutral-300">
-            Verifier
-            <select
-              value={verifier}
-              onChange={(e) => setVerifier(e.target.value)}
-              className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
-            >
-              {workerProfiles.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex-1 text-xs text-neutral-300">
-            Synthesizer
-            <select
-              value={synthesizer}
-              onChange={(e) => setSynthesizer(e.target.value)}
-              className="mt-1 w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs"
-            >
-              {workerProfiles.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-        <div className="mb-1 text-[11px] font-medium text-neutral-400">
-          Where should the swarm work?
-        </div>
-        <label className="mb-1 flex items-center gap-2 text-xs text-neutral-300">
-          <input
-            type="radio"
-            name="swarm-ws-mode"
-            checked={mode === 'scratch'}
-            onChange={() => setMode('scratch')}
-          />
-          Empty sandbox{' '}
-          <span className="text-neutral-500">(no project — a fresh, empty folder per task)</span>
-        </label>
-        <label className="mb-1 flex items-center gap-2 text-xs text-neutral-300">
-          <input
-            type="radio"
-            name="swarm-ws-mode"
-            checked={mode === 'project'}
-            onChange={() => setMode('project')}
-          />
-          A project folder
-        </label>
-        {mode === 'project' && (
-          <div className="mb-2 flex flex-col gap-2 pl-6">
-            <div className="flex items-center gap-2">
-              <input
-                value={folder}
-                onChange={(e) => setFolder(e.target.value)}
-                placeholder="No folder selected…"
-                className="flex-1 rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-xs outline-none focus:border-blue-500"
-              />
-              <button
-                onClick={() => void pickFolder()}
-                className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
-              >
-                Browse…
-              </button>
-            </div>
-            <label className="flex items-start gap-2 text-xs text-neutral-300">
-              <input
-                type="checkbox"
-                className="mt-0.5"
-                checked={isolated}
-                onChange={(e) => setIsolated(e.target.checked)}
-              />
-              <span>
-                Work on an isolated copy{' '}
-                <span className="text-neutral-500">
-                  (git worktree — each task gets its own copy; leaves your files untouched. Requires
-                  a git repo. Unchecked: every task shares the folder directly.)
-                </span>
+          <label className="flex items-start gap-2 text-xs text-neutral-300">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={isolated}
+              onChange={(e) => setIsolated(e.target.checked)}
+            />
+            <span>
+              Work on an isolated copy{' '}
+              <span className="text-neutral-500">
+                (git worktree — each task gets its own copy; leaves your files untouched. Requires a
+                git repo. Unchecked: every task shares the folder directly.)
               </span>
-            </label>
-          </div>
-        )}
-        {error && <div className="mb-2 text-xs text-red-400">{error}</div>}
-        <div className="flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            className="rounded px-3 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={() => void submit()}
-            className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-500"
-          >
-            Create Swarm
-          </button>
+            </span>
+          </label>
         </div>
+      )}
+      {error && <div className="mb-2 text-xs text-red-400">{error}</div>}
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={onClose}
+          className="rounded px-3 py-1 text-xs text-neutral-400 hover:bg-neutral-800"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => void submit()}
+          className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-500"
+        >
+          Create Swarm
+        </button>
       </div>
-    </div>
+    </Overlay>
   );
 }

--- a/src/renderer/src/hooks/use-presence.ts
+++ b/src/renderer/src/hooks/use-presence.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+export type PresenceState = 'open' | 'closed';
+
+/**
+ * Keeps content mounted through its exit animation, mirroring what Radix's
+ * Presence does for our hand-rolled overlays. While `open` is true the node is
+ * mounted with state `'open'` (plays the enter animation). When `open` flips to
+ * false the state becomes `'closed'` (plays the exit animation) and the node is
+ * unmounted only after `exitMs` elapses.
+ *
+ * `exitMs` must match the CSS exit-animation duration so the node isn't removed
+ * mid-animation.
+ */
+export function usePresence(
+  open: boolean,
+  exitMs = 150
+): { mounted: boolean; state: PresenceState } {
+  const [mounted, setMounted] = useState(open);
+  const [state, setState] = useState<PresenceState>(open ? 'open' : 'closed');
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setState('open');
+      return;
+    }
+    setState('closed');
+    const timer = setTimeout(() => setMounted(false), exitMs);
+    return () => clearTimeout(timer);
+  }, [open, exitMs]);
+
+  return { mounted, state };
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
 @import 'highlight.js/styles/atom-one-dark.css';
 @plugin "@tailwindcss/typography";
 
@@ -135,6 +136,18 @@ body,
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse {
     animation: none !important;
+  }
+  /* Neutralize entrance/exit motion and tactile press scaling for users
+     who prefer reduced motion. Opacity still resolves so nothing vanishes. */
+  .animate-in,
+  .animate-out {
+    animation: none !important;
+  }
+  .active\:scale-\[0\.97\]:active,
+  .active\:scale-\[0\.94\]:active,
+  .active\:scale-95:active,
+  .active\:scale-90:active {
+    transform: none !important;
   }
 }
 

--- a/src/renderer/src/lib/button-styles.ts
+++ b/src/renderer/src/lib/button-styles.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared button class strings. Centralizes the tactile press feedback
+ * (`active:scale-*`) and transition timing so interactive controls feel
+ * consistent app-wide. Reduced-motion users get the scale neutralized in
+ * index.css. Compose with extra classes via a template literal at the call site.
+ */
+
+/** Primary action (blue). Use for the main confirm/submit button in a surface. */
+export const primaryBtn =
+  'inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition active:scale-[0.97] hover:bg-blue-500 disabled:bg-neutral-700 disabled:text-neutral-500 disabled:active:scale-100';
+
+/** Neutral pill (Save / secondary actions). */
+export const neutralBtn =
+  'inline-flex items-center justify-center gap-2 rounded-md bg-neutral-700 px-3 py-2 text-sm text-neutral-100 transition active:scale-[0.97] hover:bg-neutral-600 disabled:text-neutral-500 disabled:active:scale-100';

--- a/src/renderer/src/lib/motion.ts
+++ b/src/renderer/src/lib/motion.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared animation class strings for Radix primitives. Radix toggles
+ * `data-[state]` (and `data-[side]` for popper content) and its built-in
+ * Presence holds the element mounted while a `data-[state=closed]` animation
+ * runs, so these give symmetric enter/exit without any JS. Reduced-motion users
+ * have `animate-in`/`animate-out` neutralized in index.css.
+ */
+
+/** Popper-positioned content (context menus, popovers): side-aware slide + zoom/fade. */
+export const popperAnim =
+  'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1';
+
+/** Tooltip content — its open state is `delayed-open`/`instant-open`, so enter is unconditional. */
+export const tooltipAnim =
+  'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95';
+
+/** Dialog overlay + content. Fade only — these center via translate, which a zoom keyframe would fight. */
+export const dialogFadeAnim =
+  'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0';

--- a/src/renderer/src/store/toast-store.ts
+++ b/src/renderer/src/store/toast-store.ts
@@ -10,6 +10,8 @@ type Toast = {
   message: string;
   duration?: number;
   action?: ToastAction;
+  /** Set while the toast plays its exit animation, just before removal. */
+  closing?: boolean;
 };
 
 type ShowOptions = {
@@ -23,20 +25,30 @@ type ToastStore = {
   dismiss: (id: string) => void;
 };
 
+// Time the toast stays mounted after `closing` is set, to let the exit
+// animation finish. Must be >= the exit-animation duration in ToastContainer.
+const EXIT_MS = 180;
+
 export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
   show: (message, options) => {
     const duration = options?.duration ?? 4000;
-    // Deduplicate: if the same message is already showing, skip
+    // Deduplicate: if the same message is already showing (and not mid-exit), skip
     const existing = useToastStore.getState().toasts;
-    if (existing.some((t) => t.message === message)) return;
+    if (existing.some((t) => t.message === message && !t.closing)) return;
     const id = crypto.randomUUID();
     set((s) => ({ toasts: [...s.toasts, { id, message, duration, action: options?.action }] }));
-    setTimeout(() => {
-      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
-    }, duration);
+    setTimeout(() => useToastStore.getState().dismiss(id), duration);
   },
   dismiss: (id) => {
-    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    // Two-phase: flag the toast so it animates out, then remove it. No-op if the
+    // toast is gone (e.g. the auto-dismiss timer firing after a manual dismiss)
+    // or already mid-exit, so we never schedule a duplicate removal timer.
+    const toast = useToastStore.getState().toasts.find((t) => t.id === id);
+    if (!toast || toast.closing) return;
+    set((s) => ({ toasts: s.toasts.map((t) => (t.id === id ? { ...t, closing: true } : t)) }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, EXIT_MS);
   }
 }));


### PR DESCRIPTION
## Summary
Adds a renderer-wide **motion foundation** and applies the highest-impact UI polish ("Tier 1"). The app previously had almost no animation layer — overlays snapped in/out, toasts popped, and ~95% of buttons had no press feedback.

- **Foundation**: `tw-animate-css` (Tailwind v4-native; `tailwindcss-animate` is v3-only), a `prefers-reduced-motion` guard, and shared class modules (`lib/button-styles.ts`, `lib/motion.ts`).
- **Overlays**: new `<Overlay>` primitive + `usePresence` hook that keeps a node mounted through its exit animation (symmetric enter/exit without framer-motion). Migrated 8 hand-rolled overlays (CommandPalette, QuickOpen, FileSearch, ClipboardHistory, GitChanges, Telescope, EnvSync, Swarm), each also shedding duplicated backdrop/Escape boilerplate.
- **Radix**: Dialog/Popover/ContextMenu/Tooltip now animate via `data-state` classes (exit handled by Radix Presence).
- **Toasts**: two-phase dismiss → slide-up/fade in and out; the undo toast animates in.
- **Press feedback**: `active:scale` added to ~40 high-traffic buttons (PaneToolbar, Sidebar, Kanban, GitChanges).

Motion is uniformly **snappy & subtle** (150ms, scale 95%→100%, 0.5rem slide) and fully respects reduced-motion.

## Notes / intentional scoping
- `SwarmModal` gets enter-only animation (its parent `&&`-gates it) — a follow-up could lift state for exit too.
- Not migrated this pass: PiPlanModal, AnnotateModal, ShortcutsPanel and a few other modals still use the raw backdrop pattern.
- A self-review pass fixed: `active:scale-95` missing from the reduced-motion guard, an orphan toast auto-dismiss timer, and two unused button-style exports.

## Test plan
- [x] `npm run typecheck` (node + web) — clean
- [x] `npm run build` — succeeds (~5s; confirms tw-animate-css resolves)
- [x] `npm run lint` — 0 new errors in changed files
- [ ] Manual: open/close each overlay — verify fade+zoom enter and exit
- [ ] Manual: trigger a toast and the undo toast — verify slide-up in/out
- [ ] Manual: press buttons across sidebar/toolbar/kanban — verify scale feedback
- [ ] Manual: enable OS "reduce motion" — verify animations/press-scale are neutralized

🤖 Generated with [Claude Code](https://claude.com/claude-code)