### PR TITLE
fix(search): cap child-process stdout to prevent main-process OOM

### DIFF
--- a/docs/learnings/main-process-oom-unbounded-search-stdout.md
+++ b/docs/learnings/main-process-oom-unbounded-search-stdout.md
@@ -1,0 +1,52 @@
+# Main-process OOM from unbounded search-tool stdout (and how to read Electron stackshots)
+
+## What happened
+
+A user's Fleet (2.39.0) "hung" for 120+ seconds and produced a macOS stackshot report.
+The raw report looked like an infinite loop with bizarre frames (`rust_png`,
+`node::sqlite`, `ares_dns_rr_get_ttl`). After re-symbolicating with Electron's
+breakpad symbols, the real stack was a **V8 heap out-of-memory crash**:
+
+```
+fs.promises completion → microtask drain → JS → Runtime_StringSplit
+→ String::SlowFlatten<ConsString> → NewRawTwoByteString
+→ CollectGarbageAndRetryAllocation → V8::FatalProcessOutOfMemory
+```
+
+The "hang" was minutes of full-GC thrashing followed by the crash-dump writer.
+
+## Root cause
+
+Three main-process modules buffered **unbounded child-process stdout** into a
+single string via `stdout += chunk.toString()` and later `.split('\n')` it:
+
+- `file-search.ts` — `mdfind` over `~` by display name, per keystroke, no output cap
+- `recent-images.ts` — `mdfind` for *every image under `~`* + recursive `readdir`
+  of Desktop/Downloads/Pictures, fired on every FileSearchOverlay open
+- `file-grep.ts` — `rg` whose `--max-count` is per-file, so total output is unbounded
+
+On machines with huge Spotlight indexes these emit hundreds of MB. The `+=`
+accumulation builds a giant ConsString; `split('\n')` must flatten it (allocating
+the whole flat copy at once) and explodes a heap already filled by prior requests.
+SIGTERM timeouts do not bound size — mdfind can emit hundreds of MB in seconds.
+
+## Fix
+
+`src/main/bounded-stdout.ts` — `captureBoundedStdout(proc, maxChars)` accumulates
+stdout and SIGTERMs the child once the cap (8M chars) is exceeded, keeping the
+truncated prefix. Applied to all five spawn sites; `scanKnownDirs()` also caps
+collected paths (`SCAN_RESULT_LIMIT`).
+
+## Lessons
+
+1. **Never accumulate child-process stdout without a byte cap** in the main
+   process — a kill-timeout is not a size bound. Use `captureBoundedStdout`.
+2. **Stripped Electron stackshot symbols are nearest-symbol garbage.** Before
+   trusting frame names, download `electron-v<ver>-darwin-arm64-symbols.zip`
+   from the Electron release matching `package-lock.json`, check the module
+   UUID against the report, and resolve `Electron Framework + <offset>` against
+   the breakpad `FUNC` records. Tiny lambdas may be ICF-merged, so take
+   promise-resolver frame identities with a grain of salt.
+3. A V8 OOM presents as a long *hang* (GC thrash) before the crash — `Event: hang`
+   reports can be memory bugs, not loops. `SlowFlatten<ConsString>` in the fatal
+   stack means a string built by `+=` was flattened; go hunting for accumulators.

--- a/src/main/__tests__/bounded-stdout.test.ts
+++ b/src/main/__tests__/bounded-stdout.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { captureBoundedStdout } from '../bounded-stdout';
+
+async function waitForClose(
+  proc: ChildProcess
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve) => {
+    proc.on('close', (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe('captureBoundedStdout', () => {
+  it('small output passes through untouched', async () => {
+    const proc = spawn(process.execPath, ['-e', "process.stdout.write('hello world')"]);
+    const out = captureBoundedStdout(proc);
+    await waitForClose(proc);
+    expect(out.text).toBe('hello world');
+    expect(out.truncated).toBe(false);
+  });
+
+  it('oversized output is truncated and the process killed', async () => {
+    const script =
+      "const c = 'a'.repeat(65536); function w(){ while(process.stdout.write(c)){} } process.stdout.on('drain', w); w();";
+    const proc = spawn(process.execPath, ['-e', script]);
+    const out = captureBoundedStdout(proc, 256 * 1024);
+    const { code, signal } = await waitForClose(proc);
+    expect(out.truncated).toBe(true);
+    expect(out.text.length).toBeGreaterThan(256 * 1024);
+    expect(out.text.length).toBeLessThan(4 * 1024 * 1024);
+    // On macOS signal should be SIGTERM; accept non-zero/null exit code as well
+    const killedBySigterm = signal === 'SIGTERM';
+    const nonZeroExit = code !== 0;
+    expect(killedBySigterm || nonZeroExit).toBe(true);
+  }, 10_000);
+
+  it('stops accumulating after truncation', async () => {
+    const script =
+      "const c = 'a'.repeat(65536); function w(){ while(process.stdout.write(c)){} } process.stdout.on('drain', w); w();";
+    const proc = spawn(process.execPath, ['-e', script]);
+    const cap = 1024;
+    const out = captureBoundedStdout(proc, cap);
+    await waitForClose(proc);
+    // After truncation the helper should stop accumulating.
+    // Allow cap + a couple of in-flight 65536-byte chunks.
+    expect(out.text.length).toBeLessThan(cap + 2 * 65536);
+  }, 10_000);
+});

--- a/src/main/bounded-stdout.ts
+++ b/src/main/bounded-stdout.ts
@@ -1,0 +1,44 @@
+import type { ChildProcess } from 'child_process';
+
+/**
+ * Cap on accumulated child-process stdout, in UTF-16 code units. Search tools
+ * like mdfind/rg can emit hundreds of MB (e.g. mdfind across the whole home
+ * directory); buffering that into one string and splitting it on newlines
+ * OOMs the main-process V8 heap. 8M chars is far more than any caller's
+ * result limit needs.
+ */
+export const MAX_STDOUT_CHARS = 8 * 1024 * 1024;
+
+export type BoundedStdout = {
+  readonly text: string;
+  readonly truncated: boolean;
+};
+
+/**
+ * Accumulate a child process's stdout into a string, SIGTERM-ing the process
+ * once the accumulated length exceeds `maxChars`. Already-buffered output is
+ * kept and may end mid-line — line parsers must tolerate a partial last line.
+ */
+export function captureBoundedStdout(
+  proc: ChildProcess,
+  maxChars: number = MAX_STDOUT_CHARS
+): BoundedStdout {
+  let text = '';
+  let truncated = false;
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    if (truncated) return;
+    text += chunk.toString();
+    if (text.length > maxChars) {
+      truncated = true;
+      proc.kill('SIGTERM');
+    }
+  });
+  return {
+    get text() {
+      return text;
+    },
+    get truncated() {
+      return truncated;
+    }
+  };
+}

--- a/src/main/file-grep.ts
+++ b/src/main/file-grep.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from 'child_process';
 import { relative } from 'path';
 import type { FileGrepRequest, FileGrepResponse, FileGrepResult } from '../shared/ipc-api';
+import { captureBoundedStdout } from './bounded-stdout';
 
 let activeProcess: ChildProcess | null = null;
 
@@ -200,7 +201,6 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
   const { cmd, args } = buildRgCommand(query, cwd, limit);
 
   return new Promise((resolve) => {
-    let stdout = '';
     let timedOut = false;
 
     const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -211,9 +211,7 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
       proc.kill('SIGTERM');
     }, 10000);
 
-    proc.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
+    const out = captureBoundedStdout(proc);
 
     proc.on('error', (err) => {
       clearTimeout(timer);
@@ -225,20 +223,17 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
         const { cmd: fbCmd, args: fbArgs } = buildFallbackCommand(query, cwd, limit);
         const fbProc = spawn(fbCmd, fbArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
         activeProcess = fbProc;
-        let fbStdout = '';
 
         const fbTimer = setTimeout(() => {
           fbProc.kill('SIGTERM');
         }, 10000);
 
-        fbProc.stdout.on('data', (chunk: Buffer) => {
-          fbStdout += chunk.toString();
-        });
+        const fbOut = captureBoundedStdout(fbProc);
 
         fbProc.on('close', () => {
           clearTimeout(fbTimer);
           activeProcess = null;
-          const results = parseFallbackOutput(fbStdout, cwd, limit);
+          const results = parseFallbackOutput(fbOut.text, cwd, limit);
           resolve({ success: true, requestId, results });
         });
 
@@ -257,12 +252,12 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
       clearTimeout(timer);
       activeProcess = null;
 
-      if (timedOut && !stdout.trim()) {
+      if (timedOut && !out.text.trim()) {
         resolve({ success: false, requestId, error: 'Grep timed out' });
         return;
       }
 
-      const results = parseRgOutput(stdout, cwd, limit);
+      const results = parseRgOutput(out.text, cwd, limit);
       resolve({ success: true, requestId, results });
     });
   });

--- a/src/main/file-search.ts
+++ b/src/main/file-search.ts
@@ -3,6 +3,7 @@ import { stat, realpath } from 'fs/promises';
 import { basename, dirname } from 'path';
 import { homedir } from 'os';
 import type { FileSearchRequest, FileSearchResponse, FileSearchResult } from '../shared/ipc-api';
+import { captureBoundedStdout } from './bounded-stdout';
 
 let activeProcess: ChildProcess | null = null;
 
@@ -75,7 +76,6 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
     const isNonIndexed = cmd === 'powershell' || cmd === 'find';
     const timeout = isNonIndexed ? 5000 : 15000;
 
-    let stdout = '';
     let timedOut = false;
 
     const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -86,9 +86,7 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
       proc.kill('SIGTERM');
     }, timeout);
 
-    proc.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
+    const out = captureBoundedStdout(proc);
 
     proc.on('error', (err) => {
       clearTimeout(timer);
@@ -111,20 +109,17 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
           stdio: ['ignore', 'pipe', 'pipe']
         });
         activeProcess = findProc;
-        let findStdout = '';
 
         const findTimer = setTimeout(() => {
           findProc.kill('SIGTERM');
         }, 5000);
 
-        findProc.stdout.on('data', (chunk: Buffer) => {
-          findStdout += chunk.toString();
-        });
+        const findOut = captureBoundedStdout(findProc);
 
         findProc.on('close', () => {
           clearTimeout(findTimer);
           activeProcess = null;
-          void processResults(findStdout, limit, requestId).then(resolve);
+          void processResults(findOut.text, limit, requestId).then(resolve);
         });
 
         findProc.on('error', () => {
@@ -142,12 +137,12 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
       clearTimeout(timer);
       activeProcess = null;
 
-      if (timedOut && !stdout.trim()) {
+      if (timedOut && !out.text.trim()) {
         resolve({ success: false, requestId, error: 'Search timed out' });
         return;
       }
 
-      void processResults(stdout, limit, requestId).then(resolve);
+      void processResults(out.text, limit, requestId).then(resolve);
     });
   });
 }

--- a/src/main/recent-images.ts
+++ b/src/main/recent-images.ts
@@ -4,11 +4,13 @@ import { basename, dirname, extname, join } from 'path';
 import { homedir } from 'os';
 import { nativeImage } from 'electron';
 import type { RecentImageResult, RecentImagesResponse } from '../shared/ipc-api';
+import { captureBoundedStdout } from './bounded-stdout';
 
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB — skip large files for thumbnail safety
 const RESULT_LIMIT = 5;
 const STAT_LIMIT = 200; // stat at most this many candidates before sorting
+const SCAN_RESULT_LIMIT = 1000; // recursive readdir over Pictures/Downloads can return enormous trees
 
 type FileCandidate = {
   path: string;
@@ -50,18 +52,15 @@ async function spawnMdfind(home: string): Promise<string[]> {
   return new Promise((resolve) => {
     const proc = spawn('mdfind', ['-onlyin', home, 'kMDItemContentTypeTree == "public.image"']);
 
-    let stdout = '';
     const timer = setTimeout(() => {
       proc.kill('SIGTERM');
     }, 3000);
 
-    proc.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
+    const out = captureBoundedStdout(proc);
 
     proc.on('close', () => {
       clearTimeout(timer);
-      resolve(stdout.split('\n').filter(Boolean));
+      resolve(out.text.split('\n').filter(Boolean));
     });
 
     proc.on('error', () => {
@@ -104,6 +103,7 @@ async function scanKnownDirs(): Promise<string[]> {
     try {
       const entries = await readdir(dir, { withFileTypes: true, recursive: true });
       for (const entry of entries) {
+        if (results.length >= SCAN_RESULT_LIMIT) return results;
         if (entry.isFile() && IMAGE_EXTS.has(extname(entry.name).toLowerCase())) {
           const fullPath = entry.parentPath
             ? join(entry.parentPath, entry.name)


### PR DESCRIPTION
## Summary
- Fixes a main-process crash (V8 heap OOM, presented as a 120s "hang" in macOS stackshot reports) caused by `file-search.ts`, `file-grep.ts`, and `recent-images.ts` buffering unbounded `mdfind`/`rg`/`grep` stdout into one string and splitting it on newlines — on big Spotlight indexes this reaches hundreds of MB and the split's cons-string flatten exhausts the heap
- Adds `captureBoundedStdout()` (`src/main/bounded-stdout.ts`): accumulates child stdout and SIGTERMs the process once 8M chars are buffered, keeping the truncated prefix; applied to all five spawn sites (incl. fallbacks)
- Caps `recent-images` recursive readdir collection at 1000 paths; adds a learnings doc covering the root cause and how to re-symbolicate stripped Electron stackshots with breakpad symbols

## Test plan
- [x] `npm run typecheck` passes
- [x] `npx eslint` clean on all touched files
- [x] Full `vitest run`: 977 passed, 0 failed (includes 3 new tests for truncation/kill behavior in `src/main/__tests__/bounded-stdout.test.ts`)
- [ ] Manual: open the file-search overlay and type short queries in a large home directory; memory stays bounded and results still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)