### PR TITLE
feat(kanban): auto-assign unassigned ready tasks (autopilot phase 1, #227)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-kanban-auto-assignment.md
+++ b/docs/superpowers/plans/2026-06-11-kanban-auto-assignment.md
@@ -1,0 +1,775 @@
+# Kanban Auto-Assignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unassigned `ready` kanban tasks get an assignee automatically (single-profile fast path, an LLM `assign` orchestrator run when there's a choice, and a deterministic fallback after repeated failure) instead of stalling forever.
+
+**Architecture:** A new `autoAssign()` stage in the existing `KanbanDispatcher` tick. It assigns deterministically in code when there is exactly one worker profile or after an attempt cap, otherwise spawns an orchestrator run in a new `assign` run mode whose terminal tool `kanban_assign(profile)` sets the assignee and returns the task to `ready`. Gated on a new `autoAssign` setting (default **on**). No schema migration — reuses existing `task_runs.mode` and `consecutive_failures` columns.
+
+**Tech Stack:** TypeScript, Electron main process, better-sqlite3 (`KanbanStore`), HTTP MCP server (`KanbanMcpServer`), rune headless workers, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md` §5. **Issue:** #227.
+
+**Deviation from spec (intentional):** The spec's §5 mentions flagging tasks with `pending_mode='assign'`. The dispatcher runs as a single synchronous tick, so flagging then claiming in the same tick is redundant — `claimForAssign()` does a direct CAS on `status='ready' AND assignee IS NULL`. We therefore add `RunMode='assign'` but do **not** add `PendingMode='assign'`. Same observable behavior, less state.
+
+---
+
+### Task 1: Add `assign` to `RunMode` and the `autoAssign` setting/config flag
+
+This task introduces the type/config surface so later tasks compile. No behavior yet.
+
+**Files:**
+- Modify: `src/shared/kanban-types.ts:15`
+- Modify: `src/shared/types.ts:156-164`
+- Modify: `src/shared/constants.ts:105-112`
+- Modify: `src/main/kanban/kanban-dispatcher.ts:30-38`
+- Modify: `src/main/index.ts:849-860`
+- Modify: `src/main/__tests__/kanban-dispatcher.test.ts:31-39,59-67,370-378`
+
+- [ ] **Step 1: Extend `RunMode`**
+
+In `src/shared/kanban-types.ts`, change line 15:
+
+```typescript
+/** What a run is doing. 'work' = normal worker; orchestrator runs are 'decompose' | 'specify' | 'assign'. */
+export type RunMode = 'work' | 'decompose' | 'specify' | 'assign';
+```
+
+- [ ] **Step 2: Add `autoAssign` to the settings type**
+
+In `src/shared/types.ts`, inside `KanbanSettings.dispatcher` (after line 163, `maxDecompose`):
+
+```typescript
+    maxDecompose: number; // concurrency cap for orchestrator runs (separate from maxInProgress)
+    autoAssign: boolean; // when true, the dispatcher auto-assigns unassigned ready tasks to a worker profile
+```
+
+- [ ] **Step 3: Add the default (on)**
+
+In `src/shared/constants.ts`, inside `DEFAULT_SETTINGS.kanban.dispatcher` (after line 111, `maxDecompose: 1`):
+
+```typescript
+      maxDecompose: 1,
+      autoAssign: true
+```
+
+- [ ] **Step 4: Add `autoAssign` to `DispatcherConfig`**
+
+In `src/main/kanban/kanban-dispatcher.ts`, inside the `DispatcherConfig` interface (after the `autoDecompose` line, ~line 35):
+
+```typescript
+  autoDecompose: boolean; // automatically arm triage tasks for decompose
+  autoAssign: boolean; // automatically assign unassigned ready tasks to a worker profile
+  maxDecompose: number; // max concurrent orchestrator runs
+```
+
+- [ ] **Step 5: Wire it into `buildDispatcherConfig`**
+
+In `src/main/index.ts`, inside `buildDispatcherConfig()` (after line 856, `autoDecompose: d.autoDecompose,`):
+
+```typescript
+      autoDecompose: d.autoDecompose,
+      autoAssign: d.autoAssign,
+      maxDecompose: d.maxDecompose,
+```
+
+- [ ] **Step 6: Fix the test config literals**
+
+In `src/main/__tests__/kanban-dispatcher.test.ts`, the two fully-spelled config objects (lines 31-39 and 59-67) and `baseConfig` (lines 370-378) each list every `DispatcherConfig` field, so each needs the new key. Add `autoAssign: false,` after the `autoDecompose: false,` line in all three:
+
+```typescript
+        autoDecompose: false,
+        autoAssign: false,
+        maxDecompose: 1,
+```
+
+(In `baseConfig`, match its formatting — `autoDecompose: false,` then `autoAssign: false,` then `maxDecompose: 1,`.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no errors).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/shared/kanban-types.ts src/shared/types.ts src/shared/constants.ts src/main/kanban/kanban-dispatcher.ts src/main/index.ts src/main/__tests__/kanban-dispatcher.test.ts
+git commit -m "feat(kanban): add assign run mode and autoAssign setting"
+```
+
+---
+
+### Task 2: Store queries — `unassignedReadyTasks()` and `claimForAssign()`
+
+**Files:**
+- Modify: `src/main/kanban/kanban-store.ts` (add methods near `readyTasks` ~line 1026 and `claimForDecompose` ~line 1485)
+- Test: `src/main/__tests__/kanban-store.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/main/__tests__/kanban-store.test.ts`, add inside the top-level `describe` (place next to the existing `claimForDecompose` test, ~line 364):
+
+```typescript
+  it('unassignedReadyTasks returns only ready tasks with no assignee', () => {
+    const store = makeStore();
+    const a = store.createTask({ title: 'unassigned', status: 'ready' });
+    store.createTask({ title: 'assigned', status: 'ready', assignee: 'w' });
+    store.createTask({ title: 'todo', status: 'todo' });
+    const got = store.unassignedReadyTasks().map((t) => t.id);
+    expect(got).toEqual([a.id]);
+    store.close();
+  });
+
+  it('claimForAssign atomically moves ready+unassigned to running', () => {
+    const store = makeStore();
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    expect(store.claimForAssign(t.id, 'L', 1000)).toBe(true);
+    expect(store.getTask(t.id)?.status).toBe('running');
+    // a second claim loses (no longer ready+unassigned)
+    expect(store.claimForAssign(t.id, 'L2', 1000)).toBe(false);
+    store.close();
+  });
+```
+
+Note: `makeStore()` is the existing helper in this test file. If it requires a clock arg, match the surrounding tests' call style.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts -t "unassignedReadyTasks|claimForAssign"`
+Expected: FAIL with "store.unassignedReadyTasks is not a function" / "store.claimForAssign is not a function".
+
+- [ ] **Step 3: Implement `unassignedReadyTasks()`**
+
+In `src/main/kanban/kanban-store.ts`, immediately after the `readyTasks()` method (ends ~line 1026):
+
+```typescript
+  /** Ready tasks with no assignee — the auto-assign stage's input (claimAndSpawn ignores these). */
+  unassignedReadyTasks(): Task[] {
+    const rows = this.db
+      .prepare(
+        "SELECT * FROM tasks WHERE status='ready' AND assignee IS NULL ORDER BY priority DESC, created_at ASC"
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+```
+
+- [ ] **Step 4: Implement `claimForAssign()`**
+
+In `src/main/kanban/kanban-store.ts`, immediately after `claimForDecompose()` (ends ~line 1485):
+
+```typescript
+  /** Atomic CAS claim of an unassigned ready task for an assign run; moves ready→running. */
+  claimForAssign(taskId: string, lock: string, ttlMs: number): boolean {
+    const ts = this.now();
+    const res = this.db
+      .prepare(
+        `UPDATE tasks
+         SET status='running', claim_lock=@lock, claim_expires=@expires,
+             last_heartbeat_at=@ts, updated_at=@ts
+         WHERE id=@id AND status='ready' AND assignee IS NULL
+           AND (claim_lock IS NULL OR claim_expires <= @ts)`
+      )
+      .run({ id: taskId, lock, expires: ts + ttlMs, ts });
+    return res.changes === 1;
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts -t "unassignedReadyTasks|claimForAssign"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kanban/kanban-store.ts src/main/__tests__/kanban-store.test.ts
+git commit -m "feat(kanban): add unassignedReadyTasks and claimForAssign store queries"
+```
+
+---
+
+### Task 3: Worker prompt + terminal tool for `assign` mode
+
+**Files:**
+- Modify: `src/main/kanban/spawn-worker.ts:63-92` (buildPrompt) and `:120-130` (requireToolsForMode)
+
+- [ ] **Step 1: Add the assign prompt branch**
+
+In `src/main/kanban/spawn-worker.ts`, inside `buildPrompt`, add a new branch **before** the final `work` return (after the `specify` block ends ~line 84):
+
+```typescript
+  if (mode === 'assign') {
+    const roster = (input.roster ?? []).map((r) => `- ${r.name}: ${r.description}`).join('\n');
+    return (
+      `assign kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `Choose the single best-matching worker profile to implement this task, based on each ` +
+      `profile's described strengths. Call kanban_assign with that profile's name. Do not do the ` +
+      `work yourself.\n\nAvailable worker profiles:\n${roster || '- default: general worker'}`
+    );
+  }
+```
+
+- [ ] **Step 2: Add the terminal tool for assign mode**
+
+In `src/main/kanban/spawn-worker.ts`, in `requireToolsForMode` (~line 120), add a case before `default`:
+
+```typescript
+    case 'specify':
+      return 'kanban_update';
+    case 'assign':
+      return 'kanban_assign';
+    default:
+      return null;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kanban/spawn-worker.ts
+git commit -m "feat(kanban): assign-mode worker prompt and require-tool"
+```
+
+---
+
+### Task 4: MCP server — `kanban_assign` tool, `ASSIGN_TOOLS`, handler
+
+**Files:**
+- Modify: `src/main/kanban/kanban-mcp-server.ts` (tool defs ~line 218, `toolsForMode` ~line 408, handler switch ~line 919)
+- Test: `src/main/__tests__/kanban-mcp-server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/main/__tests__/kanban-mcp-server.test.ts`, add inside the `describe('KanbanMcpServer', ...)` block (after the `kanban_block` test, ~line 95):
+
+```typescript
+  it('kanban_assign sets the assignee, returns to ready, and rejects unknown profiles', async () => {
+    const profiles = () =>
+      [
+        { name: 'alpha', role: 'worker' as const },
+        { name: 'beta', role: 'worker' as const }
+      ];
+    const s2 = new KanbanMcpServer(store, profiles);
+    const port2 = await s2.start(0);
+    const base2 = `http://127.0.0.1:${port2}/mcp`;
+    try {
+      const t = store.createTask({ title: 'needs owner', status: 'ready' });
+      store.claimForAssign(t.id, 'LOCK', 100000);
+      const run = store.startRun(t.id, 'orchestrator', 1, 'assign');
+      s2.registerRun('atok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'assign' }, 'LOCK');
+
+      // unknown profile is rejected
+      const bad = await rpc(`${base2}?run=atok`, 'tools/call', {
+        name: 'kanban_assign',
+        arguments: { profile: 'ghost' }
+      });
+      expect(String(bad.error?.message ?? bad.result?.content?.[0]?.text)).toMatch(
+        /unknown worker profile/i
+      );
+      expect(store.getTask(t.id)?.assignee).toBeNull();
+
+      // valid profile assigns and returns the task to ready
+      const ok = await rpc(`${base2}?run=atok`, 'tools/call', {
+        name: 'kanban_assign',
+        arguments: { profile: 'alpha' }
+      });
+      expect(ok.result.content[0].text).toMatch(/alpha/i);
+      const got = store.getTask(t.id);
+      expect(got?.assignee).toBe('alpha');
+      expect(got?.status).toBe('ready');
+      expect(store.listRuns(t.id)[0].outcome).toBe('completed');
+    } finally {
+      await s2.stop();
+    }
+  });
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts -t "kanban_assign"`
+Expected: FAIL — `kanban_assign` is rejected as `unknown tool` (not yet in ASSIGN_TOOLS) or the task isn't assigned.
+
+- [ ] **Step 3: Define `ASSIGN_TOOLS` and route it in `toolsForMode`**
+
+In `src/main/kanban/kanban-mcp-server.ts`, after the `SPECIFY_TOOLS` definition (ends ~line 230):
+
+```typescript
+const ASSIGN_TOOLS: McpTool[] = [
+  WORKER_TOOLS[0], // kanban_show
+  {
+    name: 'kanban_assign',
+    description:
+      'Assign this task to a worker profile by name. Terminal — ends the assign run.',
+    inputSchema: {
+      type: 'object',
+      properties: { profile: { type: 'string' } },
+      required: ['profile']
+    }
+  },
+  ...WORKER_TOOLS.filter((t) => t.name === 'kanban_comment' || t.name === 'kanban_heartbeat')
+];
+```
+
+Then in `toolsForMode` (~line 408), add the branch before the final return:
+
+```typescript
+function toolsForMode(mode: RunMode): McpTool[] {
+  if (mode === 'decompose') return DECOMPOSE_TOOLS;
+  if (mode === 'specify') return SPECIFY_TOOLS;
+  if (mode === 'assign') return ASSIGN_TOOLS;
+  return WORKER_TOOLS;
+}
+```
+
+- [ ] **Step 4: Implement the `kanban_assign` handler**
+
+In `src/main/kanban/kanban-mcp-server.ts`, inside the task-scope `handleToolCall` switch, add a case after `kanban_block` (~line 976, before `kanban_comment`):
+
+```typescript
+        case 'kanban_assign': {
+          const a = z.object({ profile: z.string() }).parse(args);
+          const name = a.profile.trim();
+          // Same phantom-assignee guard as kanban_create: only assign to a real worker profile.
+          const workerNames = this.getProfiles()
+            .filter((p) => p.role === 'worker')
+            .map((p) => p.name);
+          if (workerNames.length > 0 && !workerNames.includes(name)) {
+            return this.rpcError(
+              res,
+              rpcReq.id,
+              `unknown worker profile "${name}". Valid profiles: ${workerNames.join(', ')}`
+            );
+          }
+          this.store.updateTask(task.id, { assignee: name });
+          // Back to ready, now assigned — claimAndSpawn picks it up on the next tick.
+          this.store.returnToReady(task.id);
+          this.store.finishRun(scope.runId, 'completed', { summary: `assigned ${name}` });
+          this.store.appendEvent(task.id, scope.runId, 'assigned', { assignee: name, by: 'orchestrator' });
+          this.unregisterRun(token);
+          return this.text(res, rpcReq.id, `Assigned ${name}.`);
+        }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts -t "kanban_assign"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kanban/kanban-mcp-server.ts src/main/__tests__/kanban-mcp-server.test.ts
+git commit -m "feat(kanban): kanban_assign MCP tool for assign runs"
+```
+
+---
+
+### Task 5: Dispatcher `autoAssign()` stage + reclaim routing + tick wiring
+
+**Files:**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (deps ~line 52-64, reclaim ~line 147-149, add `autoAssign()` after `decompose()` ~line 277, `tick()` ~line 330-338, add a top-level const ~line 12)
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/main/__tests__/kanban-dispatcher.test.ts`, add a new `describe` block after the `KanbanDispatcher.decompose` block (~line 499):
+
+```typescript
+describe('KanbanDispatcher.autoAssign', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('fast-path: a single worker profile is assigned in code, no run spawned', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => (spawned++, 1),
+      config: { ...baseConfig, autoAssign: true },
+      workerProfileNames: () => ['solo']
+    });
+    disp.autoAssign();
+    expect(spawned).toBe(0);
+    expect(store.getTask(t.id)?.assignee).toBe('solo');
+    expect(store.getTask(t.id)?.status).toBe('ready');
+    store.close();
+  });
+
+  it('LLM path: with multiple profiles it spawns an assign run', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const spawned: Array<{ id: string; mode: string }> = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => {
+        spawned.push({ id: args.task.id, mode: args.mode });
+        return 4242;
+      },
+      config: { ...baseConfig, autoAssign: true },
+      prepareWorkspaceFn: () => '/tmp/ws',
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(spawned).toEqual([{ id: t.id, mode: 'assign' }]);
+    expect(store.getTask(t.id)?.status).toBe('running');
+    store.close();
+  });
+
+  it('fallback: after the attempt cap, assigns the first worker profile in code', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    store.recordFailure(t.id, 'a1');
+    store.recordFailure(t.id, 'a2'); // consecutiveFailures = 2 == cap
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => (spawned++, 1),
+      config: { ...baseConfig, autoAssign: true },
+      prepareWorkspaceFn: () => '/tmp/ws',
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(spawned).toBe(0);
+    expect(store.getTask(t.id)?.assignee).toBe('alpha');
+    store.close();
+  });
+
+  it('is a no-op when autoAssign is off', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoAssign: false },
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(store.getTask(t.id)?.assignee).toBeNull();
+    expect(store.getTask(t.id)?.status).toBe('ready');
+    store.close();
+  });
+
+  it('is a no-op when no worker profiles exist', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoAssign: true },
+      workerProfileNames: () => []
+    });
+    disp.autoAssign();
+    expect(store.getTask(t.id)?.assignee).toBeNull();
+    store.close();
+  });
+
+  it('reclaim returns a dead assign run to the unassigned ready pool', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    store.claimForAssign(t.id, 'L', 100); // expires 1100
+    store.startRun(t.id, 'orchestrator', 9999, 'assign');
+    clock.t = 2000; // claim expired
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig }
+    });
+    disp.reclaim();
+    const got = store.getTask(t.id);
+    expect(got?.status).toBe('ready');
+    expect(got?.assignee).toBeNull();
+    store.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts -t "autoAssign"`
+Expected: FAIL — `disp.autoAssign is not a function` and the reclaim-assign case lands in `triage` not `ready`.
+
+- [ ] **Step 3: Add the attempt-cap constant**
+
+In `src/main/kanban/kanban-dispatcher.ts`, near the other top-level consts (after line 12):
+
+```typescript
+/** Assign runs attempted before the dispatcher falls back to the default worker profile. */
+const ASSIGN_ATTEMPT_CAP = 2;
+```
+
+- [ ] **Step 4: Add the `workerProfileNames` dep**
+
+In `src/main/kanban/kanban-dispatcher.ts`, in the `DispatcherDeps` interface (after `clearWorkerExit`, ~line 63):
+
+```typescript
+  clearWorkerExit?: (runId: number) => void;
+  // Worker-role profile names (in profile order), for the auto-assign fast path and fallback.
+  workerProfileNames?: () => string[];
+```
+
+- [ ] **Step 5: Route reclaimed assign runs back to ready**
+
+In `src/main/kanban/kanban-dispatcher.ts`, in `reclaim()`, replace the mode-routing block (currently lines 147-149):
+
+```typescript
+        const mode = task.currentRunId != null ? this.store.runMode(task.currentRunId) : 'work';
+        if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
+        else this.store.returnToReady(task.id);
+```
+
+with:
+
+```typescript
+        const mode = task.currentRunId != null ? this.store.runMode(task.currentRunId) : 'work';
+        // An assign run died: return the task to the unassigned ready pool so autoAssign
+        // retries or falls back (decompose/specify go back to triage instead).
+        if (mode === 'assign') this.store.returnToReady(task.id);
+        else if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
+        else this.store.returnToReady(task.id);
+```
+
+- [ ] **Step 6: Implement `autoAssign()`**
+
+In `src/main/kanban/kanban-dispatcher.ts`, add this method immediately after `decompose()` (ends ~line 277):
+
+```typescript
+  /**
+   * Assign unassigned `ready` tasks so they don't stall (claimAndSpawn ignores
+   * tasks with no assignee). Exactly one worker profile, or a task past the
+   * attempt cap, is assigned deterministically in code; otherwise an orchestrator
+   * `assign` run picks the best-matching profile. Gated on `autoAssign`.
+   */
+  autoAssign(): void {
+    if (!this.deps.config.autoAssign) return;
+    const workerNames = this.deps.workerProfileNames?.() ?? [];
+    if (workerNames.length === 0) return; // nothing to assign to
+    let slots = this.deps.config.maxDecompose - this.store.orchestratorRunningCount();
+    const ttl = this.deps.config.claimTtlMs;
+
+    for (const task of this.store.unassignedReadyTasks()) {
+      // Deterministic assignment: a lone profile, or a task that has burned the
+      // attempt cap. No run needed.
+      if (workerNames.length === 1 || task.consecutiveFailures >= ASSIGN_ATTEMPT_CAP) {
+        const name = workerNames[0];
+        const by = workerNames.length === 1 ? 'single-profile' : 'fallback';
+        this.store.updateTask(task.id, { assignee: name });
+        this.store.appendEvent(task.id, null, 'assigned', { assignee: name, by });
+        if (by === 'fallback') {
+          this.store.addComment(
+            task.id,
+            'dispatcher',
+            `Auto-assigned ${name} after ${task.consecutiveFailures} failed assignment attempt(s).`
+          );
+        }
+        continue;
+      }
+
+      // Otherwise pick via an orchestrator assign run (bounded by the orchestrator budget).
+      if (slots <= 0) break;
+      const lock = this.nextLock();
+      if (!this.store.claimForAssign(task.id, lock, ttl)) continue; // lost the race
+      let runId: number | null = null;
+      try {
+        const workspace = this.deps.prepareWorkspaceFn
+          ? this.deps.prepareWorkspaceFn(task)
+          : (task.workspacePath ?? '');
+        const run = this.store.startRun(task.id, 'orchestrator', null, 'assign');
+        runId = run.id;
+        const pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode: 'assign' });
+        if (pid != null) this.store.setWorkerPid(task.id, run.id, pid);
+        this.store.appendEvent(task.id, run.id, 'spawned', { mode: 'assign' });
+        slots -= 1;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.store.recordFailure(task.id, msg);
+        if (runId != null) this.store.finishRun(runId, 'spawn_failed', { error: msg });
+        this.store.appendEvent(task.id, runId, 'spawn_failed', { error: msg });
+        this.store.returnToReady(task.id); // back to the unassigned ready pool
+        log.error('assign spawn failed', { taskId: task.id, error: msg });
+      }
+    }
+  }
+```
+
+- [ ] **Step 7: Call it in the tick**
+
+In `src/main/kanban/kanban-dispatcher.ts`, in `tick()` (~line 330), insert `this.autoAssign();` between `decompose()` and `promote()`:
+
+```typescript
+  tick(): void {
+    this.reclaim();
+    this.fireSchedules();
+    this.decompose();
+    this.autoAssign();
+    this.promote();
+    this.claimAndSpawn();
+    this.sweepArtifacts();
+    this.sweepMergedWorktrees();
+  }
+```
+
+- [ ] **Step 8: Run the dispatcher tests**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts`
+Expected: PASS (new `autoAssign` block + all existing tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/kanban/kanban-dispatcher.ts src/main/__tests__/kanban-dispatcher.test.ts
+git commit -m "feat(kanban): autoAssign dispatcher stage with fallback and reclaim routing"
+```
+
+---
+
+### Task 6: Wire `assign` mode + `workerProfileNames` into the real spawn path
+
+**Files:**
+- Modify: `src/main/index.ts:861-963` (dispatcher deps + `spawnWorker`)
+
+- [ ] **Step 1: Provide `workerProfileNames` to the dispatcher**
+
+In `src/main/index.ts`, in the `new KanbanDispatcher(kanbanStore, { ... })` deps object, add (e.g. right after `now: Date.now,` ~line 862):
+
+```typescript
+    now: Date.now,
+    workerProfileNames: () =>
+      settingsStore
+        .get()
+        .kanban.profiles.filter((p) => p.role === 'worker')
+        .map((p) => p.name),
+```
+
+- [ ] **Step 2: Don't overwrite the assignee on an assign run**
+
+In `src/main/index.ts`, in the `spawnWorker` dep, the non-`work` branch currently always writes `assignee` (line 962). Guard it so `assign` runs leave the assignee untouched (the run's whole job is to set it). Replace line 962:
+
+```typescript
+        kanbanStore!.updateTask(task.id, { assignee: profile?.name ?? 'orchestrator' });
+```
+
+with:
+
+```typescript
+        // decompose/specify record the orchestrator as the card's assignee; an assign run
+        // must not — it exists precisely to choose and set the real assignee itself.
+        if (mode !== 'assign') {
+          kanbanStore!.updateTask(task.id, { assignee: profile?.name ?? 'orchestrator' });
+        }
+```
+
+(The roster + orchestrator-profile selection in the same `else` branch already apply to `assign`, which is what `kanban_assign`'s prompt needs.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/index.ts
+git commit -m "feat(kanban): wire assign mode and worker roster into the spawn path"
+```
+
+---
+
+### Task 7: Settings UI toggle
+
+**Files:**
+- Modify: `src/renderer/src/components/settings/kanban/KanbanSection.tsx:102-127`
+
+- [ ] **Step 1: Add the toggle**
+
+In `src/renderer/src/components/settings/kanban/KanbanSection.tsx`, after the "Auto-decompose triage tasks" `SettingRow` (ends ~line 111), add:
+
+```tsx
+        <SettingRow label="Auto-assign unassigned tasks">
+          <input
+            type="checkbox"
+            checked={k.dispatcher.autoAssign}
+            onChange={(e) =>
+              patch({ dispatcher: { ...k.dispatcher, autoAssign: e.target.checked } })
+            }
+            className="h-4 w-4"
+          />
+        </SettingRow>
+```
+
+- [ ] **Step 2: Typecheck (web)**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/settings/kanban/KanbanSection.tsx
+git commit -m "feat(kanban): settings toggle for auto-assignment"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (both `typecheck:node` and `typecheck:web`).
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: No **new** errors from the changed files. (Repo lint is pre-existing-red in places; verify the files this plan touched are clean — no `as` casts, no eslint-disable.)
+
+- [ ] **Step 3: Run the full kanban test suite**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts src/main/__tests__/kanban-dispatcher.test.ts src/main/__tests__/kanban-mcp-server.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: SUCCESS.
+
+- [ ] **Step 5: Final confirmation**
+
+All green → the autopilot phase-1 (auto-assignment) is complete. Manual smoke (optional, not in CI): create an unassigned task directly in `ready`; within a few ticks it gains an assignee and is claimed.
+
+---
+
+## Self-Review
+
+**Spec coverage (§5):**
+- Trigger / dispatcher stage → Task 5 `autoAssign()` + tick wiring. ✓
+- Fast path (single profile, in code, `assigned` event) → Task 5, asserted. ✓
+- LLM path (orchestrator `assign` run, roster prompt, terminal `kanban_assign`) → Tasks 3, 4, 5, 6. ✓
+- `kanban_assign` phantom-profile guard → Task 4, asserted. ✓
+- After assignment → ready, claimed next tick → Task 4 (`returnToReady`) + existing `claimAndSpawn`. ✓
+- Fallback (cap reached or no orchestrator profile) → Task 5 (`ASSIGN_ATTEMPT_CAP`, first-worker assign + comment); "no worker profile" → no-op (documented; nothing to assign to). ✓
+- `autoAssign` setting default on → Tasks 1, 7. ✓
+- `readyTasks()`'s `assignee IS NOT NULL` filter stays → untouched. ✓
+
+**Deviations (documented in header):** `PendingMode='assign'` not added (claim is a direct CAS, single-tick); no schema migration (reuses `mode`/`consecutive_failures` columns). The §5 line about "no orchestrator-capable profile → default worker" reduces here to: if there are zero worker profiles, skip (there is nothing to assign); if there are worker profiles but no orchestrator, the LLM path still spawns and `spawn-worker` falls back per its existing logic — the attempt cap then forces the deterministic fallback. Acceptable and bounded.
+
+**Type consistency:** `RunMode='assign'` is used identically across `kanban-types.ts`, `spawn-worker.ts` (`buildPrompt`, `requireToolsForMode`), `kanban-mcp-server.ts` (`toolsForMode`), `kanban-dispatcher.ts` (`startRun(..., 'assign')`, reclaim), and `index.ts`. `autoAssign` field name matches across `KanbanSettings`, `DEFAULT_SETTINGS`, `DispatcherConfig`, `buildDispatcherConfig`, tests, and UI. Store methods `unassignedReadyTasks()` / `claimForAssign()` named consistently in store, dispatcher, and tests.
+
+**Placeholder scan:** none — every step has concrete code and an exact command.

--- a/docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md
+++ b/docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md
@@ -1,0 +1,233 @@
+# Kanban Integration Autopilot
+
+**Date:** 2026-06-10
+**Status:** Approved design
+
+## Problem
+
+The kanban board automates execution but not integration. Today the human must:
+
+- Manually prompt a task to fix merge conflicts when a merge fails.
+- Manually merge each finished worktree task, one review click at a time.
+- Manually create a feature, assign every related ticket to it, and ship the PR.
+- Manually assign a worker profile to every task — an unassigned `ready` task
+  stalls silently forever (`readyTasks()` filters `assignee IS NOT NULL`,
+  `kanban-store.ts:1022`, and nothing reacts to the leftover).
+
+This spec adds an integration autopilot: deterministic git automation in the
+dispatcher, with LLM runs only where judgment is required (conflict resolution,
+profile matching, grouping suggestions).
+
+## Goals
+
+- Tasks in a feature flow automatically: complete → merge into the feature's
+  integration branch → draft PR → ready PR when the feature is done.
+- Merge conflicts are resolved by an agent automatically, with a bounded retry
+  budget and a human escape hatch.
+- Decompositions always produce a feature; related loose tickets are grouped
+  via confirmed suggestions.
+- Unassigned tasks are auto-assigned to the best-matching worker profile.
+
+## Non-goals
+
+- Auto-merging the feature PR into main (human merges the PR on GitHub).
+- Rewriting history: no force-push, no rebase of pushed branches — merges only.
+- Proactively rebasing worktrees of *running* siblings; staleness is handled at
+  each task's own merge time.
+- Per-feature automation overrides (global settings only, for now).
+
+## Architecture
+
+All automation lives in the existing `KanbanDispatcher` tick (sync, atomic,
+~5s), plus new worker run modes following the established
+`decompose`/`specify` pattern. No new background services.
+
+```
+Dispatcher tick:
+  1. reclaim                      (existing)
+  2. fireSchedules                (existing)
+  3. decompose                    (existing)
+  4. autoAssign                   (new) — flag + spawn assign runs
+  5. promote                      (existing)
+  6. claimAndSpawn                (existing)
+  7. integrate                    (new) — feature merges, resolve runs, PR lifecycle
+  8. sweepArtifacts / worktrees   (existing)
+```
+
+## 1. `integrate()` dispatcher stage
+
+Gated on a new global `autoIntegrate` setting (default **on**).
+
+For each task in `review` with a `featureId`, `workspaceKind='worktree'`, and
+no resolve run in flight:
+
+1. `ensureFeatureBranch()` (existing) — integration branch exists.
+2. `checkMergeConflicts()` (existing) dry-run against the integration branch.
+3. **Clean** → `mergeWorktreeToBase()` targeting the integration branch →
+   task `done`, worktree pruned, feature branch pushed, draft PR ensured
+   (section 3). `resolve_attempts` reset to 0.
+4. **Conflict** → spawn a resolve run (section 2), or block + notify past the
+   attempt cap.
+
+Feature completion check: when every member task of an `active` feature is
+`done`/`archived` and at least one task merged work into the integration
+branch:
+
+1. `updateIntegrationBranchFromMain()` (existing) — sync with main.
+2. **Clean** → push, `gh pr ready`, notify, set feature `mergeState`.
+3. **Conflict** → create a sync-resolve task (section 2).
+
+Standalone worktree tasks (no feature) keep the human review column unchanged.
+One behavior change: when a manual "Merge to base" hits a conflict, the
+dispatcher now spawns a resolve run instead of only commenting.
+
+Git operations run serially within the tick (they are already synchronous);
+each integrate pass bounds work per tick (e.g. max 3 merges) so the tick stays
+fast.
+
+## 2. `resolve` run mode
+
+New `RunMode` value `'resolve'`, spawned via the existing orchestrator-run
+machinery (claim, lease, heartbeat, reclaim all reused).
+
+- **Workspace:** the task's existing worktree.
+- **Prompt:** "Merge `<target branch>` into your branch. Resolve all conflicts
+  preserving the intent of both sides. Verify (typecheck/build per board
+  docs). Commit. Call `kanban_complete`."
+- **Tools:** `kanban_show`, `kanban_comment`, `kanban_heartbeat`,
+  `kanban_complete`, `kanban_block`.
+- **On complete:** task returns to `review`; the next `integrate()` pass
+  retries the merge.
+- **Budget:** new `resolve_attempts` column, incremented per spawned resolve
+  run, capped at 2. Past the cap the task moves to `blocked` with a
+  notification. Reset on successful merge.
+
+**Feature-sync conflicts** (no task worktree exists for the integration
+branch): the dispatcher creates a visible system task — *"Sync `<feature>`
+with main"* — whose worktree checks out the integration branch itself,
+dispatched in resolve mode with the target `baseBranch`. On completion the
+feature-ready flow retries. This reuses the whole worker pipeline rather than
+inventing a second execution path. The task carries the `featureId` and is
+excluded from the feature's own completion roll-up (it would otherwise gate
+itself); exclusion key: new column `tasks.system_kind`
+(`'feature_sync' | NULL`) — roll-ups and completion checks skip rows where it
+is non-null.
+
+## 3. Draft PR lifecycle
+
+- First successful merge into a feature branch → push `fleet/feature-<id>` and
+  `gh pr create --draft` (extend existing `createFeaturePr()` with a draft
+  flag). PR URL/number stored on the feature (existing columns).
+- Subsequent merges → push only; the PR updates itself. `PrPoller` (existing)
+  keeps `prState`/`checksState` fresh.
+- All member tasks done + clean sync → `gh pr ready <number>` + notification.
+- Manual **Ship** button remains as an override at any point.
+- No `gh` / no remote: skip PR steps and post one deduped feature event
+  (tracked via a feature-level flag) — never a comment per tick.
+
+## 4. Auto-grouping into features
+
+**At decompose (deterministic, in code):** when a decompose run completes
+having created ≥2 worktree children and no feature, the dispatcher/commands
+layer creates a feature named after the parent task and assigns parent +
+children to it. This does not rely on the orchestrator prompt remembering
+`kanban_feature_create`.
+
+**Loose-ticket detection (PM, suggestion-gated):**
+
+- Heuristic gate in the dispatcher: ≥2 ungrouped worktree tasks sharing a
+  `repoPath` in `todo`/`ready`, and no pending suggestion for that repo.
+  Debounced (one detection run per repo per cooldown window).
+- Spawns one PM run that judges relatedness and may call a new tool
+  `kanban_suggest_feature(name, task_ids, reason)`.
+- Suggestions persist in a new `feature_suggestions` table:
+  `id, board_id, name, task_ids (JSON), reason, status
+  ('pending'|'accepted'|'dismissed'), created_at`.
+- UI: board banner listing pending suggestions with **Accept** (creates the
+  feature, assigns the tasks) and **Dismiss**. Nothing regroups without a
+  click.
+
+## 5. Auto-assignment
+
+Fixes the silent-stall gap for unassigned tasks.
+
+- **Trigger:** dispatcher stage `autoAssign()` flags unassigned `ready` tasks
+  with `pending_mode='assign'` (new `PendingMode` value).
+- **Fast path:** if exactly one worker profile exists, set it directly in code
+  (no LLM run) and append an `assigned` event.
+- **LLM path:** spawn an orchestrator run in new mode `'assign'`. The prompt
+  contains the task and the worker-profile roster (names + descriptions +
+  instructions). Terminal tool: new `kanban_assign(profile)` — sets the
+  assignee with the same phantom-profile guard as `kanban_create`, ends the
+  run. Side tools: `kanban_show`, `kanban_comment`, `kanban_heartbeat`.
+- **After assignment:** task returns to `ready`; the normal `claimAndSpawn()`
+  picks it up next tick.
+- **Fallback:** if the assign run fails twice (reusing the
+  decompose-style failure handling) or no orchestrator-capable profile
+  exists, assign the default worker profile (the same fallback
+  `resolveWorkProfile()` already encodes) and comment why.
+- **Gate:** new `autoAssign` setting, default **on** (unlike `autoDecompose`,
+  this repairs a dead-end rather than changing workflow shape).
+
+`readyTasks()`'s `assignee IS NOT NULL` filter stays — it is what keeps the
+assign stage and the claim stage from racing.
+
+## 6. Settings & guardrails
+
+New kanban settings (with existing dispatcher settings):
+
+| Setting | Default | Effect |
+|---|---|---|
+| `autoIntegrate` | on | enables the `integrate()` stage |
+| `autoAssign` | on | enables the `autoAssign()` stage |
+
+Hard guardrails, not configurable:
+
+- Merges only; never force-push, never rewrite shared history.
+- Resolve attempts capped at 2 → `blocked` + notification.
+- All git ops best-effort: failures append comments/events (existing
+  pattern), never throw out of the tick.
+- Every automated action appends a task/feature event, so the audit trail
+  stays complete.
+
+## 7. UI
+
+- Card/drawer badge for resolve and assign runs (e.g. "resolving conflicts —
+  attempt 1/2"), driven by run mode + events already streamed to the board.
+- `FeaturePrRollup`: show draft vs ready PR state; Ship button unchanged.
+- Board banner for pending feature suggestions (Accept / Dismiss).
+- Integration events (auto-merged, PR drafted, PR ready, resolve spawned)
+  appear in the task comment/event thread.
+
+## 8. Data model changes
+
+- `tasks.resolve_attempts` (INTEGER, default 0).
+- `tasks.system_kind` (TEXT, `'feature_sync' | NULL`) — system tasks excluded
+  from feature roll-ups.
+- `PendingMode` gains `'assign'`; `RunMode` gains `'resolve'` and `'assign'`.
+- New table `feature_suggestions` (section 4).
+- Feature-level flag for the deduped "PR skipped: no remote/gh" event.
+- Additive migration via existing `addColumnIfMissing` pattern (schema v11).
+
+## 9. Testing
+
+Vitest unit tests, following the existing dispatcher test style (mocked store
+deps / workspace fns):
+
+- `integrate()`: clean merge → done + prune + PR ensured; conflict → resolve
+  spawn; attempt cap → blocked + notification; all-done feature → sync + PR
+  ready; sync conflict → system sync task; `autoIntegrate` off → no-op.
+- `resolve` mode: complete → back to `review`; attempts increment/reset.
+- `autoAssign()`: single-profile fast path; LLM path spawn; fallback to
+  default profile; `autoAssign` off → no-op; `kanban_assign` rejects unknown
+  profiles.
+- Auto-grouping: decompose with ≥2 worktree children and no feature → feature
+  created; suggestion accept/dismiss state transitions.
+- Manual merge conflict → resolve run spawned (standalone task path).
+
+## Implementation phasing
+
+1. **Auto-assignment** (standalone, unblocks daily use immediately).
+2. **`integrate()` + `resolve` mode** (feature auto-merge + conflict agent).
+3. **Draft PR lifecycle** (extends 2).
+4. **Auto-grouping** (decompose enforcement, then PM suggestions + UI).

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -23,6 +23,7 @@ function makeCommands(): { store: KanbanStore; commands: KanbanCommands } {
       maxInProgress: 3,
       claimTtlMs: 1000,
       autoDecompose: false,
+      autoAssign: false,
       maxDecompose: 1,
       artifactRetentionDays: 0
     }
@@ -272,6 +273,7 @@ describe('KanbanCommands comment/link/log/dispatch', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -306,6 +308,7 @@ describe('KanbanCommands replyAndResume', () => {
         maxInProgress: 0,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 0,
         artifactRetentionDays: 0
       }
@@ -613,6 +616,7 @@ describe('KanbanCommands.createSwarm', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -34,6 +34,7 @@ describe('KanbanDispatcher.reclaim', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -62,6 +63,7 @@ describe('KanbanDispatcher.reclaim', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -202,6 +204,7 @@ describe('KanbanDispatcher.reclaim', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -232,6 +235,7 @@ describe('KanbanDispatcher.promote', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -257,6 +261,7 @@ describe('KanbanDispatcher.promote', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -289,6 +294,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -325,6 +331,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         maxInProgress: 2,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -351,6 +358,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -373,6 +381,7 @@ const baseConfig = {
   maxInProgress: 3,
   claimTtlMs: 1000,
   autoDecompose: false,
+  autoAssign: false,
   maxDecompose: 1,
   artifactRetentionDays: 0
 };
@@ -516,6 +525,7 @@ describe('KanbanDispatcher.fireSchedules', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -606,6 +616,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         maxInProgress: 1,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -620,6 +631,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -641,6 +653,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         maxInProgress: 1,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       };
@@ -688,6 +701,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           maxInProgress: 1,
           claimTtlMs: 1000,
           autoDecompose: false,
+          autoAssign: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },
@@ -700,6 +714,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           maxInProgress: 2,
           claimTtlMs: 1000,
           autoDecompose: false,
+          autoAssign: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -588,6 +588,8 @@ describe('KanbanDispatcher.autoAssign', () => {
     disp.autoAssign();
     expect(spawned).toBe(0);
     expect(store.getTask(t.id)?.assignee).toBe('alpha');
+    // Assign-phase failures must be cleared so the work phase starts with a clean slate.
+    expect(store.getTask(t.id)?.consecutiveFailures).toBe(0);
     store.close();
   });
 

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -507,6 +507,116 @@ describe('KanbanDispatcher.decompose', () => {
   });
 });
 
+describe('KanbanDispatcher.autoAssign', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('fast-path: a single worker profile is assigned in code, no run spawned', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => (spawned++, 1),
+      config: { ...baseConfig, autoAssign: true },
+      workerProfileNames: () => ['solo']
+    });
+    disp.autoAssign();
+    expect(spawned).toBe(0);
+    expect(store.getTask(t.id)?.assignee).toBe('solo');
+    expect(store.getTask(t.id)?.status).toBe('ready');
+    store.close();
+  });
+
+  it('LLM path: with multiple profiles it spawns an assign run', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const spawned: Array<{ id: string; mode: string }> = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => { spawned.push({ id: args.task.id, mode: args.mode }); return 4242; },
+      config: { ...baseConfig, autoAssign: true },
+      prepareWorkspaceFn: () => '/tmp/ws',
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(spawned).toEqual([{ id: t.id, mode: 'assign' }]);
+    expect(store.getTask(t.id)?.status).toBe('running');
+    store.close();
+  });
+
+  it('fallback: after the attempt cap, assigns the first worker profile in code', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    store.recordFailure(t.id, 'a1');
+    store.recordFailure(t.id, 'a2'); // consecutiveFailures = 2 == cap
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true,
+      spawnWorker: () => (spawned++, 1),
+      config: { ...baseConfig, autoAssign: true },
+      prepareWorkspaceFn: () => '/tmp/ws',
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(spawned).toBe(0);
+    expect(store.getTask(t.id)?.assignee).toBe('alpha');
+    store.close();
+  });
+
+  it('is a no-op when autoAssign is off', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      config: { ...baseConfig, autoAssign: false },
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(store.getTask(t.id)?.assignee).toBeNull();
+    expect(store.getTask(t.id)?.status).toBe('ready');
+    store.close();
+  });
+
+  it('is a no-op when no worker profiles exist', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      config: { ...baseConfig, autoAssign: true },
+      workerProfileNames: () => []
+    });
+    disp.autoAssign();
+    expect(store.getTask(t.id)?.assignee).toBeNull();
+    store.close();
+  });
+
+  it('reclaim returns a dead assign run to the unassigned ready pool', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    store.claimForAssign(t.id, 'L', 100); // expires 1100
+    store.startRun(t.id, 'orchestrator', 9999, 'assign');
+    clock.t = 2000; // claim expired
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      config: { ...baseConfig }
+    });
+    disp.reclaim();
+    const got = store.getTask(t.id);
+    expect(got?.status).toBe('ready');
+    expect(got?.assignee).toBeNull();
+    store.close();
+  });
+});
+
 describe('KanbanDispatcher.fireSchedules', () => {
   beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
   afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -546,6 +546,28 @@ describe('KanbanDispatcher.autoAssign', () => {
     disp.autoAssign();
     expect(spawned).toEqual([{ id: t.id, mode: 'assign' }]);
     expect(store.getTask(t.id)?.status).toBe('running');
+    expect(store.getTask(t.id)?.assignee).toBeNull();
+    store.close();
+  });
+
+  it('LLM path: stays below the cap (failures = cap - 1) so it spawns an assign run', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    store.recordFailure(t.id, 'a1'); // consecutiveFailures = 1 < cap (2)
+    const spawned: Array<{ id: string; mode: string }> = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => { spawned.push({ id: args.task.id, mode: args.mode }); return 4242; },
+      config: { ...baseConfig, autoAssign: true },
+      prepareWorkspaceFn: () => '/tmp/ws',
+      workerProfileNames: () => ['alpha', 'beta']
+    });
+    disp.autoAssign();
+    expect(spawned).toEqual([{ id: t.id, mode: 'assign' }]);
+    expect(store.getTask(t.id)?.status).toBe('running');
+    expect(store.getTask(t.id)?.assignee).toBeNull();
     store.close();
   });
 

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -449,6 +449,41 @@ describe('KanbanMcpServer', () => {
     expect(r.error).toBeTruthy();
     expect(String(r.error.message)).toMatch(/not a swarm root/i);
   });
+
+  it('kanban_assign sets the assignee, returns to ready, and rejects unknown profiles', async () => {
+    const profiles = () => [
+      { name: 'alpha', role: 'worker' as const },
+      { name: 'beta', role: 'worker' as const }
+    ];
+    const s2 = new KanbanMcpServer(store, profiles);
+    const port2 = await s2.start(0);
+    const base2 = `http://127.0.0.1:${port2}/mcp`;
+    try {
+      const t = store.createTask({ title: 'needs owner', status: 'ready' });
+      store.claimForAssign(t.id, 'LOCK', 100000);
+      const run = store.startRun(t.id, 'orchestrator', 1, 'assign');
+      s2.registerRun('atok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'assign' }, 'LOCK');
+
+      const bad = await rpc(`${base2}?run=atok`, 'tools/call', {
+        name: 'kanban_assign',
+        arguments: { profile: 'ghost' }
+      });
+      expect(String(bad.error?.message ?? bad.result?.content?.[0]?.text)).toMatch(/unknown worker profile/i);
+      expect(store.getTask(t.id)?.assignee).toBeNull();
+
+      const ok = await rpc(`${base2}?run=atok`, 'tools/call', {
+        name: 'kanban_assign',
+        arguments: { profile: 'alpha' }
+      });
+      expect(ok.result.content[0].text).toMatch(/alpha/i);
+      const got = store.getTask(t.id);
+      expect(got?.assignee).toBe('alpha');
+      expect(got?.status).toBe('ready');
+      expect(store.listRuns(t.id)[0].outcome).toBe('completed');
+    } finally {
+      await s2.stop();
+    }
+  });
 });
 
 describe('KanbanMcpServer board scope (PM chat)', () => {

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -470,6 +470,7 @@ describe('KanbanMcpServer board scope (PM chat)', () => {
         maxInProgress: 3,
         claimTtlMs: 1000,
         autoDecompose: false,
+        autoAssign: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -471,6 +471,9 @@ describe('KanbanMcpServer', () => {
       expect(String(bad.error?.message ?? bad.result?.content?.[0]?.text)).toMatch(/unknown worker profile/i);
       expect(store.getTask(t.id)?.assignee).toBeNull();
 
+      // Simulate a prior assign-phase failure so we can verify it's cleared on success.
+      store.recordFailure(t.id, 'prior assign failure');
+
       const ok = await rpc(`${base2}?run=atok`, 'tools/call', {
         name: 'kanban_assign',
         arguments: { profile: 'alpha' }
@@ -480,6 +483,8 @@ describe('KanbanMcpServer', () => {
       expect(got?.assignee).toBe('alpha');
       expect(got?.status).toBe('ready');
       expect(store.listRuns(t.id)[0].outcome).toBe('completed');
+      // Assign-phase failures must not carry into the work phase's retry budget.
+      expect(got?.consecutiveFailures).toBe(0);
 
       // Terminal: the run token must be unregistered after a successful assign.
       const after = await rpc(`${base2}?run=atok`, 'tools/call', {

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -480,6 +480,14 @@ describe('KanbanMcpServer', () => {
       expect(got?.assignee).toBe('alpha');
       expect(got?.status).toBe('ready');
       expect(store.listRuns(t.id)[0].outcome).toBe('completed');
+
+      // Terminal: the run token must be unregistered after a successful assign.
+      const after = await rpc(`${base2}?run=atok`, 'tools/call', {
+        name: 'kanban_assign',
+        arguments: { profile: 'alpha' }
+      });
+      expect(after.error).toBeTruthy();
+      expect(String(after.error.message)).toMatch(/run token/i);
     } finally {
       await s2.stop();
     }

--- a/src/main/__tests__/kanban-spawn-worker.test.ts
+++ b/src/main/__tests__/kanban-spawn-worker.test.ts
@@ -338,6 +338,26 @@ describe('buildWorkerInvocation', () => {
     expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_update');
   });
 
+  it('builds an assign prompt with the worker roster and passes --require-tool kanban_assign', () => {
+    const workspace = join(ROOT, 'wsassign');
+    mkdirSync(workspace, { recursive: true });
+    const inv = buildWorkerInvocation({
+      task: { id: 'ta', title: 'pick worker', body: 'needs routing', assignee: null, modelOverride: null },
+      workspace,
+      mcpPort: 1234,
+      runToken: 'tok',
+      logPath: join(ROOT, 'a.log'),
+      mode: 'assign',
+      roster: [{ name: 'coder', description: 'writes code' }]
+    });
+    const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
+    expect(prompt).toMatch(/^assign kanban task ta/);
+    expect(prompt).toContain('coder: writes code');
+    expect(prompt).toContain('kanban_assign');
+    expect(prompt).toMatch(/do not do the work yourself/i);
+    expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_assign');
+  });
+
   it('does not include attachments in decompose mode', () => {
     const workspace = join(ROOT, 'wsc');
     mkdirSync(workspace, { recursive: true });

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -371,6 +371,22 @@ describe('KanbanStore', () => {
     expect(store.claimForDecompose(t.id, 'L2', 1000)).toBe(false);
   });
 
+  it('unassignedReadyTasks returns only ready tasks with no assignee', () => {
+    const a = store.createTask({ title: 'unassigned', status: 'ready' });
+    store.createTask({ title: 'assigned', status: 'ready', assignee: 'w' });
+    store.createTask({ title: 'todo', status: 'todo' });
+    const got = store.unassignedReadyTasks().map((t) => t.id);
+    expect(got).toEqual([a.id]);
+  });
+
+  it('claimForAssign atomically moves ready+unassigned to running', () => {
+    const t = store.createTask({ title: 'x', status: 'ready' });
+    expect(store.claimForAssign(t.id, 'L', 1000)).toBe(true);
+    expect(store.getTask(t.id)?.status).toBe('running');
+    // a second claim loses (no longer ready+unassigned)
+    expect(store.claimForAssign(t.id, 'L2', 1000)).toBe(false);
+  });
+
   it('startRun records the run mode', () => {
     const t = store.createTask({ title: 'x', status: 'triage' });
     const run = store.startRun(t.id, 'orchestrator', null, 'decompose');

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -387,6 +387,20 @@ describe('KanbanStore', () => {
     expect(store.claimForAssign(t.id, 'L2', 1000)).toBe(false);
   });
 
+  it('claimForAssign re-claims an unassigned ready task whose claim has expired', () => {
+    let clock = 1000;
+    const s = new KanbanStore(join(TEST_DIR, 'assign-claim.db'), { now: () => clock });
+    const t = s.createTask({ title: 'x', status: 'ready' });
+    expect(s.claimForAssign(t.id, 'lock-A', 100)).toBe(true); // expires at 1100
+    // Put the row back to ready+unassigned but KEEP the live lease, so the ONLY thing
+    // blocking a second claim is the unexpired lock.
+    s.setStatus(t.id, 'ready');
+    expect(s.claimForAssign(t.id, 'lock-B', 100)).toBe(false); // still leased
+    clock = 1200; // past expiry
+    expect(s.claimForAssign(t.id, 'lock-B', 100)).toBe(true); // lease expired → re-claimable
+    s.close();
+  });
+
   it('startRun records the run mode', () => {
     const t = store.createTask({ title: 'x', status: 'triage' });
     const run = store.startRun(t.id, 'orchestrator', null, 'decompose');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -861,6 +861,11 @@ void app.whenReady().then(async () => {
   };
   kanbanDispatcher = new KanbanDispatcher(kanbanStore, {
     now: Date.now,
+    workerProfileNames: () =>
+      settingsStore
+        .get()
+        .kanban.profiles.filter((p) => p.role === 'worker')
+        .map((p) => p.name),
     isAlive: (pid) => {
       try {
         process.kill(pid, 0);
@@ -960,7 +965,11 @@ void app.whenReady().then(async () => {
         // Record the orchestrator as the task's assignee so the triage card reflects who is
         // running it. The dispatcher never sets this for decompose/specify runs (it only writes
         // task_runs.profile), leaving the card unassigned otherwise.
-        kanbanStore!.updateTask(task.id, { assignee: profile?.name ?? 'orchestrator' });
+        // decompose/specify record the orchestrator as the card's assignee; an assign run
+        // must not — it exists precisely to choose and set the real assignee itself.
+        if (mode !== 'assign') {
+          kanbanStore!.updateTask(task.id, { assignee: profile?.name ?? 'orchestrator' });
+        }
       }
       const logPath = join(KANBAN_HOME, 'logs', `${runToken}.log`);
       const spawnedAt = Date.now();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -854,6 +854,7 @@ void app.whenReady().then(async () => {
       maxInProgress: d.maxInProgress,
       claimTtlMs: d.claimTtlMs,
       autoDecompose: d.autoDecompose,
+      autoAssign: d.autoAssign,
       maxDecompose: d.maxDecompose,
       artifactRetentionDays: settingsStore.get().kanban.artifactRetentionDays
     };

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -19,7 +19,11 @@ const WORKTREE_SWEEP_INTERVAL_MS = 300_000;
  */
 const REVIEW_REQUIRED_EXIT_CODE = 3;
 
-/** Assign runs attempted before the dispatcher falls back to the default worker profile. */
+/**
+ * Assign runs attempted before the dispatcher falls back to the default worker profile.
+ * MUST stay below the default failureLimit (3) so the deterministic fallback fires before
+ * a task is ever given up/blocked. At cap=2, failureLimit=3 this holds.
+ */
 const ASSIGN_ATTEMPT_CAP = 2;
 
 export interface SpawnWorkerArgs {
@@ -299,6 +303,8 @@ export class KanbanDispatcher {
         const name = workerNames[0];
         const by = workerNames.length === 1 ? 'single-profile' : 'fallback';
         this.store.updateTask(task.id, { assignee: name });
+        // assign phase done — reset failures so they don't eat the work phase's retry budget
+        this.store.clearFailures(task.id);
         this.store.appendEvent(task.id, null, 'assigned', { assignee: name, by });
         if (by === 'fallback') {
           this.store.addComment(

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -33,6 +33,7 @@ export interface DispatcherConfig {
   maxInProgress: number; // concurrency cap
   claimTtlMs: number; // claim lease length
   autoDecompose: boolean; // automatically arm triage tasks for decompose
+  autoAssign: boolean; // automatically assign unassigned ready tasks to a worker profile
   maxDecompose: number; // max concurrent orchestrator runs
   artifactRetentionDays: number; // auto-purge discarded artifacts older than this; 0 disables
 }

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -151,6 +151,8 @@ export class KanbanDispatcher {
         log.warn('task gave up', { taskId: task.id, failures });
       } else {
         const mode = task.currentRunId != null ? this.store.runMode(task.currentRunId) : 'work';
+        // assign is also a non-work orchestrator mode — this branch MUST stay before the
+        // generic non-work branch below, or a dead assign run would wrongly route to triage.
         if (mode === 'assign') this.store.returnToReady(task.id);
         else if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
         else this.store.returnToReady(task.id);
@@ -307,7 +309,9 @@ export class KanbanDispatcher {
         }
         continue;
       }
-      if (slots <= 0) break;
+      // Only the LLM-spawn path is bounded by orchestrator slots; skip (don't break)
+      // so later deterministic tasks still get assigned in code this tick.
+      if (slots <= 0) continue;
       const lock = this.nextLock();
       if (!this.store.claimForAssign(task.id, lock, ttl)) continue;
       let runId: number | null = null;

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -19,6 +19,9 @@ const WORKTREE_SWEEP_INTERVAL_MS = 300_000;
  */
 const REVIEW_REQUIRED_EXIT_CODE = 3;
 
+/** Assign runs attempted before the dispatcher falls back to the default worker profile. */
+const ASSIGN_ATTEMPT_CAP = 2;
+
 export interface SpawnWorkerArgs {
   task: Task;
   runId: number;
@@ -62,6 +65,8 @@ export interface DispatcherDeps {
   // from a crash. clearWorkerExit drops the entry once consumed.
   workerExit?: (runId: number) => WorkerExit | undefined;
   clearWorkerExit?: (runId: number) => void;
+  /** Worker-role profile names (in profile order), for the auto-assign fast path and fallback. */
+  workerProfileNames?: () => string[];
 }
 
 export class KanbanDispatcher {
@@ -146,7 +151,8 @@ export class KanbanDispatcher {
         log.warn('task gave up', { taskId: task.id, failures });
       } else {
         const mode = task.currentRunId != null ? this.store.runMode(task.currentRunId) : 'work';
-        if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
+        if (mode === 'assign') this.store.returnToReady(task.id);
+        else if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
         else this.store.returnToReady(task.id);
       }
     }
@@ -277,6 +283,55 @@ export class KanbanDispatcher {
     }
   }
 
+  /** Assign unassigned ready tasks to a worker profile, either in code (fast path / fallback)
+   *  or by spawning an orchestrator assign run (multi-profile LLM path). */
+  autoAssign(): void {
+    if (!this.deps.config.autoAssign) return;
+    const workerNames = this.deps.workerProfileNames?.() ?? [];
+    if (workerNames.length === 0) return;
+    let slots = this.deps.config.maxDecompose - this.store.orchestratorRunningCount();
+    const ttl = this.deps.config.claimTtlMs;
+
+    for (const task of this.store.unassignedReadyTasks()) {
+      if (workerNames.length === 1 || task.consecutiveFailures >= ASSIGN_ATTEMPT_CAP) {
+        const name = workerNames[0];
+        const by = workerNames.length === 1 ? 'single-profile' : 'fallback';
+        this.store.updateTask(task.id, { assignee: name });
+        this.store.appendEvent(task.id, null, 'assigned', { assignee: name, by });
+        if (by === 'fallback') {
+          this.store.addComment(
+            task.id,
+            'dispatcher',
+            `Auto-assigned ${name} after ${task.consecutiveFailures} failed assignment attempt(s).`
+          );
+        }
+        continue;
+      }
+      if (slots <= 0) break;
+      const lock = this.nextLock();
+      if (!this.store.claimForAssign(task.id, lock, ttl)) continue;
+      let runId: number | null = null;
+      try {
+        const workspace = this.deps.prepareWorkspaceFn
+          ? this.deps.prepareWorkspaceFn(task)
+          : (task.workspacePath ?? '');
+        const run = this.store.startRun(task.id, 'orchestrator', null, 'assign');
+        runId = run.id;
+        const pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode: 'assign' });
+        if (pid != null) this.store.setWorkerPid(task.id, run.id, pid);
+        this.store.appendEvent(task.id, run.id, 'spawned', { pid: pid ?? null, mode: 'assign' });
+        slots -= 1;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.store.recordFailure(task.id, msg);
+        if (runId != null) this.store.finishRun(runId, 'spawn_failed', { error: msg });
+        this.store.appendEvent(task.id, runId, 'spawn_failed', { error: msg });
+        this.store.returnToReady(task.id);
+        log.error('assign spawn failed', { taskId: task.id, error: msg });
+      }
+    }
+  }
+
   /** Purge discarded artifacts past the retention window; surface each deletion as an event. */
   sweepArtifacts(): void {
     const days = this.deps.config.artifactRetentionDays;
@@ -332,6 +387,7 @@ export class KanbanDispatcher {
     this.reclaim();
     this.fireSchedules();
     this.decompose();
+    this.autoAssign();
     this.promote();
     this.claimAndSpawn();
     this.sweepArtifacts();

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -229,6 +229,20 @@ const SPECIFY_TOOLS: McpTool[] = [
   ...WORKER_TOOLS.filter((t) => t.name === 'kanban_comment' || t.name === 'kanban_heartbeat')
 ];
 
+const ASSIGN_TOOLS: McpTool[] = [
+  ...WORKER_TOOLS.filter((t) => t.name === 'kanban_show'),
+  {
+    name: 'kanban_assign',
+    description: 'Assign this task to a worker profile by name. Terminal — ends the assign run.',
+    inputSchema: {
+      type: 'object',
+      properties: { profile: { type: 'string' } },
+      required: ['profile']
+    }
+  },
+  ...WORKER_TOOLS.filter((t) => t.name === 'kanban_comment' || t.name === 'kanban_heartbeat')
+];
+
 /** Statuses the PM may set — mirrors MANUAL_STATUSES (dispatcher owns `running`). */
 const PM_SETTABLE_STATUSES = [
   'triage',
@@ -408,6 +422,7 @@ const PM_TOOLS: McpTool[] = [
 function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'decompose') return DECOMPOSE_TOOLS;
   if (mode === 'specify') return SPECIFY_TOOLS;
+  if (mode === 'assign') return ASSIGN_TOOLS;
   return WORKER_TOOLS;
 }
 
@@ -973,6 +988,26 @@ export class KanbanMcpServer {
           this.store.appendEvent(task.id, scope.runId, 'blocked', { reason: a.reason });
           this.unregisterRun(token);
           return this.text(res, rpcReq.id, `Task ${task.id} blocked.`);
+        }
+        case 'kanban_assign': {
+          const a = z.object({ profile: z.string() }).parse(args);
+          const name = a.profile.trim();
+          const workerNames = this.getProfiles()
+            .filter((p) => p.role === 'worker')
+            .map((p) => p.name);
+          if (workerNames.length > 0 && !workerNames.includes(name)) {
+            return this.rpcError(
+              res,
+              rpcReq.id,
+              `unknown worker profile "${name}". Valid profiles: ${workerNames.join(', ')}`
+            );
+          }
+          this.store.updateTask(task.id, { assignee: name });
+          this.store.returnToReady(task.id);
+          this.store.finishRun(scope.runId, 'completed', { summary: `assigned ${name}` });
+          this.store.appendEvent(task.id, scope.runId, 'assigned', { assignee: name, by: 'orchestrator' });
+          this.unregisterRun(token);
+          return this.text(res, rpcReq.id, `Assigned ${name}.`);
         }
         case 'kanban_comment': {
           const a = z.object({ body: z.string() }).parse(args);

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -1006,6 +1006,8 @@ export class KanbanMcpServer {
             );
           }
           this.store.updateTask(task.id, { assignee: profile });
+          // assign phase done — reset failures so they don't eat the work phase's retry budget
+          this.store.clearFailures(task.id);
           this.store.returnToReady(task.id);
           this.store.finishRun(scope.runId, 'completed', { summary: `assigned ${profile}` });
           this.store.appendEvent(task.id, scope.runId, 'assigned', {

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -991,23 +991,29 @@ export class KanbanMcpServer {
         }
         case 'kanban_assign': {
           const a = z.object({ profile: z.string() }).parse(args);
-          const name = a.profile.trim();
+          const profile = a.profile.trim();
+          if (!profile) {
+            return this.rpcError(res, rpcReq.id, 'profile is required');
+          }
           const workerNames = this.getProfiles()
             .filter((p) => p.role === 'worker')
             .map((p) => p.name);
-          if (workerNames.length > 0 && !workerNames.includes(name)) {
+          if (workerNames.length > 0 && !workerNames.includes(profile)) {
             return this.rpcError(
               res,
               rpcReq.id,
-              `unknown worker profile "${name}". Valid profiles: ${workerNames.join(', ')}`
+              `unknown worker profile "${profile}". Valid profiles: ${workerNames.join(', ')}`
             );
           }
-          this.store.updateTask(task.id, { assignee: name });
+          this.store.updateTask(task.id, { assignee: profile });
           this.store.returnToReady(task.id);
-          this.store.finishRun(scope.runId, 'completed', { summary: `assigned ${name}` });
-          this.store.appendEvent(task.id, scope.runId, 'assigned', { assignee: name, by: 'orchestrator' });
+          this.store.finishRun(scope.runId, 'completed', { summary: `assigned ${profile}` });
+          this.store.appendEvent(task.id, scope.runId, 'assigned', {
+            assignee: profile,
+            by: 'orchestrator'
+          });
           this.unregisterRun(token);
-          return this.text(res, rpcReq.id, `Assigned ${name}.`);
+          return this.text(res, rpcReq.id, `Assigned ${profile}.`);
         }
         case 'kanban_comment': {
           const a = z.object({ body: z.string() }).parse(args);

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1025,6 +1025,16 @@ export class KanbanStore {
     return rows.map((r) => this.rowToTask(r));
   }
 
+  /** Ready tasks with no assignee — the auto-assign stage's input (claimAndSpawn ignores these). */
+  unassignedReadyTasks(): Task[] {
+    const rows = this.db
+      .prepare(
+        "SELECT * FROM tasks WHERE status='ready' AND assignee IS NULL ORDER BY priority DESC, created_at ASC"
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
   listBoard(boardSlug?: string): BoardCard[] {
     const tasks = boardSlug
       ? this.listTasks().filter((t) => t.boardId === boardSlug)
@@ -1478,6 +1488,21 @@ export class KanbanStore {
          SET status='running', claim_lock=@lock, claim_expires=@expires,
              last_heartbeat_at=@ts, pending_mode=NULL, updated_at=@ts
          WHERE id=@id AND status='triage' AND pending_mode IS NOT NULL
+           AND (claim_lock IS NULL OR claim_expires <= @ts)`
+      )
+      .run({ id: taskId, lock, expires: ts + ttlMs, ts });
+    return res.changes === 1;
+  }
+
+  /** Atomic CAS claim of an unassigned ready task for an assign run; moves ready→running. */
+  claimForAssign(taskId: string, lock: string, ttlMs: number): boolean {
+    const ts = this.now();
+    const res = this.db
+      .prepare(
+        `UPDATE tasks
+         SET status='running', claim_lock=@lock, claim_expires=@expires,
+             last_heartbeat_at=@ts, updated_at=@ts
+         WHERE id=@id AND status='ready' AND assignee IS NULL
            AND (claim_lock IS NULL OR claim_expires <= @ts)`
       )
       .run({ id: taskId, lock, expires: ts + ttlMs, ts });

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -82,6 +82,15 @@ function buildPrompt(input: BuildWorkerInput): string {
       `call kanban_update with the improved title and body.`
     );
   }
+  if (mode === 'assign') {
+    const roster = (input.roster ?? []).map((r) => `- ${r.name}: ${r.description}`).join('\n');
+    return (
+      `assign kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `Choose the single best-matching worker profile to implement this task, based on each ` +
+      `profile's described strengths. Call kanban_assign with that profile's name. Do not do the ` +
+      `work yourself.\n\nAvailable worker profiles:\n${roster || '- default: general worker'}`
+    );
+  }
   return (
     `work kanban task ${task.id}: ${task.title}\n\n${task.body}` +
     attachmentsSection(input) +
@@ -124,6 +133,8 @@ function requireToolsForMode(mode: RunMode): string | null {
       return 'kanban_complete,kanban_block';
     case 'specify':
       return 'kanban_update';
+    case 'assign':
+      return 'kanban_assign';
     default:
       return null;
   }

--- a/src/renderer/src/components/settings/kanban/KanbanSection.tsx
+++ b/src/renderer/src/components/settings/kanban/KanbanSection.tsx
@@ -109,6 +109,16 @@ export function KanbanSection(): React.JSX.Element | null {
             className="h-4 w-4"
           />
         </SettingRow>
+        <SettingRow label="Auto-assign unassigned tasks">
+          <input
+            type="checkbox"
+            checked={k.dispatcher.autoAssign}
+            onChange={(e) =>
+              patch({ dispatcher: { ...k.dispatcher, autoAssign: e.target.checked } })
+            }
+            className="h-4 w-4"
+          />
+        </SettingRow>
         <SettingRow label="Max concurrent orchestrator runs">
           <input
             type="number"

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -108,7 +108,8 @@ export const DEFAULT_SETTINGS: FleetSettings = {
       failureLimit: 3,
       claimTtlMs: 900_000,
       autoDecompose: false,
-      maxDecompose: 1
+      maxDecompose: 1,
+      autoAssign: true
     },
     defaults: { workspaceKind: 'scratch', maxRuntimeSeconds: null },
     artifactRetentionDays: 14,

--- a/src/shared/kanban-types.ts
+++ b/src/shared/kanban-types.ts
@@ -11,8 +11,8 @@ export type TaskStatus =
 
 export type WorkspaceKind = 'scratch' | 'dir' | 'worktree';
 
-/** What a run is doing. 'work' = normal worker; orchestrator runs are 'decompose' | 'specify'. */
-export type RunMode = 'work' | 'decompose' | 'specify';
+/** What a run is doing. 'work' = normal worker; orchestrator runs are 'decompose' | 'specify' | 'assign'. */
+export type RunMode = 'work' | 'decompose' | 'specify' | 'assign';
 
 /** A triage task can be flagged for an orchestrator run. */
 export type PendingMode = 'decompose' | 'specify';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -161,6 +161,7 @@ export type KanbanSettings = {
     claimTtlMs: number;
     autoDecompose: boolean; // when true, the dispatcher auto-flags triage tasks for decompose
     maxDecompose: number; // concurrency cap for orchestrator runs (separate from maxInProgress)
+    autoAssign: boolean; // when true, the dispatcher auto-assigns unassigned ready tasks to a worker profile
   };
   defaults: {
     workspaceKind: WorkspaceKind;


### PR DESCRIPTION
Closes #227.

## Problem

An unassigned `ready` kanban task stalls forever: the claim query requires `assignee IS NOT NULL` (`kanban-store.ts` `readyTasks()`), so `claimAndSpawn()` never sees it and no run is ever spawned.

## Fix — autopilot phase 1

A new `autoAssign()` stage in the `KanbanDispatcher` tick resolves unassigned `ready` tasks:

- **Fast path** — exactly one worker profile → assigned deterministically in code.
- **LLM path** — multiple profiles → an orchestrator run in a new `RunMode='assign'` whose prompt instructs it to pick the best-matching worker profile and call the new terminal MCP tool `kanban_assign(profile)` (validated against real worker profiles, same phantom-profile guard as `kanban_create`). The tool sets the assignee, returns the task to `ready`, finishes the run, and unregisters the token.
- **Fallback** — after `ASSIGN_ATTEMPT_CAP=2` failed attempts → deterministic assign to the first worker profile + a dispatcher comment.
- **Reclaim routing** — a dead `assign` run returns to the unassigned `ready` pool (not `triage`), so `autoAssign` retries or falls back.
- New `autoAssign` setting (**default on**), surfaced in the Kanban settings panel.
- Failure count is cleared on successful assignment so assign-phase failures don't consume the work-phase retry budget.

No schema migration — reuses `task_runs.mode` and `consecutive_failures`.

### Intentional deviation from the spec
The §5 spec mentions flagging tasks with `pending_mode='assign'`. The dispatcher runs as a single synchronous tick, so flag-then-claim in the same tick is redundant — `claimForAssign()` does a direct CAS on `status='ready' AND assignee IS NULL`. `RunMode='assign'` is added; `PendingMode='assign'` is not. Same observable behavior, less state.

## Verification

- `npm run typecheck` — pass
- 253 kanban tests — pass (new coverage: `unassignedReadyTasks`/`claimForAssign` incl. lease-expiry re-claim, `kanban_assign` incl. unknown-profile rejection + token invalidation, `autoAssign` fast-path/LLM/fallback/no-op/reclaim + cap boundary)
- lint — net-zero vs `main`
- `npm run build` — success

## Plan / spec
- Plan: `docs/superpowers/plans/2026-06-11-kanban-auto-assignment.md`
- Spec: `docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md` §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
