### PR TITLE
fix(env-editor): preserve row focus and adopt shared modal animation

### DIFF
--- a/src/renderer/src/components/env-editor/EnvEditorModal.tsx
+++ b/src/renderer/src/components/env-editor/EnvEditorModal.tsx
@@ -282,7 +282,7 @@ export function EnvEditorModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 duration-150 animate-in fade-in-0"
       onClick={requestClose}
     >
       <div
@@ -295,7 +295,7 @@ export function EnvEditorModal({
           }
         }}
         onClick={(e) => e.stopPropagation()}
-        className="env-editor-pop flex h-[85vh] w-[860px] flex-col overflow-hidden rounded-xl border border-neutral-700 bg-neutral-900 shadow-2xl"
+        className="flex h-[85vh] w-[860px] flex-col overflow-hidden rounded-xl border border-neutral-700 bg-neutral-900 shadow-2xl duration-150 animate-in fade-in-0 zoom-in-95"
       >
         <div className="flex items-center gap-3 border-b border-neutral-800 px-5 py-3">
           <h2 className="text-base font-semibold text-neutral-100">Env Editor</h2>

--- a/src/renderer/src/components/env-editor/EnvForm.tsx
+++ b/src/renderer/src/components/env-editor/EnvForm.tsx
@@ -68,7 +68,7 @@ export function EnvForm({
         const isDup = Boolean(line.key) && dupKeys.has(line.key);
         return (
           <div
-            key={index}
+            key={line.id}
             className="group flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-neutral-800/60 focus-within:bg-neutral-800/80 focus-within:shadow-[inset_0_0_0_1px_#2563eb]"
           >
             <input

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -151,15 +151,6 @@ body,
   }
 }
 
-@keyframes env-editor-pop {
-  from { opacity: 0; transform: scale(0.97); }
-  to { opacity: 1; transform: scale(1); }
-}
-.env-editor-pop { animation: env-editor-pop 200ms ease-out; }
-@media (prefers-reduced-motion: reduce) {
-  .env-editor-pop { animation: none; }
-}
-
 /* ── Markdown Preview Prose Styles ──────────────────────────────────── */
 
 .markdown-preview h1 {

--- a/src/shared/__tests__/env-parse.test.ts
+++ b/src/shared/__tests__/env-parse.test.ts
@@ -62,6 +62,18 @@ describe('env-parse', () => {
     expect(countVars(SAMPLE)).toBe(4);
   });
 
+  it('keeps a stable var id across edits but a fresh id for new lines', () => {
+    const { lines } = parseEnvFile(SAMPLE);
+    const port = lines.find((l) => l.kind === 'var' && l.key === 'PORT');
+    if (port?.kind !== 'var') throw new Error('expected PORT var line');
+    // Editing preserves the id so React keys (and focus) survive keystrokes.
+    expect(updateVarLine(port, 'PORT', '4000').id).toBe(port.id);
+    // Parsed var lines and new lines all get distinct ids.
+    const ids = lines.filter((l) => l.kind === 'var').map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).not.toContain(newVarLine('NEW', 'v').id);
+  });
+
   it('round-trips whitespace-only blank lines byte-for-byte', () => {
     const text = 'A=1\n   \n\t\nB=2\n';
     expect(serializeEnvFile(parseEnvFile(text))).toBe(text);

--- a/src/shared/env-parse.ts
+++ b/src/shared/env-parse.ts
@@ -1,12 +1,16 @@
 /** One physical line, preserved for round-trip fidelity. */
 export type EnvLine =
-  | { kind: 'var'; key: string; value: string; raw: string }
+  | { kind: 'var'; id: number; key: string; value: string; raw: string }
   | { kind: 'comment'; raw: string }
   | { kind: 'blank'; raw: string };
 
 export type VarLine = Extract<EnvLine, { kind: 'var' }>;
 
 export type ParsedEnvFile = { lines: EnvLine[]; trailingNewline: boolean };
+
+/** Stable id for var rows, so React keys survive edits and deletes (not serialized). */
+let varIdCounter = 0;
+const nextVarId = (): number => ++varIdCounter;
 
 /** Parse .env text into ordered lines. Splits on '\n' only so CRLF is kept in raw. */
 export function parseEnvFile(text: string): ParsedEnvFile {
@@ -30,7 +34,7 @@ export function parseEnvFile(text: string): ParsedEnvFile {
     ) {
       value = value.slice(1, -1);
     }
-    return { kind: 'var', key, value, raw };
+    return { kind: 'var', id: nextVarId(), key, value, raw };
   });
   return { lines, trailingNewline };
 }
@@ -49,11 +53,11 @@ export function formatVarLine(key: string, value: string, originalRaw?: string):
 }
 
 export function updateVarLine(line: VarLine, key: string, value: string): VarLine {
-  return { kind: 'var', key, value, raw: formatVarLine(key, value, line.raw) };
+  return { kind: 'var', id: line.id, key, value, raw: formatVarLine(key, value, line.raw) };
 }
 
 export function newVarLine(key: string, value: string): VarLine {
-  return { kind: 'var', key, value, raw: formatVarLine(key, value) };
+  return { kind: 'var', id: nextVarId(), key, value, raw: formatVarLine(key, value) };
 }
 
 export function countVars(text: string): number {


### PR DESCRIPTION
## Summary
Addresses the two deferred Env Editor polish issues.

- **Closes #216** — Form rows were keyed by array index, so deleting a variable above a focused input remounted the rows below and stole focus. Var lines now carry a stable in-memory `id` (assigned at parse time, preserved through `updateVarLine` so keystrokes don't remount, fresh in `newVarLine`); rows key by that id. The id is never serialized, so round-trip fidelity is unchanged.
- **Closes #217** — Replaced the bespoke `env-editor-pop` keyframe with the shared `tw-animate-css` utilities (`animate-in fade-in-0 zoom-in-95` on the panel, `fade-in-0` on the backdrop) at the project's 150ms convention, and removed the keyframe + media query from `index.css`. Reduced motion is handled by the existing global `prefers-reduced-motion` neutralizer, matching `Overlay`/`ToastContainer`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` (env-parse) — 9/9 pass, incl. new test asserting id stability across edits + uniqueness for new lines
- [x] `eslint` on touched files — clean
- [ ] Manual: delete a variable row above a focused value input → focus is retained; typing into key/value never drops focus
- [ ] Manual: open the Env Editor modal → still animates; with OS "reduce motion" on → no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)