### PR TITLE
feat(sessions): branch/DAG tree visualization for Rune sessions

### DIFF
--- a/src/main/sessions/__tests__/rune-source.test.ts
+++ b/src/main/sessions/__tests__/rune-source.test.ts
@@ -79,7 +79,13 @@ describe('summarizeRune', () => {
     const withNullContent = {
       ...RAW,
       nodes: [
-        { id: 'root', parent_id: '', children: ['n1'], has_message: false, message: { role: '', content: null } },
+        {
+          id: 'root',
+          parent_id: '',
+          children: ['n1'],
+          has_message: false,
+          message: { role: '', content: null }
+        },
         ...RAW.nodes.slice(1)
       ]
     };
@@ -199,5 +205,81 @@ describe('compacted sessions', () => {
     const s = summarizeRune(compacted, 1)!;
     expect(s.messageCount).toBe(2);
     expect(s.preview).toBe('do the thing');
+  });
+});
+
+describe('session tree (branch DAG)', () => {
+  it('omits the tree for a single-branch (linear) session', () => {
+    const t = readRuneTranscript(RAW, 1)!;
+    expect(t.tree).toBeUndefined();
+  });
+
+  it('builds a tree for a branching session, dropping the empty root', () => {
+    const t = readRuneTranscript(BRANCHING, 1)!;
+    expect(t.tree).toBeDefined();
+    const tree = t.tree!;
+    expect(tree.activeId).toBe('a1');
+    // Root has no message and must not appear as a node.
+    expect(tree.nodes.map((n) => n.id).sort()).toEqual(['a1', 'b1', 'n1']);
+    // n1 hangs off the (omitted) root -> parentId null; a1/b1 are its children.
+    const n1 = tree.nodes.find((n) => n.id === 'n1')!;
+    expect(n1.parentId).toBeNull();
+    expect(n1.childIds.sort()).toEqual(['a1', 'b1']);
+    const a1 = tree.nodes.find((n) => n.id === 'a1')!;
+    expect(a1.parentId).toBe('n1');
+    expect(a1.role).toBe('assistant');
+    expect(a1.preview).toBe('active branch');
+  });
+
+  it('resolves a message-less active_id so the tree never points outside its nodes', () => {
+    // active_id points at the empty root; the resolved activeId must be a real node.
+    const tree = readRuneTranscript({ ...BRANCHING, active_id: 'root' }, 1)!.tree!;
+    expect(tree.nodes.some((n) => n.id === tree.activeId)).toBe(true);
+  });
+
+  it('maps usage (capitalized rune keys) and compacted_count onto tree nodes', () => {
+    const withMeta = {
+      ...BRANCHING,
+      nodes: BRANCHING.nodes.map((n) =>
+        n.id === 'a1'
+          ? {
+              ...n,
+              usage: { Input: 100, Output: 20, CacheRead: 5 },
+              compacted_count: 3,
+              created: '2026-04-30T09:08:12Z'
+            }
+          : n
+      )
+    };
+    const tree = readRuneTranscript(withMeta, 1)!.tree!;
+    const a1 = tree.nodes.find((n) => n.id === 'a1')!;
+    expect(a1.usage).toEqual({ input: 100, output: 20, cacheRead: 5 });
+    expect(a1.compactedCount).toBe(3);
+    expect(a1.createdAt).toBe(Date.parse('2026-04-30T09:08:12Z'));
+  });
+
+  it('parses session-level subagents', () => {
+    const withSubagents = {
+      ...BRANCHING,
+      subagents: [
+        {
+          task_id: 's1',
+          name: 'explorer',
+          agent_type: 'code-explorer',
+          status: 'completed',
+          summary: 'mapped the data layer'
+        }
+      ]
+    };
+    const t = readRuneTranscript(withSubagents, 1)!;
+    expect(t.subagents).toEqual([
+      {
+        id: 's1',
+        name: 'explorer',
+        agentType: 'code-explorer',
+        status: 'completed',
+        summary: 'mapped the data layer'
+      }
+    ]);
   });
 });

--- a/src/main/sessions/rune-source.ts
+++ b/src/main/sessions/rune-source.ts
@@ -6,6 +6,10 @@ import { z } from 'zod';
 import type {
   SessionSummary,
   SessionTranscript,
+  SessionTree,
+  SessionTreeNode,
+  SubagentSummary,
+  TokenUsage,
   TranscriptBlock,
   TranscriptMessage
 } from '../../shared/sessions';
@@ -22,6 +26,15 @@ const contentBlockSchema = z
     is_error: z.boolean().optional()
   })
   .passthrough();
+
+// Rune's ai.Usage struct has no JSON tags, so Go serializes the keys capitalized.
+const usageSchema = z
+  .object({
+    Input: z.number().optional(),
+    Output: z.number().optional(),
+    CacheRead: z.number().optional()
+  })
+  .partial();
 
 const nodeSchema = z
   .object({
@@ -40,7 +53,19 @@ const nodeSchema = z
           .transform((v) => v ?? [])
       })
       .optional(),
-    created: z.string().optional()
+    created: z.string().optional(),
+    usage: usageSchema.optional(),
+    compacted_count: z.number().optional()
+  })
+  .passthrough();
+
+const subagentSchema = z
+  .object({
+    task_id: z.string(),
+    name: z.string().optional().default(''),
+    agent_type: z.string().optional(),
+    status: z.string().optional().default(''),
+    summary: z.string().optional()
   })
   .passthrough();
 
@@ -54,7 +79,8 @@ export const runeSessionSchema = z
     cwd: z.string().optional().default(''),
     root_id: z.string().optional().default(''),
     active_id: z.string().optional().default(''),
-    nodes: z.array(nodeSchema).optional().default([])
+    nodes: z.array(nodeSchema).optional().default([]),
+    subagents: z.array(subagentSchema).optional().default([])
   })
   .passthrough();
 
@@ -115,6 +141,101 @@ function toBlocks(content: Array<z.infer<typeof contentBlockSchema>>): Transcrip
   });
 }
 
+function parseCreated(value?: string): number | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+function mapUsage(usage?: z.infer<typeof usageSchema>): TokenUsage | undefined {
+  if (!usage) return undefined;
+  const input = usage.Input ?? 0;
+  const output = usage.Output ?? 0;
+  const cacheRead = usage.CacheRead ?? 0;
+  if (input === 0 && output === 0 && cacheRead === 0) return undefined;
+  return { input, output, cacheRead };
+}
+
+function nodePreview(content: Array<z.infer<typeof contentBlockSchema>>): string {
+  const text = content.find((b) => b.type === 'text')?.text ?? '';
+  return text.trim().replace(/\s+/g, ' ').slice(0, 80);
+}
+
+/** Nearest ancestor that carries a message, skipping the empty root and any message-less nodes. */
+function nearestMessageAncestor(
+  node: RuneSession['nodes'][number],
+  byId: Map<string, RuneSession['nodes'][number]>
+): string | null {
+  const seen = new Set<string>();
+  let parent = node.parent_id ? byId.get(node.parent_id) : undefined;
+  while (parent && !seen.has(parent.id)) {
+    seen.add(parent.id);
+    if (parent.has_message && parent.message) return parent.id;
+    parent = parent.parent_id ? byId.get(parent.parent_id) : undefined;
+  }
+  return null;
+}
+
+/**
+ * Reconstruct the message-bearing graph. The empty root node is dropped; its children
+ * become top-level nodes (parentId null). Returns undefined for linear sessions so the
+ * renderer falls back to the plain transcript view.
+ */
+function buildTree(session: RuneSession): SessionTree | undefined {
+  const byId = new Map(session.nodes.map((n) => [n.id, n]));
+  const msgNodes = session.nodes.filter((n) => n.has_message && n.message);
+
+  const parentOf = new Map<string, string | null>();
+  for (const n of msgNodes) parentOf.set(n.id, nearestMessageAncestor(n, byId));
+
+  const childrenOf = new Map<string, string[]>();
+  for (const n of msgNodes) {
+    const parent = parentOf.get(n.id);
+    if (!parent) continue;
+    const siblings = childrenOf.get(parent);
+    if (siblings) siblings.push(n.id);
+    else childrenOf.set(parent, [n.id]);
+  }
+
+  const topLevelCount = msgNodes.filter((n) => parentOf.get(n.id) === null).length;
+  const hasBranches =
+    topLevelCount > 1 || msgNodes.some((n) => (childrenOf.get(n.id)?.length ?? 0) > 1);
+  if (!hasBranches) return undefined;
+
+  const nodes: SessionTreeNode[] = msgNodes.map((n) => ({
+    id: n.id,
+    parentId: parentOf.get(n.id) ?? null,
+    childIds: childrenOf.get(n.id) ?? [],
+    role: toRole(n.message!.role),
+    blocks: toBlocks(n.message!.content),
+    createdAt: parseCreated(n.created),
+    usage: mapUsage(n.usage),
+    compactedCount: n.compacted_count && n.compacted_count > 0 ? n.compacted_count : undefined,
+    preview: nodePreview(n.message!.content)
+  }));
+
+  // active_id is usually a leaf message node, but guard against it pointing at the
+  // message-less root (or a stray id) so the renderer never defaults to a blank path.
+  const msgIds = new Set(msgNodes.map((n) => n.id));
+  const rawActive = byId.get(session.active_id);
+  const activeId = msgIds.has(session.active_id)
+    ? session.active_id
+    : ((rawActive ? nearestMessageAncestor(rawActive, byId) : null) ?? nodes[nodes.length - 1].id);
+
+  return { activeId, nodes };
+}
+
+function mapSubagents(subagents: RuneSession['subagents']): SubagentSummary[] | undefined {
+  if (subagents.length === 0) return undefined;
+  return subagents.map((s) => ({
+    id: s.task_id,
+    name: s.name,
+    agentType: s.agent_type,
+    status: s.status,
+    summary: s.summary || undefined
+  }));
+}
+
 export function summarizeRune(raw: unknown, updatedAt: number): SessionSummary | null {
   const parsed = runeSessionSchema.safeParse(raw);
   if (!parsed.success) return null;
@@ -145,7 +266,12 @@ export function readRuneTranscript(raw: unknown, updatedAt: number): SessionTran
       blocks: toBlocks(node.message!.content)
     })
   );
-  return { summary, messages };
+  const result: SessionTranscript = { summary, messages };
+  const tree = buildTree(session);
+  if (tree) result.tree = tree;
+  const subagents = mapSubagents(session.subagents);
+  if (subagents) result.subagents = subagents;
+  return result;
 }
 
 export function runeSessionsDir(): string {

--- a/src/renderer/src/components/sessions/SessionTree.tsx
+++ b/src/renderer/src/components/sessions/SessionTree.tsx
@@ -1,0 +1,129 @@
+// src/renderer/src/components/sessions/SessionTree.tsx
+import { useMemo } from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import type { SessionTree as SessionTreeData, SessionTreeNode } from '../../../../shared/sessions';
+import { tooltipAnim } from '../../lib/motion';
+import { flattenTree, pathIds, type TreeRow } from './tree-utils';
+
+function connectorPrefix(row: TreeRow): string {
+  const bars = row.ancestorBars.map((bar) => (bar ? '│ ' : '  ')).join('');
+  if (row.isRoot) return bars;
+  return bars + (row.isLast ? '└─' : '├─');
+}
+
+function formatTime(ms?: number): string | null {
+  if (ms === undefined) return null;
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function NodeRow({
+  row,
+  isActive,
+  isSelected,
+  onSelect
+}: {
+  row: TreeRow;
+  isActive: boolean;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}): React.JSX.Element {
+  const { node } = row;
+  const time = formatTime(node.createdAt);
+  const dotColor = isActive ? 'text-blue-400' : 'text-fleet-text-subtle';
+  const label = node.preview || `(${node.role})`;
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <button
+          onClick={() => onSelect(node.id)}
+          className={`flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-xs ${
+            isSelected ? 'bg-blue-600/20' : 'hover:bg-fleet-surface-2/50'
+          }`}
+        >
+          <span className="whitespace-pre font-mono text-fleet-text-subtle">
+            {connectorPrefix(row)}
+          </span>
+          <span className={`font-mono ${dotColor}`}>●</span>
+          <span className="text-[10px] uppercase tracking-wider text-fleet-text-subtle">
+            {node.role}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-fleet-text">{label}</span>
+          {node.compactedCount ? (
+            <span className="flex-shrink-0 rounded bg-amber-500/20 px-1 text-[10px] text-amber-300">
+              compacted {node.compactedCount}
+            </span>
+          ) : null}
+          {isActive ? (
+            <span className="flex-shrink-0 text-[10px] text-blue-400">◀ active</span>
+          ) : null}
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          side="right"
+          sideOffset={6}
+          className={`z-50 max-w-[260px] rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-white shadow-lg ${tooltipAnim}`}
+        >
+          <NodeMeta node={node} time={time} />
+          <Tooltip.Arrow className="fill-neutral-800" />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+}
+
+function NodeMeta({
+  node,
+  time
+}: {
+  node: SessionTreeNode;
+  time: string | null;
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="capitalize text-neutral-300">{node.role}</span>
+      {time ? <span className="text-neutral-400">{time}</span> : null}
+      {node.usage ? (
+        <span className="font-mono text-neutral-400">
+          ↑{node.usage.input} ↓{node.usage.output}
+          {node.usage.cacheRead > 0 ? ` ⚡${node.usage.cacheRead}` : ''}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function SessionTree({
+  tree,
+  selectedNodeId,
+  onSelect
+}: {
+  tree: SessionTreeData;
+  selectedNodeId: string | null;
+  onSelect: (id: string) => void;
+}): React.JSX.Element {
+  const rows = useMemo(() => flattenTree(tree), [tree]);
+  const activeIds = useMemo(() => pathIds(tree, tree.activeId), [tree]);
+
+  return (
+    <Tooltip.Provider delayDuration={300}>
+      <div className="flex flex-col gap-0.5">
+        {rows.map((row) => (
+          <NodeRow
+            key={row.node.id}
+            row={row}
+            isActive={activeIds.has(row.node.id)}
+            isSelected={row.node.id === selectedNodeId}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </Tooltip.Provider>
+  );
+}

--- a/src/renderer/src/components/sessions/TranscriptView.tsx
+++ b/src/renderer/src/components/sessions/TranscriptView.tsx
@@ -1,11 +1,15 @@
 // src/renderer/src/components/sessions/TranscriptView.tsx
+import { useMemo, useState } from 'react';
 import type {
   SessionSummary,
+  SubagentSummary,
   TranscriptBlock,
   TranscriptMessage
 } from '../../../../shared/sessions';
 import { useSessionsStore } from '../../store/sessions-store';
 import { useWorkspaceStore } from '../../store/workspace-store';
+import { SessionTree } from './SessionTree';
+import { pathToNode } from './tree-utils';
 
 function resumeCommand(s: SessionSummary): string {
   return s.agent === 'rune' ? `rune --resume ${s.id}` : `claude --resume ${s.id}`;
@@ -56,9 +60,50 @@ function Message({ message }: { message: TranscriptMessage }): React.JSX.Element
   );
 }
 
+function SubagentList({ subagents }: { subagents: SubagentSummary[] }): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-fleet-text-subtle">
+        Subagents
+      </div>
+      {subagents.map((sa) => (
+        <div key={sa.id} className="rounded bg-fleet-surface-2/40 px-2 py-1 text-xs">
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-fleet-text">
+              {sa.name.length > 0 ? sa.name : '(unnamed)'}
+            </span>
+            <span className="flex-shrink-0 rounded bg-fleet-surface-2 px-1 text-[10px] text-fleet-text-subtle">
+              {sa.status}
+            </span>
+          </div>
+          {sa.agentType ? (
+            <div className="truncate text-[10px] text-fleet-text-subtle">{sa.agentType}</div>
+          ) : null}
+          {sa.summary ? (
+            <div className="mt-0.5 line-clamp-3 text-[11px] text-fleet-text-subtle">
+              {sa.summary}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function TranscriptView(): React.JSX.Element {
-  const { selected, transcript, isLoadingTranscript, transcriptError } = useSessionsStore();
+  const { selected, transcript, selectedNodeId, selectNode, isLoadingTranscript, transcriptError } =
+    useSessionsStore();
   const openResumeTab = useWorkspaceStore((s) => s.openResumeTab);
+  const [showRail, setShowRail] = useState(true);
+
+  const tree = transcript?.tree;
+  const subagents = transcript?.subagents;
+  const hasRail = Boolean(tree) || (subagents !== undefined && subagents.length > 0);
+
+  const messages = useMemo<TranscriptMessage[]>(() => {
+    if (!transcript) return [];
+    return tree ? pathToNode(tree, selectedNodeId) : transcript.messages;
+  }, [transcript, tree, selectedNodeId]);
 
   if (!selected) {
     return (
@@ -90,20 +135,40 @@ export function TranscriptView(): React.JSX.Element {
           <div className="truncate text-sm font-semibold text-fleet-text">{s.title}</div>
           <div className="text-xs text-fleet-text-subtle">
             {s.agent} {s.provider ? `· ${s.provider}` : ''} {s.model ? `· ${s.model}` : ''} ·{' '}
-            {s.messageCount} msgs
+            {messages.length} msgs
           </div>
         </div>
-        <button
-          onClick={() => openResumeTab(s.cwd, resumeCommand(s), s.title)}
-          className="flex-shrink-0 rounded bg-blue-600/80 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-600"
-        >
-          Resume ▸
-        </button>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          {hasRail ? (
+            <button
+              onClick={() => setShowRail((v) => !v)}
+              className="rounded border border-fleet-border-strong px-2 py-1.5 text-xs text-fleet-text-subtle hover:bg-fleet-surface-2/50"
+            >
+              {showRail ? '⌹ Hide branches' : '⌹ Branches'}
+            </button>
+          ) : null}
+          <button
+            onClick={() => openResumeTab(s.cwd, resumeCommand(s), s.title)}
+            className="rounded bg-blue-600/80 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-600"
+          >
+            Resume ▸
+          </button>
+        </div>
       </div>
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 flex flex-col gap-3">
-        {transcript.messages.map((m, i) => (
-          <Message key={i} message={m} />
-        ))}
+      <div className="flex min-h-0 flex-1">
+        {hasRail && showRail ? (
+          <div className="flex w-64 flex-shrink-0 flex-col gap-3 overflow-y-auto border-r border-fleet-border px-2 py-3">
+            {tree ? (
+              <SessionTree tree={tree} selectedNodeId={selectedNodeId} onSelect={selectNode} />
+            ) : null}
+            {subagents && subagents.length > 0 ? <SubagentList subagents={subagents} /> : null}
+          </div>
+        ) : null}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3">
+          {messages.map((m, i) => (
+            <Message key={i} message={m} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/src/components/sessions/__tests__/tree-utils.test.ts
+++ b/src/renderer/src/components/sessions/__tests__/tree-utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionTree, SessionTreeNode } from '../../../../../shared/sessions';
+import { flattenTree, pathIds, pathToNode } from '../tree-utils';
+
+function node(id: string, parentId: string | null, childIds: string[]): SessionTreeNode {
+  return {
+    id,
+    parentId,
+    childIds,
+    role: 'assistant',
+    blocks: [{ type: 'text', text: id }],
+    preview: id
+  };
+}
+
+// n1 (top-level) -> { a1 (active), b1 }; a1 -> a2
+const TREE: SessionTree = {
+  activeId: 'a2',
+  nodes: [
+    node('n1', null, ['a1', 'b1']),
+    node('a1', 'n1', ['a2']),
+    node('a2', 'a1', []),
+    node('b1', 'n1', [])
+  ]
+};
+
+describe('pathIds', () => {
+  it('returns the ids on root -> node inclusive', () => {
+    expect(pathIds(TREE, 'a2')).toEqual(new Set(['a2', 'a1', 'n1']));
+    expect(pathIds(TREE, 'b1')).toEqual(new Set(['b1', 'n1']));
+  });
+
+  it('returns an empty set for a null selection', () => {
+    expect(pathIds(TREE, null).size).toBe(0);
+  });
+});
+
+describe('pathToNode', () => {
+  it('returns messages in chronological (root-first) order', () => {
+    expect(pathToNode(TREE, 'a2').map((m) => m.blocks[0])).toEqual([
+      { type: 'text', text: 'n1' },
+      { type: 'text', text: 'a1' },
+      { type: 'text', text: 'a2' }
+    ]);
+  });
+
+  it('walks the abandoned branch when that node is selected', () => {
+    expect(pathToNode(TREE, 'b1').map((m) => m.blocks[0])).toEqual([
+      { type: 'text', text: 'n1' },
+      { type: 'text', text: 'b1' }
+    ]);
+  });
+});
+
+describe('flattenTree', () => {
+  it('emits depth-first pre-order rows with connector metadata', () => {
+    const rows = flattenTree(TREE);
+    expect(rows.map((r) => r.node.id)).toEqual(['n1', 'a1', 'a2', 'b1']);
+
+    const byId = Object.fromEntries(rows.map((r) => [r.node.id, r]));
+    // Top-level node: no connector, no ancestor bars.
+    expect(byId.n1.isRoot).toBe(true);
+    expect(byId.n1.ancestorBars).toEqual([]);
+    // a1 is the first (non-last) child of root -> elbow but no leading bar column.
+    expect(byId.a1.isRoot).toBe(false);
+    expect(byId.a1.isLast).toBe(false);
+    expect(byId.a1.ancestorBars).toEqual([]);
+    // a2 is the last child of a1; a1 still has a following sibling (b1), so a bar continues.
+    expect(byId.a2.ancestorBars).toEqual([true]);
+    expect(byId.a2.isLast).toBe(true);
+    // b1 is the last child of root.
+    expect(byId.b1.isLast).toBe(true);
+    expect(byId.b1.ancestorBars).toEqual([]);
+  });
+});

--- a/src/renderer/src/components/sessions/tree-utils.ts
+++ b/src/renderer/src/components/sessions/tree-utils.ts
@@ -1,0 +1,74 @@
+// src/renderer/src/components/sessions/tree-utils.ts
+// Pure helpers for navigating a Rune session's branch graph.
+import type { SessionTree, SessionTreeNode, TranscriptMessage } from '../../../../shared/sessions';
+
+/** Map of node id -> node for a tree. */
+function indexById(tree: SessionTree): Map<string, SessionTreeNode> {
+  return new Map(tree.nodes.map((n) => [n.id, n]));
+}
+
+/** Ids on the path root -> nodeId (inclusive), walking parentId links upward. */
+export function pathIds(tree: SessionTree, nodeId: string | null): Set<string> {
+  const byId = indexById(tree);
+  const ids = new Set<string>();
+  let current = nodeId ? byId.get(nodeId) : undefined;
+  while (current && !ids.has(current.id)) {
+    ids.add(current.id);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return ids;
+}
+
+/** Messages on the path root -> nodeId, in chronological order. */
+export function pathToNode(tree: SessionTree, nodeId: string | null): TranscriptMessage[] {
+  const byId = indexById(tree);
+  const chain: SessionTreeNode[] = [];
+  const guard = new Set<string>();
+  let current = nodeId ? byId.get(nodeId) : undefined;
+  while (current && !guard.has(current.id)) {
+    guard.add(current.id);
+    chain.push(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return chain.reverse().map((n) => ({ role: n.role, blocks: n.blocks, createdAt: n.createdAt }));
+}
+
+export type TreeRow = {
+  node: SessionTreeNode;
+  /** One entry per ancestor column (excluding the root): true = draw a vertical bar. */
+  ancestorBars: boolean[];
+  /** Whether this node is the last among its siblings. */
+  isLast: boolean;
+  /** Top-level node (hangs off the omitted root); rendered without an elbow connector. */
+  isRoot: boolean;
+};
+
+/** Depth-first pre-order flattening with the connector metadata each row needs to render. */
+export function flattenTree(tree: SessionTree): TreeRow[] {
+  const byId = indexById(tree);
+  const childrenOf = (n: SessionTreeNode): SessionTreeNode[] =>
+    n.childIds.map((id) => byId.get(id)).filter((x): x is SessionTreeNode => Boolean(x));
+  const roots = tree.nodes.filter((n) => n.parentId === null);
+  const rows: TreeRow[] = [];
+  const visited = new Set<string>();
+
+  const visit = (
+    node: SessionTreeNode,
+    ancestorBars: boolean[],
+    isLast: boolean,
+    isRoot: boolean
+  ): void => {
+    if (visited.has(node.id)) return;
+    visited.add(node.id);
+    rows.push({ node, ancestorBars, isLast, isRoot });
+    // The root occupies column 0 with its dot, so it contributes no bar column; its
+    // children connect directly beneath it. Deeper nodes add a bar that continues
+    // downward only while the current node still has a following sibling.
+    const childBars = isRoot ? ancestorBars : [...ancestorBars, !isLast];
+    const kids = childrenOf(node);
+    kids.forEach((kid, i) => visit(kid, childBars, i === kids.length - 1, false));
+  };
+
+  roots.forEach((r, i) => visit(r, [], i === roots.length - 1, true));
+  return rows;
+}

--- a/src/renderer/src/store/sessions-store.ts
+++ b/src/renderer/src/store/sessions-store.ts
@@ -9,10 +9,13 @@ type SessionsStoreState = {
   isLoaded: boolean;
   selected: SelectedKey | null;
   transcript: SessionTranscript | null;
+  /** Node selected in the branch tree; defaults to the session's active node. */
+  selectedNodeId: string | null;
   isLoadingTranscript: boolean;
   transcriptError: string | null;
   load: () => Promise<void>;
   select: (s: SessionSummary) => Promise<void>;
+  selectNode: (nodeId: string) => void;
 };
 
 const READ_FAILED = 'This session could not be loaded. The file may have been moved or deleted.';
@@ -22,6 +25,7 @@ export const useSessionsStore = create<SessionsStoreState>((set, get) => ({
   isLoaded: false,
   selected: null,
   transcript: null,
+  selectedNodeId: null,
   isLoadingTranscript: false,
   transcriptError: null,
 
@@ -34,7 +38,15 @@ export const useSessionsStore = create<SessionsStoreState>((set, get) => ({
       try {
         const transcript = await window.fleet.sessions.read(sel);
         const cur = get().selected;
-        if (cur?.id === sel.id && cur?.agent === sel.agent && transcript) set({ transcript });
+        if (cur?.id === sel.id && cur?.agent === sel.agent && transcript) {
+          // Keep the user's branch selection if it still exists; otherwise reset to active.
+          const keep = get().selectedNodeId;
+          const stillValid = transcript.tree?.nodes.some((n) => n.id === keep) ?? false;
+          set({
+            transcript,
+            selectedNodeId: stillValid ? keep : (transcript.tree?.activeId ?? null)
+          });
+        }
       } catch {
         // ignore refresh failure; keep existing transcript
       }
@@ -43,7 +55,13 @@ export const useSessionsStore = create<SessionsStoreState>((set, get) => ({
 
   select: async (s) => {
     const selected = { agent: s.agent, id: s.id, cwd: s.cwd };
-    set({ selected, isLoadingTranscript: true, transcript: null, transcriptError: null });
+    set({
+      selected,
+      isLoadingTranscript: true,
+      transcript: null,
+      selectedNodeId: null,
+      transcriptError: null
+    });
     const isCurrent = (): boolean => {
       const cur = get().selected;
       return cur?.id === s.id && cur?.agent === s.agent;
@@ -51,10 +69,17 @@ export const useSessionsStore = create<SessionsStoreState>((set, get) => ({
     try {
       const transcript = await window.fleet.sessions.read(selected);
       if (!isCurrent()) return;
-      if (transcript) set({ transcript, isLoadingTranscript: false });
+      if (transcript)
+        set({
+          transcript,
+          selectedNodeId: transcript.tree?.activeId ?? null,
+          isLoadingTranscript: false
+        });
       else set({ isLoadingTranscript: false, transcriptError: READ_FAILED });
     } catch {
       if (isCurrent()) set({ isLoadingTranscript: false, transcriptError: READ_FAILED });
     }
-  }
+  },
+
+  selectNode: (nodeId) => set({ selectedNodeId: nodeId })
 }));

--- a/src/shared/sessions.ts
+++ b/src/shared/sessions.ts
@@ -31,9 +31,44 @@ export type SessionSummary = {
   preview: string;
 };
 
+export type TokenUsage = { input: number; output: number; cacheRead: number };
+
+/** A single node in a Rune session's branching DAG. The empty root node is not included. */
+export type SessionTreeNode = {
+  id: string;
+  /** Nearest message-bearing ancestor; null when the node hangs directly off the root. */
+  parentId: string | null;
+  childIds: string[];
+  role: TranscriptMessage['role'];
+  blocks: TranscriptBlock[];
+  createdAt?: number; // epoch ms
+  usage?: TokenUsage;
+  compactedCount?: number; // >0 marks a compaction summary node
+  preview: string; // short text label for the graph row
+};
+
+export type SubagentSummary = {
+  id: string;
+  name: string;
+  agentType?: string;
+  status: string;
+  summary?: string;
+};
+
+/** The full branching graph of a Rune session. Present only when the session has branches. */
+export type SessionTree = {
+  /** Leaf of the live branch; always present in `nodes`. Graph roots are nodes with parentId null. */
+  activeId: string;
+  nodes: SessionTreeNode[];
+};
+
 export type SessionTranscript = {
   summary: SessionSummary;
   messages: TranscriptMessage[];
+  /** Branch graph; only set for Rune sessions that actually fork. */
+  tree?: SessionTree;
+  /** Session-level subagents; Rune only. Not linked to individual nodes. */
+  subagents?: SubagentSummary[];
 };
 
 export type SessionGroup = {


### PR DESCRIPTION
## Summary

Implements #222. Rune persists each session as a branching **DAG**, but the Sessions tool only ever walked `root_id → active_id`, so forks, clones, and compaction were invisible. This exposes the full node graph and adds a navigable tree view.

- **Data**: the Rune adapter now reconstructs the full message-bearing graph (parent/children, role, blocks, `created`, token `usage`, `compacted_count`) instead of just the active path. The empty root node is dropped. A tree is built **only when a session actually branches**; the graph rides the existing `sessions:read` payload — no new IPC channel.
- **UI**: a collapsible tree rail in the transcript pane renders a `git log --graph`-style graph with `├─ └─ │ ●` connectors. The **active branch** is marked (blue + `◀ active`), **compaction** nodes are badged (`compacted N`), and per-node **role / time / token usage** show on hover. Clicking a node swaps the main transcript to that branch's path (root → node) with no re-fetch.
- **Subagents**: surfaced as a session-level list in the rail. (The persisted format stores subagents flat, not linked to nodes — confirmed against real data — so per-node attribution isn't possible; noted in the issue as a Rune dependency.)
- **Degrade**: single-branch Rune sessions and all Claude sessions keep the existing linear view — no empty/awkward tree UI.

Out of scope per the issue: branch-targeted resume (depends on khang859/rune#17).

## Notes

Of 141 real Rune sessions on disk, 0 currently branch (forks are rare) but 29 have subagents and 6 have compaction — so the subagent rail is the most visible part day-to-day. `usage` keys on disk are capitalized (`Input`/`Output`/`CacheRead`) because Go's `ai.Usage` has no JSON tags; the Zod schema handles that.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors
- [x] `npm test` — 974 pass (added 10: graph reconstruction, usage/compaction/subagent parsing, active-id resolution, path derivation, connector layout)
- [x] `npm run build` — succeeds
- [ ] Manual: open a Rune session with forks → tree renders, clicking a branch shows its transcript; active branch + compaction nodes distinct; single-branch session shows no tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)