### PR TITLE
fix(sessions): show rune and claude sessions that were silently dropped

### DIFF
--- a/docs/learnings/2026-06-09-sessions-empty-strict-schema-and-first-line-cwd.md
+++ b/docs/learnings/2026-06-09-sessions-empty-strict-schema-and-first-line-cwd.md
@@ -1,0 +1,75 @@
+# Sessions tab showed "No sessions" — both sources silently dropped every session
+
+## Symptom
+
+Right after the Sessions tool shipped, the panel showed **"No sessions."** even though
+the user had 141 Rune sessions (`~/.rune/sessions`) and 52 Claude transcripts
+(`~/.claude/projects`). Both sources returned empty lists, so the default `rune` filter
+(and `all`) showed nothing.
+
+## Two independent root causes
+
+Both failures were silent: each session is dropped inside a `try/catch` or a
+`if (!x) continue`, so a bad assumption looks identical to "no data".
+
+### 1. Rune — `content: null` failed the whole-session zod parse
+
+Rune writes `message: { role: "", content: null }` on nodes without content (root/system
+nodes). The schema declared:
+
+```ts
+content: z.array(contentBlockSchema).optional().default([])
+```
+
+`.optional()` and `.default()` only handle **`undefined`**, not **`null`**. `summarizeRune`
+runs `safeParse` on the *entire* session, so one null-content node fails the parse → returns
+`null` → the session is skipped. **All 141 files failed** (`["nodes",0,"message","content"]:
+expected array, received null`).
+
+Fix: coerce null/undefined → `[]`:
+
+```ts
+content: z.array(contentBlockSchema).nullish().transform((v) => v ?? [])
+```
+
+### 2. Claude — cwd read only from the first line, which is now metadata
+
+`cwdFromTranscript` parsed only the **first non-empty line** for a top-level `cwd`. Recent
+Claude Code versions prepend metadata lines that carry no cwd — observed first-line types:
+`last-prompt` (33), `mode` (15), `file-history-snapshot` (4). None have `cwd`, so the
+function returned `''` → `if (!cwd) continue` → **all 52 sessions dropped**. The cwd was
+present on a later line in every file.
+
+Fix: scan for the first line that actually carries a top-level `cwd`:
+
+```ts
+for (const line of content.split('\n')) {
+  if (!line.includes('"cwd"')) continue;
+  try {
+    const parsed = cwdLineSchema.safeParse(JSON.parse(line));
+    if (parsed.success && parsed.data.cwd) return parsed.data.cwd;
+  } catch { /* skip malformed line */ }
+}
+```
+
+## Why tests didn't catch it
+
+The unit-test fixtures used idealized, hand-written data — clean array `content`, a `cwd` on
+line 1. Real on-disk data had `content: null` and metadata-prefixed transcripts. Added
+regression tests using the **real-world shapes** (`summarizeRune` with a null-content node;
+`cwdFromTranscript` with leading `last-prompt`/`mode` lines).
+
+## Lessons
+
+- **Validate against real data, not fixtures.** A 30-second `node -e` script running the
+  actual zod schema over `~/.rune/sessions` / `~/.claude/projects` found both bugs instantly;
+  the green test suite hid them.
+- **zod `.optional()`/`.default()` ≠ nullable.** External JSON that can be `null` needs
+  `.nullish()` / `.nullable()`, usually with a `.transform(v => v ?? default)`.
+- **Don't assume line 1 of a `.jsonl` transcript is a message.** Claude Code prepends
+  metadata records; scan for the field you need.
+- **Silent `continue`/`catch` on a whole record turns a parse bug into "no data".** When a
+  list comes back empty, suspect over-strict parsing before suspecting empty sources.
+- **Beware the sandbox resetting `cwd`.** An early `cd ~/.claude/projects && find .` ran
+  against the wrong tree (shell cwd was reset), producing bogus counts. Use absolute paths in
+  diagnostic scripts.

--- a/src/main/sessions/__tests__/claude-source.test.ts
+++ b/src/main/sessions/__tests__/claude-source.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { claudeMessagesToTranscriptMessages, claudePreview } from '../claude-source';
+import { claudeMessagesToTranscriptMessages, claudePreview, cwdFromTranscript } from '../claude-source';
 import { parseClaudeTranscript } from '../../copilot/conversation-reader';
 import type { CopilotChatMessage } from '../../../shared/types';
 
@@ -44,6 +44,22 @@ describe('claudeMessagesToTranscriptMessages', () => {
 describe('claudePreview', () => {
   it('returns the first user text', () => {
     expect(claudePreview(MESSAGES)).toBe('refactor the api');
+  });
+});
+
+describe('cwdFromTranscript', () => {
+  // Recent Claude Code versions prepend metadata lines that carry no cwd.
+  it('finds cwd past leading metadata lines (last-prompt/mode/file-history-snapshot)', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'last-prompt', leafUuid: 'x', sessionId: 's' }),
+      JSON.stringify({ type: 'mode', mode: 'default' }),
+      JSON.stringify({ type: 'user', uuid: 'u1', cwd: '/Users/me/proj', message: { role: 'user', content: 'hi' } })
+    ].join('\n');
+    expect(cwdFromTranscript(jsonl)).toBe('/Users/me/proj');
+  });
+
+  it('returns empty string when no line carries a cwd', () => {
+    expect(cwdFromTranscript('{"type":"last-prompt"}\n{"type":"mode"}')).toBe('');
   });
 });
 

--- a/src/main/sessions/__tests__/rune-source.test.ts
+++ b/src/main/sessions/__tests__/rune-source.test.ts
@@ -72,6 +72,22 @@ describe('summarizeRune', () => {
   it('returns null for malformed input', () => {
     expect(summarizeRune({ nope: true }, 1)).toBeNull();
   });
+
+  // Rune writes `message: { role: '', content: null }` on nodes without content
+  // (e.g. the root/system node). `content: null` must not fail the whole session.
+  it('parses sessions whose nodes have null message content', () => {
+    const withNullContent = {
+      ...RAW,
+      nodes: [
+        { id: 'root', parent_id: '', children: ['n1'], has_message: false, message: { role: '', content: null } },
+        ...RAW.nodes.slice(1)
+      ]
+    };
+    const s = summarizeRune(withNullContent, 1);
+    expect(s).not.toBeNull();
+    expect(s!.messageCount).toBe(2);
+    expect(s!.preview).toBe('fix the login issue in auth.go');
+  });
 });
 
 describe('readRuneTranscript', () => {

--- a/src/main/sessions/claude-source.ts
+++ b/src/main/sessions/claude-source.ts
@@ -18,16 +18,23 @@ export function claudeProjectsDir(): string {
   return join(homedir(), '.claude', 'projects');
 }
 
-/** Read the cwd recorded in the first JSON line of an already-loaded transcript. */
-function cwdFromTranscript(content: string): string {
-  const firstLine = content.split('\n').find((l) => l.trim().length > 0);
-  if (!firstLine) return '';
-  try {
-    const parsed = cwdLineSchema.safeParse(JSON.parse(firstLine));
-    return parsed.success ? parsed.data.cwd : '';
-  } catch {
-    return '';
+/**
+ * Read the cwd recorded in a transcript. Recent Claude Code versions prepend
+ * metadata lines (`last-prompt`, `mode`, `file-history-snapshot`) that carry no
+ * cwd, so scan for the first line that actually has a top-level cwd rather than
+ * assuming it's on line 1.
+ */
+export function cwdFromTranscript(content: string): string {
+  for (const line of content.split('\n')) {
+    if (!line.includes('"cwd"')) continue;
+    try {
+      const parsed = cwdLineSchema.safeParse(JSON.parse(line));
+      if (parsed.success && parsed.data.cwd) return parsed.data.cwd;
+    } catch {
+      // skip malformed line
+    }
   }
+  return '';
 }
 
 export async function listClaudeSessions(): Promise<SessionSummary[]> {

--- a/src/main/sessions/rune-source.ts
+++ b/src/main/sessions/rune-source.ts
@@ -30,7 +30,15 @@ const nodeSchema = z
     children: z.array(z.string()).optional().default([]),
     has_message: z.boolean().optional().default(false),
     message: z
-      .object({ role: z.string(), content: z.array(contentBlockSchema).optional().default([]) })
+      .object({
+        role: z.string(),
+        // Rune writes `content: null` on nodes without message content; coerce
+        // null/undefined to [] so one such node can't fail the whole session.
+        content: z
+          .array(contentBlockSchema)
+          .nullish()
+          .transform((v) => v ?? [])
+      })
       .optional(),
     created: z.string().optional()
   })


### PR DESCRIPTION
## Summary
The Sessions tool shipped showing **"No sessions"** even though there were 141 Rune + 52 Claude sessions on disk. Both sources returned empty lists, each for a different reason:

- **Rune (0/141 surfaced):** nodes carry `message.content: null`, but the zod schema used `.optional().default([])` — which only coerces `undefined`, not `null`. Since `summarizeRune` `safeParse`s the whole session, one null-content node failed the entire parse and dropped the session. Now `.nullish().transform((v) => v ?? [])`.
- **Claude (0/52 surfaced):** `cwd` was read only from the first transcript line, which recent Claude Code versions fill with metadata (`last-prompt`/`mode`/`file-history-snapshot`) that has no `cwd`, so every session hit `if (!cwd) continue`. Now scans for the first line that actually carries a top-level `cwd`.

Added regression tests using the **real on-disk shapes** — the prior fixtures used idealized data and hid both bugs. Documented in `docs/learnings/`.

## Test plan
- [x] `npx vitest run src/main/sessions` → 14 passed, 0 failed
- [x] `npm run typecheck` → clean
- [x] Replayed actual list logic over real data: rune 141/141 parse, claude 52/52 surface
- [ ] Open the Sessions tab and confirm sessions appear under both `rune` and `claude` filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)