### PR TITLE
docs: clarify macOS arm64 vs x64 download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Fleet gives you a single window to manage all your terminal sessions with vertic
 
 Download the latest release for your platform:
 
-- [macOS (Apple Silicon)](https://github.com/khang859/fleet/releases/latest) — `.dmg`
-- [macOS (Intel)](https://github.com/khang859/fleet/releases/latest) — `.dmg`
+- [macOS — Apple Silicon (M1/M2/M3/M4)](https://github.com/khang859/fleet/releases/latest) — download `fleet-<version>-arm64.dmg`
+- [macOS — Intel](https://github.com/khang859/fleet/releases/latest) — download `fleet-<version>-x64.dmg`
 - [Windows](https://github.com/khang859/fleet/releases/latest) — `.exe`
 - [Linux](https://github.com/khang859/fleet/releases/latest) — `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL), `.AppImage` (universal)
 


### PR DESCRIPTION
## Summary
- README "Apple Silicon" and "Intel" download links both pointed at the same generic releases page, so a user could grab the `x64` DMG on an Apple Silicon Mac.
- That x64 build runs under Rosetta, which Apple restricts starting in macOS 28 ([Apple support article 102527](https://support.apple.com/en-us/102527)).
- Each link now names its architecture's DMG (`arm64` for Apple Silicon, `x64` for Intel) so users pick the native build.

## Test plan
- [ ] Confirm README renders the two macOS bullets with the correct arch labels and DMG filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)