### PR TITLE
feat(kanban): PM chat panel for conversational ticket management

### DIFF
--- a/docs/learnings/2026-05-30-better-sqlite3-electron-vs-node-abi.md
+++ b/docs/learnings/2026-05-30-better-sqlite3-electron-vs-node-abi.md
@@ -39,3 +39,4 @@ npx electron-rebuild -f -w better-sqlite3
 
    So `npm test` and `npm run dev` each rebuild for their own ABI on the way in — no manual `electron-rebuild` step, no clobbering.
 4. **Bootstrap ordering is a latent footgun.** Registering IPC handlers as the last line after several `await`/throwable calls means any earlier failure silently strips the whole feature's IPC. Consider registering handlers early / wrapping risky bootstrap steps so one failure doesn't take down unrelated wiring.
+5. **(2026-06-09) The self-healing hooks have two bypasses.** `npx vitest run` skips the `pretest` hook (only `npm test` triggers it), and `electron-builder install-app-deps` can report "finished" while leaving a stale Node-ABI binary in place (its staleness check trusts a marker, not the actual ABI). When `npm run dev` still hits `NODE_MODULE_VERSION` after a rebuild "succeeded", force it: `./node_modules/.bin/electron-rebuild --force --module-dir . --which-module better-sqlite3`.

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -4,6 +4,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { KanbanStore } from '../kanban/kanban-store';
 import { KanbanMcpServer } from '../kanban/kanban-mcp-server';
+import { KanbanDispatcher } from '../kanban/kanban-dispatcher';
+import { KanbanCommands } from '../kanban/kanban-commands';
 import { createSwarm } from '../kanban/kanban-swarm';
 
 const TEST_DIR = join(tmpdir(), `fleet-kanban-mcp-test-${Date.now()}`);
@@ -65,7 +67,7 @@ describe('KanbanMcpServer', () => {
     const t = store.createTask({ title: 'x', status: 'ready', assignee: 'r' });
     store.claimTask(t.id, 'LOCK', 100000);
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tok1', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok1', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
 
     const r = await rpc(`${base}?run=tok1`, 'tools/call', {
       name: 'kanban_complete',
@@ -82,7 +84,7 @@ describe('KanbanMcpServer', () => {
     const t = store.createTask({ title: 'x', status: 'ready', assignee: 'r' });
     store.claimTask(t.id, 'LOCK', 100000);
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tok2', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok2', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     await rpc(`${base}?run=tok2`, 'tools/call', {
       name: 'kanban_block',
       arguments: { reason: 'review-required: see comment' }
@@ -93,7 +95,7 @@ describe('KanbanMcpServer', () => {
   it('kanban_comment appends a comment authored by the assignee', async () => {
     const t = store.createTask({ title: 'x', status: 'ready', assignee: 'researcher' });
     const run = store.startRun(t.id, 'researcher', 1);
-    server.registerRun('tok3', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok3', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     await rpc(`${base}?run=tok3`, 'tools/call', {
       name: 'kanban_comment',
       arguments: { body: 'progress note' }
@@ -108,7 +110,7 @@ describe('KanbanMcpServer', () => {
     store.claimTask(t.id, 'LOCK', 1000);
     const before = store.getTask(t.id)?.claimExpires ?? 0;
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tok4', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok4', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     await rpc(`${base}?run=tok4`, 'tools/call', { name: 'kanban_heartbeat', arguments: {} });
     const after = store.getTask(t.id)?.claimExpires ?? 0;
     expect(after).toBeGreaterThanOrEqual(before);
@@ -122,7 +124,7 @@ describe('KanbanMcpServer', () => {
       assignee: 'r'
     });
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tok5', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok5', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     const r = await rpc(`${base}?run=tok5`, 'tools/call', { name: 'kanban_show', arguments: {} });
     expect(r.result.content[0].text).toMatch(/My task/);
     expect(r.result.content[0].text).toMatch(/do the thing/);
@@ -131,7 +133,7 @@ describe('KanbanMcpServer', () => {
   it('writes a task_event for each tool call', async () => {
     const t = store.createTask({ title: 'x', status: 'ready', assignee: 'r' });
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tok6', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tok6', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     await rpc(`${base}?run=tok6`, 'tools/call', {
       name: 'kanban_comment',
       arguments: { body: 'x' }
@@ -144,7 +146,7 @@ describe('KanbanMcpServer', () => {
     const t = store.createTask({ title: 'x', status: 'ready', assignee: 'r' });
     store.claimTask(t.id, 'LOCK', 100000);
     const run = store.startRun(t.id, 'r', 1);
-    server.registerRun('tokX', { taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tokX', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'LOCK');
     await rpc(`${base}?run=tokX`, 'tools/call', {
       name: 'kanban_complete',
       arguments: { summary: 's' }
@@ -158,7 +160,7 @@ describe('KanbanMcpServer', () => {
   it('tools/list returns decompose tools for a decompose-mode token', async () => {
     const t = store.createTask({ title: 'big', status: 'running' });
     const run = store.startRun(t.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('dtok', { taskId: t.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('dtok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=dtok`, 'tools/list');
     const names = r.result.tools.map((x: { name: string }) => x.name);
     expect(names).toContain('kanban_create');
@@ -170,7 +172,7 @@ describe('KanbanMcpServer', () => {
   it('a worker-mode token cannot call kanban_create', async () => {
     const t = store.createTask({ title: 'x', status: 'running', assignee: 'r' });
     const run = store.startRun(t.id, 'r', 1, 'work');
-    server.registerRun('wtok', { taskId: t.id, runId: run.id, mode: 'work' }, 'L');
+    server.registerRun('wtok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'work' }, 'L');
     const r = await rpc(`${base}?run=wtok`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child' }
@@ -181,7 +183,7 @@ describe('KanbanMcpServer', () => {
   it('kanban_create makes a todo child linked to the orchestrator task', async () => {
     const parent = store.createTask({ title: 'big', status: 'running' });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('dtok2', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('dtok2', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=dtok2`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child task', assignee: 'default' }
@@ -198,7 +200,7 @@ describe('KanbanMcpServer', () => {
     store.createBoard('Research');
     const parent = store.createTask({ title: 'p', status: 'running', boardId: 'research' });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('btok', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('btok', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=btok`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child' }
@@ -216,7 +218,7 @@ describe('KanbanMcpServer', () => {
       repoPath: '/src/myrepo'
     });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('itok', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('itok', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=itok`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child' }
@@ -230,7 +232,7 @@ describe('KanbanMcpServer', () => {
   it('kanban_create leaves children as scratch when the parent is not a worktree', async () => {
     const parent = store.createTask({ title: 'big', status: 'running' });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('itok2', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('itok2', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=itok2`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child' }
@@ -249,7 +251,7 @@ describe('KanbanMcpServer', () => {
       // repoPath intentionally omitted
     });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('itok3', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('itok3', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=itok3`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child' }
@@ -264,7 +266,7 @@ describe('KanbanMcpServer', () => {
     const parent = store.createTask({ title: 'big', status: 'running' });
     const dep = store.createTask({ title: 'dep', status: 'todo' });
     const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-    server.registerRun('dtok3', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+    server.registerRun('dtok3', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
     const r = await rpc(`${base}?run=dtok3`, 'tools/call', {
       name: 'kanban_create',
       arguments: { title: 'child', parents: [dep.id] }
@@ -276,7 +278,7 @@ describe('KanbanMcpServer', () => {
   it('kanban_update (specify) rewrites the body and returns the task to todo', async () => {
     const t = store.createTask({ title: 'vague', body: 'old', status: 'running' });
     const run = store.startRun(t.id, 'orchestrator', 1, 'specify');
-    server.registerRun('stok', { taskId: t.id, runId: run.id, mode: 'specify' }, 'L');
+    server.registerRun('stok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'specify' }, 'L');
     const r = await rpc(`${base}?run=stok`, 'tools/call', {
       name: 'kanban_update',
       arguments: { title: 'clear title', body: 'a much fuller spec' }
@@ -300,7 +302,7 @@ describe('KanbanMcpServer', () => {
     store.setStatus(workerId, 'ready');
     store.claimTask(workerId, 'LOCK', 100000);
     const run = store.startRun(workerId, 'w', 1);
-    server.registerRun('toksw', { taskId: workerId, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('toksw', { kind: 'task', taskId: workerId, runId: run.id, mode: 'work' }, 'LOCK');
 
     const post = await rpc(`${base}?run=toksw`, 'tools/call', {
       name: 'kanban_swarm_post',
@@ -328,7 +330,7 @@ describe('KanbanMcpServer', () => {
     store.setStatus(workerId, 'ready');
     store.claimTask(workerId, 'LOCK', 100000);
     const run = store.startRun(workerId, 'w', 1);
-    server.registerRun('tokres', { taskId: workerId, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tokres', { kind: 'task', taskId: workerId, runId: run.id, mode: 'work' }, 'LOCK');
     const r = await rpc(`${base}?run=tokres`, 'tools/call', {
       name: 'kanban_swarm_post',
       arguments: { root: created.rootId, key: '_authors', value: 'x' }
@@ -351,7 +353,7 @@ describe('KanbanMcpServer', () => {
     });
     store.claimTask(orch.id, 'LOCK', 100000);
     const run = store.startRun(orch.id, 'orchestrator', 1);
-    server.registerRun('tokorch', { taskId: orch.id, runId: run.id, mode: 'decompose' }, 'LOCK');
+    server.registerRun('tokorch', { kind: 'task', taskId: orch.id, runId: run.id, mode: 'decompose' }, 'LOCK');
 
     const r = await rpc(`${base}?run=tokorch`, 'tools/call', {
       name: 'kanban_swarm',
@@ -379,7 +381,7 @@ describe('KanbanMcpServer', () => {
       const url = `http://127.0.0.1:${port}/mcp`;
       const parent = store.createTask({ title: 'big', status: 'running' });
       const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-      profiled.registerRun('ptok', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+      profiled.registerRun('ptok', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
       const r = await rpc(`${url}?run=ptok`, 'tools/call', {
         name: 'kanban_create',
         arguments: { title: 'child', assignee: 'backend-dev' }
@@ -403,7 +405,7 @@ describe('KanbanMcpServer', () => {
       const url = `http://127.0.0.1:${port}/mcp`;
       const parent = store.createTask({ title: 'big', status: 'running' });
       const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-      profiled.registerRun('ptok2', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+      profiled.registerRun('ptok2', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
       const r = await rpc(`${url}?run=ptok2`, 'tools/call', {
         name: 'kanban_create',
         arguments: { title: 'child', assignee: 'orchestrator' }
@@ -422,7 +424,7 @@ describe('KanbanMcpServer', () => {
       const url = `http://127.0.0.1:${port}/mcp`;
       const parent = store.createTask({ title: 'big', status: 'running' });
       const run = store.startRun(parent.id, 'orchestrator', 1, 'decompose');
-      profiled.registerRun('ptok3', { taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
+      profiled.registerRun('ptok3', { kind: 'task', taskId: parent.id, runId: run.id, mode: 'decompose' }, 'L');
       const r = await rpc(`${url}?run=ptok3`, 'tools/call', {
         name: 'kanban_create',
         arguments: { title: 'child', assignee: 'researcher' }
@@ -438,7 +440,7 @@ describe('KanbanMcpServer', () => {
     const plain = store.createTask({ title: 'plain', status: 'ready', assignee: 'r' });
     store.claimTask(plain.id, 'LOCK', 100000);
     const run = store.startRun(plain.id, 'r', 1);
-    server.registerRun('tokplain', { taskId: plain.id, runId: run.id, mode: 'work' }, 'LOCK');
+    server.registerRun('tokplain', { kind: 'task', taskId: plain.id, runId: run.id, mode: 'work' }, 'LOCK');
 
     const r = await rpc(`${base}?run=tokplain`, 'tools/call', {
       name: 'kanban_swarm_read',
@@ -446,5 +448,158 @@ describe('KanbanMcpServer', () => {
     });
     expect(r.error).toBeTruthy();
     expect(String(r.error.message)).toMatch(/not a swarm root/i);
+  });
+});
+
+describe('KanbanMcpServer board scope (PM chat)', () => {
+  let store: KanbanStore;
+  let server: KanbanMcpServer;
+  let base: string;
+
+  beforeEach(async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    store = new KanbanStore(join(TEST_DIR, `pm-${Math.random().toString(36).slice(2)}.db`));
+    const dispatcher = new KanbanDispatcher(store, {
+      now: () => 0,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: {
+        failureLimit: 2,
+        claimGraceMs: 0,
+        maxInProgress: 3,
+        claimTtlMs: 1000,
+        autoDecompose: false,
+        maxDecompose: 1,
+        artifactRetentionDays: 0
+      }
+    });
+    const commands = new KanbanCommands(store, dispatcher, () => ({
+      workspaceKind: 'scratch',
+      maxRuntimeSeconds: null
+    }));
+    server = new KanbanMcpServer(store);
+    server.setCommands(commands);
+    server.registerRun('pmtok', { kind: 'board', boardId: 'default' });
+    const port = await server.start(0);
+    base = `http://127.0.0.1:${port}/mcp`;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    store.close();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('lists PM tools for a board token (no worker terminal tools)', async () => {
+    const r = await rpc(`${base}?run=pmtok`, 'tools/list');
+    const names = r.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain('kanban_create');
+    expect(names).toContain('kanban_set_status');
+    expect(names).toContain('kanban_feature_create');
+    expect(names).not.toContain('kanban_complete');
+    expect(names).not.toContain('kanban_block');
+    expect(names).not.toContain('kanban_swarm');
+  });
+
+  it('kanban_create makes a scratch todo task on the scoped board', async () => {
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'PM made this', body: 'spec', priority: 2 }
+    });
+    const id = String(r.result.content[0].text).trim();
+    const task = store.getTask(id);
+    expect(task?.title).toBe('PM made this');
+    expect(task?.status).toBe('todo');
+    expect(task?.priority).toBe(2);
+    expect(task?.boardId).toBe('default');
+    expect(task?.workspaceKind).toBe('scratch');
+  });
+
+  it('kanban_create links listed parents', async () => {
+    const parent = store.createTask({ title: 'parent', status: 'todo' });
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'child', parents: [parent.id] }
+    });
+    const id = String(r.result.content[0].text).trim();
+    expect(store.parentsOf(id)).toContain(parent.id);
+  });
+
+  it('kanban_set_status moves a task but refuses running tasks', async () => {
+    const t = store.createTask({ title: 'm', status: 'todo' });
+    const ok = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_set_status',
+      arguments: { task_id: t.id, status: 'ready' }
+    });
+    expect(ok.error).toBeFalsy();
+    expect(store.getTask(t.id)?.status).toBe('ready');
+
+    const running = store.createTask({ title: 'r', status: 'running' });
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_set_status',
+      arguments: { task_id: running.id, status: 'todo' }
+    });
+    expect(r.error).toBeTruthy();
+    expect(String(r.error.message)).toMatch(/running/i);
+  });
+
+  it('kanban_update edits title and priority of any board task', async () => {
+    const t = store.createTask({ title: 'old', status: 'todo' });
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_update',
+      arguments: { task_id: t.id, title: 'new', priority: 5 }
+    });
+    expect(r.error).toBeFalsy();
+    const after = store.getTask(t.id);
+    expect(after?.title).toBe('new');
+    expect(after?.priority).toBe(5);
+  });
+
+  it('rejects tasks on a different board', async () => {
+    const other = store.createBoard('Other Board');
+    const t = store.createTask({ title: 'elsewhere', status: 'todo', boardId: other.slug });
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_set_status',
+      arguments: { task_id: t.id, status: 'ready' }
+    });
+    expect(r.error).toBeTruthy();
+    expect(String(r.error.message)).toMatch(/not found on this board/i);
+  });
+
+  it('kanban_feature_create + kanban_create with feature_id inherit the feature repo', async () => {
+    const f = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_feature_create',
+      arguments: { name: 'Login flow', repo_path: '/tmp/some-repo', base_branch: 'main' }
+    });
+    const featureId = String(f.result.content[0].text).trim();
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'Add login form', feature_id: featureId }
+    });
+    const id = String(r.result.content[0].text).trim();
+    const task = store.getTask(id);
+    expect(task?.featureId).toBe(featureId);
+    expect(task?.workspaceKind).toBe('worktree');
+    expect(task?.repoPath).toBe('/tmp/some-repo');
+  });
+
+  it('worker tools are rejected on a board token', async () => {
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_complete',
+      arguments: { summary: 'nope' }
+    });
+    expect(r.error).toBeTruthy();
+    expect(String(r.error.message)).toMatch(/unknown tool/i);
+  });
+
+  it('kanban_update refuses running tasks', async () => {
+    const t = store.createTask({ title: 'busy', status: 'running' });
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_update',
+      arguments: { task_id: t.id, title: 'hijacked' }
+    });
+    expect(r.error).toBeTruthy();
+    expect(String(r.error.message)).toMatch(/running/i);
+    expect(store.getTask(t.id)?.title).toBe('busy');
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -51,6 +51,7 @@ import { KanbanDispatcher } from './kanban/kanban-dispatcher';
 import type { DispatcherConfig, WorkerExit } from './kanban/kanban-dispatcher';
 import { setKanbanSettingsApplier } from './kanban/kanban-settings-bridge';
 import { KanbanMcpServer } from './kanban/kanban-mcp-server';
+import { PmChatService } from './kanban/pm-chat-service';
 import { prepareWorkspace, ensureFeatureBranch } from './kanban/workspace';
 import { PrPoller } from './kanban/pr-poller';
 import {
@@ -83,6 +84,7 @@ let kanbanDispatcher: KanbanDispatcher | undefined;
 let kanbanPrPoller: PrPoller | undefined;
 let kanbanCommands: KanbanCommands | undefined;
 let kanbanNotifier: KanbanNotifier | null = null;
+let pmChat: PmChatService | undefined;
 const ptyManager = new PtyManager();
 const layoutStore = new LayoutStore();
 const eventBus = new EventBus();
@@ -927,7 +929,7 @@ void app.whenReady().then(async () => {
         throw new Error(RUNE_NOT_INSTALLED_MESSAGE);
       }
       const runToken = randomUUID();
-      kanbanMcpRef.registerRun(runToken, { taskId: task.id, runId, mode }, lock);
+      kanbanMcpRef.registerRun(runToken, { kind: 'task', taskId: task.id, runId, mode }, lock);
       const profiles = settingsStore.get().kanban.profiles;
       let profile: WorkerProfile | null;
       let roster: Array<{ name: string; description: string }> | undefined;
@@ -1039,7 +1041,23 @@ void app.whenReady().then(async () => {
     () => settingsStore.get().kanban.profiles
   );
   kanbanMcp.setSwarmHandler((input) => kanbanCommands!.createSwarm(input));
-  registerKanbanIpc(kanbanCommands);
+  kanbanMcp.setCommands(kanbanCommands);
+  pmChat = new PmChatService({
+    mcp: kanbanMcp,
+    mcpPort: kanbanMcpPort,
+    kanbanHome: KANBAN_HOME,
+    emitStatus: (payload) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(IPC_CHANNELS.KANBAN_PM_STATUS, payload);
+      }
+    },
+    emitTranscript: (payload) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(IPC_CHANNELS.KANBAN_PM_TRANSCRIPT, payload);
+      }
+    }
+  });
+  registerKanbanIpc(kanbanCommands, pmChat);
 
   sessionsService = new SessionsService();
   registerSessionsIpcHandlers(sessionsService);
@@ -1077,6 +1095,7 @@ function shutdownAll(): void {
   annotateService.destroy();
   kanbanDispatcher?.stop();
   kanbanPrPoller?.stop();
+  pmChat?.dispose();
   void kanbanMcp?.stop();
   kanbanStore?.close();
 }

--- a/src/main/kanban/kanban-ipc.ts
+++ b/src/main/kanban/kanban-ipc.ts
@@ -4,6 +4,7 @@ import { IPC_CHANNELS } from '../../shared/ipc-channels';
 import { createLogger } from '../logger';
 import { readArtifactPreview } from './artifact-files';
 import type { KanbanCommands } from './kanban-commands';
+import type { PmChatService } from './pm-chat-service';
 import type {
   CreateTaskInput,
   TaskDetail,
@@ -34,12 +35,13 @@ import type {
   KanbanArtifactPreviewResponse,
   KanbanReuseArtifactRequest,
   KanbanCreateTaskFromArtifactRequest,
-  KanbanCreateSwarmFromArtifactRequest
+  KanbanCreateSwarmFromArtifactRequest,
+  PmChatSendRequest
 } from '../../shared/ipc-api';
 
 const log = createLogger('kanban-ipc');
 
-export function registerKanbanIpc(commands: KanbanCommands): void {
+export function registerKanbanIpc(commands: KanbanCommands, pmChat: PmChatService): void {
   ipcMain.handle(IPC_CHANNELS.KANBAN_LIST_BOARD, (_e, boardSlug?: string) =>
     commands.list({ boardSlug })
   );
@@ -319,6 +321,18 @@ export function registerKanbanIpc(commands: KanbanCommands): void {
   ipcMain.handle(IPC_CHANNELS.KANBAN_PRUNE_MERGED_WORKTREES, (_e, boardId: string) =>
     commands.pruneMergedWorktrees(boardId)
   );
+
+  ipcMain.handle(IPC_CHANNELS.KANBAN_PM_SEND, (_e, req: PmChatSendRequest) => {
+    pmChat.sendMessage(req.boardId, req.text);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.KANBAN_PM_STATE, async (_e, boardId: string) =>
+    pmChat.getState(boardId)
+  );
+
+  ipcMain.handle(IPC_CHANNELS.KANBAN_PM_RESET, (_e, boardId: string) => {
+    pmChat.reset(boardId);
+  });
 
   log.info('kanban IPC handlers registered');
 }

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -3,18 +3,35 @@ import { URL } from 'url';
 import { z } from 'zod';
 import { createLogger } from '../logger';
 import type { KanbanStore } from './kanban-store';
-import type { RunMode, SwarmInput, SwarmCreated, Task } from '../../shared/kanban-types';
+import type { KanbanCommands } from './kanban-commands';
+import type {
+  CreateTaskInput,
+  RunMode,
+  SwarmInput,
+  SwarmCreated,
+  Task
+} from '../../shared/kanban-types';
 import type { WorkerProfile } from '../../shared/types';
 import { latestBlackboard, postBlackboardUpdate, isSwarmRoot } from './kanban-swarm';
 import { finalizeWorktree, reviewStat, checkMergeConflicts } from './workspace';
 
 const log = createLogger('kanban-mcp');
 
-interface RunScope {
+/** A worker/orchestrator run bound to one task. */
+interface TaskScope {
+  kind: 'task';
   taskId: string;
   runId: number;
   mode: RunMode;
 }
+
+/** A PM chat turn scoped to a whole board — no task, no run, no claim. */
+interface BoardScope {
+  kind: 'board';
+  boardId: string;
+}
+
+export type RunScope = TaskScope | BoardScope;
 
 interface JsonRpcRequest {
   jsonrpc: string;
@@ -208,6 +225,136 @@ const SPECIFY_TOOLS: McpTool[] = [
   ...WORKER_TOOLS.filter((t) => t.name === 'kanban_comment' || t.name === 'kanban_heartbeat')
 ];
 
+/** Statuses the PM may set — mirrors MANUAL_STATUSES (dispatcher owns `running`). */
+const PM_SETTABLE_STATUSES = [
+  'triage',
+  'todo',
+  'ready',
+  'blocked',
+  'review',
+  'done',
+  'archived'
+] as const;
+
+/**
+ * Board-scoped tools for the PM chat. Unlike worker tools there is no implicit
+ * "current task" — every task-touching tool takes an explicit task_id. Mutations
+ * route through KanbanCommands so the PM obeys the same validation as the UI
+ * (running tasks are dispatcher-owned, review is worktree-only, etc.).
+ */
+const PM_TOOLS: McpTool[] = [
+  {
+    name: 'kanban_list',
+    description: 'List the board tasks. Optional filters by status and assignee.',
+    inputSchema: {
+      type: 'object',
+      properties: { status: { type: 'string' }, assignee: { type: 'string' } }
+    }
+  },
+  {
+    name: 'kanban_show',
+    description: 'Show one task by id: title, body, status, comments, prior run summaries.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: { type: 'string' } },
+      required: ['task_id']
+    }
+  },
+  {
+    name: 'kanban_create',
+    description:
+      'Create a task on the board. Status defaults to todo (use triage for ideas needing ' +
+      'refinement). Pass feature_id to group it under a feature, parents for dependencies.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        body: { type: 'string' },
+        assignee: { type: 'string' },
+        priority: { type: 'number' },
+        status: { type: 'string', enum: ['triage', 'todo', 'ready', 'blocked'] },
+        parents: { type: 'array', items: { type: 'string' } },
+        feature_id: { type: 'string' }
+      },
+      required: ['title']
+    }
+  },
+  {
+    name: 'kanban_update',
+    description: 'Update a task by id: title, body, priority, and/or assignee.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        title: { type: 'string' },
+        body: { type: 'string' },
+        priority: { type: 'number' },
+        assignee: { type: 'string' }
+      },
+      required: ['task_id']
+    }
+  },
+  {
+    name: 'kanban_set_status',
+    description:
+      'Move a task to a new status (triage/todo/ready/blocked/review/done/archived). ' +
+      'Running tasks are dispatcher-owned and cannot be moved.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        status: { type: 'string', enum: [...PM_SETTABLE_STATUSES] }
+      },
+      required: ['task_id', 'status']
+    }
+  },
+  {
+    name: 'kanban_comment',
+    description: 'Append a durable comment to a task thread.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: { type: 'string' }, body: { type: 'string' } },
+      required: ['task_id', 'body']
+    }
+  },
+  {
+    name: 'kanban_link',
+    description: 'Add a dependency link: child waits for parent to be done.',
+    inputSchema: {
+      type: 'object',
+      properties: { parent_id: { type: 'string' }, child_id: { type: 'string' } },
+      required: ['parent_id', 'child_id']
+    }
+  },
+  {
+    name: 'kanban_feature_create',
+    description:
+      'Create a feature (task grouping) on this board. Returns its id; pass it to ' +
+      'kanban_create as feature_id to group tasks.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        repo_path: { type: 'string' },
+        base_branch: { type: 'string' }
+      },
+      required: ['name']
+    }
+  },
+  {
+    name: 'kanban_assign_feature',
+    description: 'Set or clear (pass null) a task feature membership.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        feature_id: { type: ['string', 'null'] }
+      },
+      required: ['task_id', 'feature_id']
+    }
+  }
+];
+
 function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'decompose') return DECOMPOSE_TOOLS;
   if (mode === 'specify') return SPECIFY_TOOLS;
@@ -221,6 +368,7 @@ export class KanbanMcpServer {
 
   private store: KanbanStore;
   private swarmHandler: ((input: SwarmInput) => SwarmCreated) | null = null;
+  private commands: KanbanCommands | null = null;
   private getProfiles: () => Array<Pick<WorkerProfile, 'name' | 'role'>>;
   constructor(
     store: KanbanStore,
@@ -235,10 +383,15 @@ export class KanbanMcpServer {
     this.swarmHandler = handler;
   }
 
+  /** Inject the command layer; PM (board-scoped) tools route through it for validation. */
+  setCommands(commands: KanbanCommands): void {
+    this.commands = commands;
+  }
+
   /** Register a per-run token; returns the token to embed in the worker's MCP url. */
-  registerRun(token: string, scope: RunScope, claimLock: string): void {
+  registerRun(token: string, scope: RunScope, claimLock?: string): void {
     this.runs.set(token, scope);
-    this.claimLocks.set(token, claimLock);
+    if (claimLock) this.claimLocks.set(token, claimLock);
   }
 
   unregisterRun(token: string): void {
@@ -317,6 +470,7 @@ export class KanbanMcpServer {
         return;
       case 'tools/list': {
         const scope = this.runs.get(token);
+        if (scope?.kind === 'board') return this.rpcResult(res, rpcReq.id, { tools: PM_TOOLS });
         return this.rpcResult(res, rpcReq.id, { tools: toolsForMode(scope?.mode ?? 'work') });
       }
       case 'tools/call':
@@ -359,6 +513,213 @@ export class KanbanMcpServer {
     return { ...feature };
   }
 
+  /** A task resolved by id, only if it lives on the PM scope's board. */
+  private pmTask(scope: BoardScope, id: string): Task | null {
+    const t = this.store.getTask(id);
+    return t && t.boardId === scope.boardId ? t : null;
+  }
+
+  /** Board-scoped (PM chat) tool dispatch. Mutations route through KanbanCommands. */
+  private handlePmToolCall(
+    res: ServerResponse,
+    rpcReq: JsonRpcRequest,
+    scope: BoardScope,
+    name: string,
+    args: Record<string, unknown>
+  ): void {
+    const commands = this.commands;
+    if (!commands) return this.rpcError(res, rpcReq.id, 'kanban commands are not available');
+    if (!PM_TOOLS.some((t) => t.name === name)) {
+      return this.rpcError(res, rpcReq.id, `unknown tool: ${name}`);
+    }
+    try {
+      switch (name) {
+        case 'kanban_list': {
+          const a = z
+            .object({ status: z.string().optional(), assignee: z.string().optional() })
+            .parse(args);
+          let rows = this.store.listBoard(scope.boardId);
+          if (a.status) rows = rows.filter((c) => c.status === a.status);
+          if (a.assignee) rows = rows.filter((c) => c.assignee === a.assignee);
+          const lines = rows.map(
+            (c) => `${c.id}\t${c.status}\tp${c.priority}\t${c.assignee ?? '-'}\t${c.title}`
+          );
+          return this.text(res, rpcReq.id, lines.join('\n') || '(no tasks)');
+        }
+        case 'kanban_show': {
+          const a = z.object({ task_id: z.string() }).parse(args);
+          const detail = commands.show(a.task_id);
+          if (!detail || detail.task.boardId !== scope.boardId) {
+            return this.rpcError(res, rpcReq.id, `task not found on this board: ${a.task_id}`);
+          }
+          const { task, comments, runs } = detail;
+          const summaries = runs.filter((r) => r.summary);
+          const lines = [
+            `# ${task.title} (${task.id})`,
+            `status: ${task.status}  priority: ${task.priority}  assignee: ${task.assignee ?? '-'}`,
+            task.featureId ? `feature: ${task.featureId}` : '',
+            '',
+            task.body || '(no body)',
+            comments.length ? '## Comments' : '',
+            ...comments.map((c) => `- ${c.author}: ${c.body}`),
+            summaries.length ? '## Prior runs' : '',
+            ...summaries.map((r) => `- ${r.outcome}: ${r.summary ?? ''}`)
+          ].filter(Boolean);
+          return this.text(res, rpcReq.id, lines.join('\n'));
+        }
+        case 'kanban_create': {
+          const a = z
+            .object({
+              title: z.string(),
+              body: z.string().optional(),
+              assignee: z.string().optional(),
+              priority: z.number().optional(),
+              status: z.enum(['triage', 'todo', 'ready', 'blocked']).optional(),
+              parents: z.array(z.string()).optional(),
+              feature_id: z.string().optional()
+            })
+            .parse(args);
+          // Same phantom-assignee guard as the orchestrator's kanban_create.
+          const assignee = a.assignee?.trim() || null;
+          const workerNames = this.getProfiles()
+            .filter((p) => p.role === 'worker')
+            .map((p) => p.name);
+          if (assignee && workerNames.length > 0 && !workerNames.includes(assignee)) {
+            return this.rpcError(
+              res,
+              rpcReq.id,
+              `unknown worker profile "${assignee}". Valid profiles: ${workerNames.join(', ')}`
+            );
+          }
+          // A feature carries the repo its member tasks work in; inherit it so the
+          // PM never needs folder config. Featureless PM tasks start as scratch.
+          let workspace: Partial<
+            Pick<CreateTaskInput, 'workspaceKind' | 'repoPath' | 'baseBranch'>
+          > = { workspaceKind: 'scratch' };
+          if (a.feature_id) {
+            const feature = this.store.getFeature(a.feature_id);
+            if (!feature || feature.boardId !== scope.boardId) {
+              return this.rpcError(
+                res,
+                rpcReq.id,
+                `feature not found on this board: ${a.feature_id}`
+              );
+            }
+            if (feature.repoPath) {
+              workspace = {
+                workspaceKind: 'worktree',
+                repoPath: feature.repoPath,
+                baseBranch: feature.baseBranch
+              };
+            }
+          }
+          for (const p of a.parents ?? []) {
+            if (!this.pmTask(scope, p)) {
+              return this.rpcError(res, rpcReq.id, `parent task not found on this board: ${p}`);
+            }
+          }
+          const task = commands.create({
+            title: a.title,
+            body: a.body ?? '',
+            assignee,
+            priority: a.priority ?? 0,
+            status: a.status ?? 'todo',
+            boardId: scope.boardId,
+            featureId: a.feature_id ?? null,
+            ...workspace
+          });
+          for (const p of a.parents ?? []) commands.link(p, task.id);
+          return this.text(res, rpcReq.id, task.id);
+        }
+        case 'kanban_update': {
+          const a = z
+            .object({
+              task_id: z.string(),
+              title: z.string().optional(),
+              body: z.string().optional(),
+              priority: z.number().optional(),
+              assignee: z.string().optional()
+            })
+            .parse(args);
+          const existing = this.pmTask(scope, a.task_id);
+          if (!existing) {
+            return this.rpcError(res, rpcReq.id, `task not found on this board: ${a.task_id}`);
+          }
+          // A running worker reads its task via kanban_show mid-turn; editing it
+          // out from under the worker is dispatcher territory, same as status.
+          if (existing.status === 'running') {
+            return this.rpcError(res, rpcReq.id, 'cannot update a running task');
+          }
+          commands.update(a.task_id, {
+            title: a.title,
+            body: a.body,
+            priority: a.priority,
+            ...(a.assignee !== undefined ? { assignee: a.assignee.trim() || null } : {})
+          });
+          return this.text(res, rpcReq.id, 'Task updated.');
+        }
+        case 'kanban_set_status': {
+          const a = z
+            .object({ task_id: z.string(), status: z.enum(PM_SETTABLE_STATUSES) })
+            .parse(args);
+          if (!this.pmTask(scope, a.task_id)) {
+            return this.rpcError(res, rpcReq.id, `task not found on this board: ${a.task_id}`);
+          }
+          commands.setManualStatus(a.task_id, a.status);
+          return this.text(res, rpcReq.id, `Task ${a.task_id} moved to ${a.status}.`);
+        }
+        case 'kanban_comment': {
+          const a = z.object({ task_id: z.string(), body: z.string() }).parse(args);
+          if (!this.pmTask(scope, a.task_id)) {
+            return this.rpcError(res, rpcReq.id, `task not found on this board: ${a.task_id}`);
+          }
+          this.store.addComment(a.task_id, 'pm', a.body);
+          this.store.appendEvent(a.task_id, null, 'comment_added', { author: 'pm' });
+          return this.text(res, rpcReq.id, 'Comment added.');
+        }
+        case 'kanban_link': {
+          const a = z.object({ parent_id: z.string(), child_id: z.string() }).parse(args);
+          if (!this.pmTask(scope, a.parent_id) || !this.pmTask(scope, a.child_id)) {
+            return this.rpcError(res, rpcReq.id, 'both tasks must exist on this board');
+          }
+          commands.link(a.parent_id, a.child_id);
+          return this.text(res, rpcReq.id, 'Linked.');
+        }
+        case 'kanban_feature_create': {
+          const a = z
+            .object({
+              name: z.string(),
+              repo_path: z.string().optional(),
+              base_branch: z.string().optional()
+            })
+            .parse(args);
+          const feature = commands.createFeature({
+            boardId: scope.boardId,
+            name: a.name,
+            repoPath: a.repo_path ?? null,
+            baseBranch: a.base_branch ?? null
+          });
+          return this.text(res, rpcReq.id, feature.id);
+        }
+        case 'kanban_assign_feature': {
+          const a = z
+            .object({ task_id: z.string(), feature_id: z.union([z.string(), z.null()]) })
+            .parse(args);
+          if (!this.pmTask(scope, a.task_id)) {
+            return this.rpcError(res, rpcReq.id, `task not found on this board: ${a.task_id}`);
+          }
+          commands.assignTaskToFeature(a.task_id, a.feature_id);
+          return this.text(res, rpcReq.id, 'Feature membership updated.');
+        }
+        default:
+          return this.rpcError(res, rpcReq.id, `unknown tool: ${name}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return this.rpcError(res, rpcReq.id, msg);
+    }
+  }
+
   private handleToolCall(res: ServerResponse, rpcReq: JsonRpcRequest, token: string): void {
     const scope = this.runs.get(token);
     if (!scope) return this.rpcError(res, rpcReq.id, 'unknown or missing run token');
@@ -366,6 +727,7 @@ export class KanbanMcpServer {
     const params = rpcReq.params ?? {};
     const name = String(params.name ?? '');
     const args = (params.arguments ?? {}) as Record<string, unknown>;
+    if (scope.kind === 'board') return this.handlePmToolCall(res, rpcReq, scope, name, args);
     const task = this.store.getTask(scope.taskId);
     if (!task) return this.rpcError(res, rpcReq.id, `task ${scope.taskId} not found`);
     const author = task.assignee ?? 'worker';

--- a/src/main/kanban/pm-chat-service.ts
+++ b/src/main/kanban/pm-chat-service.ts
@@ -1,0 +1,257 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, renameSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { createLogger } from '../logger';
+import { CodedError } from '../errors';
+import { RUNE_NOT_INSTALLED_MESSAGE } from '../../shared/rune';
+import { isAuthFailureText } from './spawn-worker';
+import { readRuneSession } from '../sessions/rune-source';
+import type { KanbanMcpServer } from './kanban-mcp-server';
+import type { TranscriptMessage } from '../../shared/sessions';
+import type {
+  PmChatState,
+  PmChatStatusPayload,
+  PmChatTranscriptPayload
+} from '../../shared/ipc-api';
+
+const log = createLogger('kanban-pm');
+
+/** A PM turn that runs longer than this is assumed hung and killed. */
+const PM_TURN_TIMEOUT_MS = 5 * 60 * 1000;
+/** Keep only this much of the child's output in memory (see docs/learnings on stdout OOM). */
+const OUTPUT_CAP = 64 * 1024;
+
+/**
+ * Rune appends the cwd's AGENTS.md to its system prompt, so the PM persona lives
+ * in the PM workspace dir instead of polluting the first user message.
+ */
+const PM_AGENTS_MD = `# Fleet board PM
+
+You are the product manager for this Fleet kanban board. The user chats with you
+to shape work: turning ideas into well-scoped tickets, splitting features,
+prioritizing, and keeping the board tidy.
+
+- Use the kanban MCP tools for every board change (kanban_create, kanban_update,
+  kanban_set_status, kanban_link, kanban_feature_create, kanban_assign_feature,
+  kanban_comment). Never just describe a change — make it.
+- Check the board first (kanban_list, kanban_show) so you don't create duplicates.
+- Write tickets like a good PM: an outcome-focused title and a body with context,
+  acceptance criteria, and any constraints the user mentioned.
+- Ask at most one or two brief clarifying questions when the request is genuinely
+  ambiguous; otherwise make a sensible call and say what you assumed.
+- Group related tickets under a feature (kanban_feature_create) when the user
+  describes a multi-ticket effort, and link dependencies with kanban_link.
+- New tickets default to todo; use triage for raw ideas that need refinement.
+- Keep replies short and conversational; end with the task ids you touched.
+- Your job is the board — do not write code or edit files.
+`;
+
+const sessionsFileSchema = z.record(z.string(), z.string());
+
+interface BoardChat {
+  sessionId: string | null;
+  inFlight: boolean;
+  error: string | null;
+}
+
+export interface PmChatServiceOptions {
+  mcp: KanbanMcpServer;
+  mcpPort: number;
+  /** Kanban home dir (~/.fleet/kanban); PM state lives under <home>/pm. */
+  kanbanHome: string;
+  emitStatus: (payload: PmChatStatusPayload) => void;
+  emitTranscript: (payload: PmChatTranscriptPayload) => void;
+}
+
+/**
+ * Drives the PM chat: one rune session per board, advanced one headless turn per
+ * user message (`rune --prompt`, then `rune --resume <id> --prompt`). The turn's
+ * board mutations arrive through the kanban MCP server under a board-scoped
+ * token; the conversation transcript is read back from rune's session JSON.
+ */
+export class PmChatService {
+  private chats = new Map<string, BoardChat>();
+  private opts: PmChatServiceOptions;
+  private sessionsLoaded = false;
+  private inFlightChildren = new Set<ChildProcess>();
+
+  constructor(opts: PmChatServiceOptions) {
+    this.opts = opts;
+  }
+
+  /** Kill any in-flight PM rune turns (app shutdown). */
+  dispose(): void {
+    for (const child of this.inFlightChildren) child.kill('SIGTERM');
+    this.inFlightChildren.clear();
+  }
+
+  private sessionsPath(): string {
+    return join(this.opts.kanbanHome, 'pm', 'pm-sessions.json');
+  }
+
+  /** Lazily hydrate persisted board→session ids so conversations survive restarts. */
+  private chat(boardId: string): BoardChat {
+    if (!this.sessionsLoaded) {
+      this.sessionsLoaded = true;
+      try {
+        const raw = sessionsFileSchema.parse(
+          JSON.parse(readFileSync(this.sessionsPath(), 'utf-8'))
+        );
+        for (const [board, sessionId] of Object.entries(raw)) {
+          this.chats.set(board, { sessionId, inFlight: false, error: null });
+        }
+      } catch {
+        // first run or unreadable file — start fresh
+      }
+    }
+    let c = this.chats.get(boardId);
+    if (!c) {
+      c = { sessionId: null, inFlight: false, error: null };
+      this.chats.set(boardId, c);
+    }
+    return c;
+  }
+
+  private persistSessions(): void {
+    const data: Record<string, string> = {};
+    for (const [board, c] of this.chats) {
+      if (c.sessionId) data[board] = c.sessionId;
+    }
+    const path = this.sessionsPath();
+    mkdirSync(join(this.opts.kanbanHome, 'pm'), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data, null, 2));
+    renameSync(tmp, path);
+  }
+
+  async getState(boardId: string): Promise<PmChatState> {
+    const c = this.chat(boardId);
+    return {
+      boardId,
+      inFlight: c.inFlight,
+      error: c.error,
+      messages: await this.readMessages(c.sessionId)
+    };
+  }
+
+  /** Forget the conversation (the rune session file is left untouched). */
+  reset(boardId: string): void {
+    const c = this.chat(boardId);
+    if (c.inFlight) {
+      throw new CodedError('wait for the PM to finish responding first', 'BAD_REQUEST');
+    }
+    c.sessionId = null;
+    c.error = null;
+    this.persistSessions();
+  }
+
+  sendMessage(boardId: string, text: string): void {
+    const body = text.trim();
+    if (body === '') throw new CodedError('message is empty', 'BAD_REQUEST');
+    const c = this.chat(boardId);
+    if (c.inFlight) {
+      throw new CodedError('the PM is still responding', 'BAD_REQUEST');
+    }
+    c.inFlight = true;
+    c.error = null;
+    this.opts.emitStatus({ boardId, status: 'thinking' });
+
+    const token = randomUUID();
+    this.opts.mcp.registerRun(token, { kind: 'board', boardId });
+
+    const dir = join(this.opts.kanbanHome, 'pm', boardId);
+    const runeDir = join(dir, '.rune');
+    mkdirSync(runeDir, { recursive: true });
+    writeFileSync(join(dir, 'AGENTS.md'), PM_AGENTS_MD);
+    const mcpConfigPath = join(runeDir, 'mcp.json');
+    const url = `http://127.0.0.1:${this.opts.mcpPort}/mcp?run=${token}`;
+    writeFileSync(
+      mcpConfigPath,
+      JSON.stringify({ servers: { kanban: { type: 'http', url } } }, null, 2)
+    );
+
+    const args = ['--prompt', body];
+    if (c.sessionId) args.push('--resume', c.sessionId);
+    const child = spawn('rune', args, {
+      cwd: dir,
+      env: { ...process.env, RUNE_MCP_CONFIG: mcpConfigPath },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    this.inFlightChildren.add(child);
+
+    let output = ''; // merged stdout+stderr tail, for error classification
+    let sessionId: string | null = c.sessionId;
+    const collect = (chunk: Buffer): void => {
+      output = (output + chunk.toString('utf-8')).slice(-OUTPUT_CAP);
+      if (!sessionId) {
+        sessionId = /^session-id: ([A-Za-z0-9_-]+)$/m.exec(output)?.[1] ?? null;
+      }
+    };
+    child.stdout.on('data', collect);
+    child.stderr.on('data', collect);
+
+    // One-shot: a failed spawn fires 'error' AND 'exit', and the second call
+    // would clobber the specific error with the generic exit fallback.
+    let finished = false;
+    const finish = (error: string | null): void => {
+      if (finished) return;
+      finished = true;
+      this.inFlightChildren.delete(child);
+      clearTimeout(timeout);
+      this.opts.mcp.unregisterRun(token);
+      c.inFlight = false;
+      c.error = error;
+      if (sessionId && sessionId !== c.sessionId) {
+        c.sessionId = sessionId;
+        this.persistSessions();
+      }
+      void this.readMessages(c.sessionId).then((messages) => {
+        if (messages.length > 0) this.opts.emitTranscript({ boardId, messages });
+        this.opts.emitStatus(
+          error ? { boardId, status: 'error', error } : { boardId, status: 'idle' }
+        );
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      log.warn('pm turn timed out; killing rune', { boardId, pid: child.pid });
+      child.kill('SIGTERM');
+    }, PM_TURN_TIMEOUT_MS);
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      log.error('pm rune failed to spawn', { boardId, error: err.message });
+      finish(err.code === 'ENOENT' ? RUNE_NOT_INSTALLED_MESSAGE : err.message);
+    });
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        finish(null);
+        return;
+      }
+      if (signal) {
+        finish('the PM run was interrupted; try again');
+        return;
+      }
+      if (isAuthFailureText(output)) {
+        finish(
+          'rune authentication failed — fix the provider credentials (e.g. `rune login`) and retry'
+        );
+        return;
+      }
+      const lastLine = output
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .pop();
+      finish(lastLine ? lastLine.slice(0, 300) : `the PM run failed (exit ${code ?? '?'})`);
+    });
+  }
+
+  private async readMessages(sessionId: string | null): Promise<TranscriptMessage[]> {
+    if (!sessionId) return [];
+    const transcript = await readRuneSession(sessionId);
+    return transcript?.messages ?? [];
+  }
+}

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -208,6 +208,11 @@ export function detectAuthFailure(logPath: string): boolean {
   return AUTH_FAILURE_RE.test(readLogTail(logPath));
 }
 
+/** Same auth/credential check for output already held in memory (PM chat stderr). */
+export function isAuthFailureText(text: string): boolean {
+  return AUTH_FAILURE_RE.test(text);
+}
+
 /**
  * Extracts the most recent rune `[error: …]` marker from a worker log — the
  * fatal provider/runtime error rune prints before dying (auth, a 4xx like

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -59,7 +59,11 @@ import type {
   KanbanUpdateFeatureRequest,
   KanbanAssignTaskToFeatureRequest,
   KanbanConflictResult,
-  KanbanPruneWorktreeResult
+  KanbanPruneWorktreeResult,
+  PmChatSendRequest,
+  PmChatState,
+  PmChatStatusPayload,
+  PmChatTranscriptPayload
 } from '../shared/ipc-api';
 import type {
   Board,
@@ -619,7 +623,17 @@ const fleetApi = {
     pruneWorktree: async (taskId: string): Promise<KanbanPruneWorktreeResult> =>
       typedInvoke<KanbanPruneWorktreeResult>(IPC_CHANNELS.KANBAN_PRUNE_WORKTREE, taskId),
     pruneMergedWorktrees: async (boardId: string): Promise<PruneResult> =>
-      typedInvoke<PruneResult>(IPC_CHANNELS.KANBAN_PRUNE_MERGED_WORKTREES, boardId)
+      typedInvoke<PruneResult>(IPC_CHANNELS.KANBAN_PRUNE_MERGED_WORKTREES, boardId),
+    pmSend: async (req: PmChatSendRequest): Promise<void> =>
+      typedInvoke<void>(IPC_CHANNELS.KANBAN_PM_SEND, req),
+    pmState: async (boardId: string): Promise<PmChatState> =>
+      typedInvoke<PmChatState>(IPC_CHANNELS.KANBAN_PM_STATE, boardId),
+    pmReset: async (boardId: string): Promise<void> =>
+      typedInvoke<void>(IPC_CHANNELS.KANBAN_PM_RESET, boardId),
+    onPmStatus: (callback: (payload: PmChatStatusPayload) => void): Unsubscribe =>
+      onChannel<PmChatStatusPayload>(IPC_CHANNELS.KANBAN_PM_STATUS, callback),
+    onPmTranscript: (callback: (payload: PmChatTranscriptPayload) => void): Unsubscribe =>
+      onChannel<PmChatTranscriptPayload>(IPC_CHANNELS.KANBAN_PM_TRANSCRIPT, callback)
   },
   envSync: {
     getConfig: async (repoDir: string): Promise<EnvSyncConfig | null> =>

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -12,9 +12,12 @@ import {
   KanbanSquare,
   Package,
   Layers,
-  GitBranch
+  GitBranch,
+  Bot
 } from 'lucide-react';
 import { SwarmModal } from './SwarmModal';
+import { PmChatPanel } from './PmChatPanel';
+import { usePmChatStore } from '../../store/pm-chat-store';
 import { ArtifactsView } from './ArtifactsView';
 import { RuneMissingBanner } from './RuneMissingBanner';
 import { FeatureSelector } from './FeatureSelector';
@@ -47,6 +50,8 @@ export function KanbanBoard(): React.JSX.Element {
     setFocusedFeature
   } = useKanbanStore();
   const focusedFeature = features.find((f) => f.id === selectedFeatureId) ?? null;
+  const pmOpen = usePmChatStore((s) => s.panelOpen);
+  const togglePm = usePmChatStore((s) => s.togglePanel);
   const [view, setView] = useState<'board' | 'artifacts' | 'features' | 'worktrees'>('board');
   const [search, setSearch] = useState('');
   const [assigneeFilter, setAssigneeFilter] = useState<string>('');
@@ -355,6 +360,17 @@ export function KanbanBoard(): React.JSX.Element {
                 <Zap size={12} /> Nudge
               </button>
               <button
+                onClick={togglePm}
+                className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs transition active:scale-[0.97] ${
+                  pmOpen
+                    ? 'bg-emerald-700 text-white'
+                    : 'bg-emerald-600 text-white hover:bg-emerald-500'
+                }`}
+                title="Chat with the board PM to shape and create tickets"
+              >
+                <Bot size={12} /> PM
+              </button>
+              <button
                 onClick={() => setSwarming(true)}
                 className="inline-flex items-center gap-1 rounded bg-purple-600 px-2 py-1 text-xs text-white transition active:scale-[0.97] hover:bg-purple-500"
                 title="Create a swarm: workers → verifier → synthesizer"
@@ -573,6 +589,7 @@ export function KanbanBoard(): React.JSX.Element {
           </div>
 
           {openTaskId && <KanbanDrawer />}
+          {pmOpen && <PmChatPanel boardId={activeBoardSlug} shiftLeft={openTaskId !== null} />}
 
           <SwarmModal
             open={swarming}

--- a/src/renderer/src/components/kanban/PmChatPanel.tsx
+++ b/src/renderer/src/components/kanban/PmChatPanel.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, Bot, RotateCcw, Wrench } from 'lucide-react';
+import { usePmChatStore } from '../../store/pm-chat-store';
+import type { TranscriptMessage } from '../../../../shared/sessions';
+
+type Props = {
+  boardId: string;
+  /** True when the task drawer is open, so the panel parks to its left. */
+  shiftLeft: boolean;
+};
+
+/** Compact one-line label for a tool call, e.g. "kanban_create". */
+function toolChips(msg: TranscriptMessage): string[] {
+  return msg.blocks.flatMap((b) => (b.type === 'tool_use' ? [b.name] : []));
+}
+
+function messageText(msg: TranscriptMessage): string {
+  return msg.blocks
+    .map((b) => (b.type === 'text' ? b.text : ''))
+    .join('')
+    .trim();
+}
+
+export function PmChatPanel({ boardId, shiftLeft }: Props): React.JSX.Element {
+  const {
+    closePanel,
+    loadState,
+    send,
+    reset,
+    applyStatus,
+    applyTranscript,
+    status,
+    error,
+    messages
+  } = usePmChatStore();
+  const [draft, setDraft] = useState('');
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    void loadState(boardId);
+    const offStatus = window.fleet.kanban.onPmStatus((p) => {
+      if (p.boardId === boardId) applyStatus(p.status, p.error);
+    });
+    const offTranscript = window.fleet.kanban.onPmTranscript((p) => {
+      if (p.boardId === boardId) applyTranscript(p.messages);
+    });
+    return () => {
+      offStatus();
+      offTranscript();
+    };
+  }, [boardId, loadState, applyStatus, applyTranscript]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' });
+  }, [messages.length, status]);
+
+  function handleSend(): void {
+    const text = draft.trim();
+    if (!text || status === 'thinking') return;
+    setDraft('');
+    void send(boardId, text);
+  }
+
+  const thinking = status === 'thinking';
+
+  return (
+    <div
+      className={`fixed bottom-0 top-9 z-30 flex w-[380px] flex-col border-l border-neutral-800 bg-neutral-900 shadow-2xl ${
+        shiftLeft ? 'right-[420px]' : 'right-0'
+      }`}
+    >
+      <div className="flex items-center gap-2 border-b border-neutral-800 px-3 py-2">
+        <Bot size={14} className="text-emerald-400" />
+        <span className="text-xs font-medium text-neutral-200">Board PM</span>
+        <div className="flex-1" />
+        <button
+          onClick={() => {
+            if (messages.length === 0 || window.confirm('Start a new conversation?')) {
+              void reset(boardId);
+            }
+          }}
+          disabled={thinking}
+          className="rounded p-1 text-neutral-500 transition active:scale-90 hover:bg-neutral-800 hover:text-neutral-300 disabled:opacity-40"
+          title="New conversation"
+        >
+          <RotateCcw size={12} />
+        </button>
+        <button
+          onClick={closePanel}
+          className="rounded p-1 text-neutral-500 transition active:scale-90 hover:bg-neutral-800 hover:text-neutral-300"
+          title="Close"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-3 py-2">
+        {messages.length === 0 && !thinking && (
+          <p className="mt-4 text-center text-xs text-neutral-500">
+            Talk to your board PM — describe a feature, a bug, or a pile of ideas, and it will shape
+            them into tickets.
+          </p>
+        )}
+        {messages.map((m, i) => {
+          const text = messageText(m);
+          const chips = toolChips(m);
+          if (!text && chips.length === 0) return null;
+          return (
+            <div
+              key={i}
+              className={`flex flex-col gap-1 ${m.role === 'user' ? 'items-end' : 'items-start'}`}
+            >
+              {text && (
+                <div
+                  className={`max-w-[90%] whitespace-pre-wrap rounded-md px-2.5 py-1.5 text-xs ${
+                    m.role === 'user'
+                      ? 'bg-blue-600/20 text-blue-100'
+                      : 'bg-neutral-800 text-neutral-200'
+                  }`}
+                >
+                  {text}
+                </div>
+              )}
+              {chips.map((name, j) => (
+                <span
+                  key={j}
+                  className="inline-flex items-center gap-1 rounded-full border border-neutral-700 bg-neutral-950 px-2 py-0.5 text-[10px] text-neutral-400"
+                >
+                  <Wrench size={9} /> {name}
+                </span>
+              ))}
+            </div>
+          );
+        })}
+        {thinking && (
+          <div className="flex items-center gap-2 text-xs text-neutral-500">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+            Thinking…
+          </div>
+        )}
+        {status === 'error' && error && (
+          <div className="rounded border border-red-900 bg-red-950/40 px-2 py-1.5 text-[11px] text-red-300">
+            {error}
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="border-t border-neutral-800 p-2">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+          placeholder={
+            thinking
+              ? 'PM is thinking…'
+              : 'Message the PM… (Enter to send, Shift+Enter for newline)'
+          }
+          disabled={thinking}
+          rows={2}
+          className="w-full resize-none rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 text-xs text-neutral-200 outline-none focus:border-blue-500 disabled:opacity-60"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/store/__tests__/workspace-store.test.ts
+++ b/src/renderer/src/store/__tests__/workspace-store.test.ts
@@ -76,6 +76,13 @@ const WS_C: Workspace = {
 };
 
 beforeEach(() => {
+  // setToolVisible persists visibility through the settings bridge with a
+  // fire-and-forget updateSettings; the bare window.fleet stub from test-setup
+  // would make that call reject unhandled and fail the run.
+  (window.fleet as { settings: unknown }).settings = {
+    set: async () => undefined,
+    get: async () => ({})
+  };
   useWorkspaceStore.setState({
     workspace: WS_A,
     backgroundWorkspaces: new Map(),

--- a/src/renderer/src/store/pm-chat-store.ts
+++ b/src/renderer/src/store/pm-chat-store.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import type { TranscriptMessage } from '../../../shared/sessions';
+
+type PmStatus = 'idle' | 'thinking' | 'error';
+
+type PmChatStoreState = {
+  panelOpen: boolean;
+  /** Board whose conversation is currently loaded (the active board). */
+  boardId: string | null;
+  status: PmStatus;
+  error: string | null;
+  messages: TranscriptMessage[];
+  togglePanel: () => void;
+  closePanel: () => void;
+  loadState: (boardId: string) => Promise<void>;
+  send: (boardId: string, text: string) => Promise<void>;
+  reset: (boardId: string) => Promise<void>;
+  applyStatus: (status: PmStatus, error?: string) => void;
+  applyTranscript: (messages: TranscriptMessage[]) => void;
+};
+
+export const usePmChatStore = create<PmChatStoreState>((set, get) => ({
+  panelOpen: false,
+  boardId: null,
+  status: 'idle',
+  error: null,
+  messages: [],
+
+  togglePanel: () => set((s) => ({ panelOpen: !s.panelOpen })),
+  closePanel: () => set({ panelOpen: false }),
+
+  loadState: async (boardId) => {
+    // Clear immediately so a board switch never flashes the previous board's chat.
+    set({ boardId, messages: [], status: 'idle', error: null });
+    const state = await window.fleet.kanban.pmState(boardId);
+    if (get().boardId !== boardId) return; // user switched boards mid-load
+    set({
+      messages: state.messages,
+      status: state.inFlight ? 'thinking' : state.error ? 'error' : 'idle',
+      error: state.error
+    });
+  },
+
+  send: async (boardId, text) => {
+    // Optimistic echo: the real transcript replaces this when the turn lands.
+    set((s) => ({
+      status: 'thinking',
+      error: null,
+      messages: [...s.messages, { role: 'user', blocks: [{ type: 'text', text }] }]
+    }));
+    try {
+      await window.fleet.kanban.pmSend({ boardId, text });
+    } catch (err) {
+      set({ status: 'error', error: err instanceof Error ? err.message : String(err) });
+    }
+  },
+
+  reset: async (boardId) => {
+    await window.fleet.kanban.pmReset(boardId);
+    await get().loadState(boardId); // re-sync from main — the source of truth
+  },
+
+  applyStatus: (status, error) => set({ status, error: error ?? null }),
+  applyTranscript: (messages) => set({ messages })
+}));

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -1,5 +1,6 @@
 import type { Workspace, NotificationEvent, ActivityState } from './types';
 import type { ShellProfile, WslDistroState } from './shell-profiles';
+import type { TranscriptMessage } from './sessions';
 import type {
   UpdateTaskFields,
   TaskStatus,
@@ -392,6 +393,30 @@ export type KanbanPruneWorktreeResult = {
 export type KanbanAssignTaskToFeatureRequest = {
   taskId: string;
   featureId: string | null;
+};
+
+export type PmChatSendRequest = {
+  boardId: string;
+  text: string;
+};
+
+/** Full PM chat state for one board, returned by kanban:pm-state. */
+export type PmChatState = {
+  boardId: string;
+  inFlight: boolean;
+  error: string | null;
+  messages: TranscriptMessage[];
+};
+
+export type PmChatStatusPayload = {
+  boardId: string;
+  status: 'thinking' | 'idle' | 'error';
+  error?: string;
+};
+
+export type PmChatTranscriptPayload = {
+  boardId: string;
+  messages: TranscriptMessage[];
 };
 
 export type {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -204,6 +204,11 @@ export const IPC_CHANNELS = {
   KANBAN_LIST_WORKTREES: 'kanban:list-worktrees',
   KANBAN_PRUNE_WORKTREE: 'kanban:prune-worktree',
   KANBAN_PRUNE_MERGED_WORKTREES: 'kanban:prune-merged-worktrees',
+  KANBAN_PM_SEND: 'kanban:pm-send',
+  KANBAN_PM_STATE: 'kanban:pm-state',
+  KANBAN_PM_RESET: 'kanban:pm-reset',
+  KANBAN_PM_STATUS: 'kanban:pm-status',
+  KANBAN_PM_TRANSCRIPT: 'kanban:pm-transcript',
   // Sessions
   SESSIONS_LIST: 'sessions:list',
   SESSIONS_READ: 'sessions:read',


### PR DESCRIPTION
## Summary
- Adds a **Board PM** chat panel to the Kanban tab (green PM button in the toolbar): talk to an AI product manager that creates/refines tickets, prioritizes, links dependencies, creates features, and moves cards — directly on the board as you chat.
- Backend is headless **rune**, one session per board, one turn per message (`--prompt`, then `--resume <id> --prompt`). Requires rune with headless resume (khang859/rune#25). Conversations persist across app restarts; rune-missing/auth/crash errors surface in the panel; turns time out after 5 min; in-flight children are killed on quit.
- The kanban MCP server gains a board-scoped token (`RunScope` → `TaskScope | BoardScope` union) and a `PM_TOOLS` set with explicit `task_id` params. Mutations route through `KanbanCommands`, so the PM follows the same rules as the UI: can't touch running tasks (status or edits), review stays worktree-only, other boards are invisible. PM persona ships as an `AGENTS.md` rune loads into its system prompt.

## Test plan
- [x] `npm run typecheck` (node + web) and `npm run build` pass
- [x] Full vitest suite: 987 pass, incl. 9 new board-scope MCP tests (PM toolset listing, create/links/feature-inherit, running-task guards, cross-board isolation, worker-tool rejection)
- [x] Rune-side: 693 tests pass; live smoke confirmed session resume retains context
- [x] End-to-end via CDP against the dev app: sent a chat message → PM called `kanban_create` → ticket appeared in Triage with the PM confirming the id; concurrent turns on two boards ran isolated
- [ ] Manual: try the PM on a real board (note: assistant reply renders at turn end; board updates live throughout)

## Notes / follow-ups
- Tool chips show rune's server-prefixed tool name (`kanban_kanban_create`) — cosmetic
- Assistant markdown renders as plain text in bubbles
- `kanban_swarm` excluded from PM tools in v1 (needs a board-scoped workspace-inheritance variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)