### PR TITLE
feat(terminal): background slideshows with crossfade transitions

### DIFF
--- a/src/main/__tests__/settings-store.test.ts
+++ b/src/main/__tests__/settings-store.test.ts
@@ -37,6 +37,18 @@ describe('SettingsStore settings merge', () => {
     expect(s.general.accentColor).toBe('teal');
   });
 
+  it('merges a partial terminalBackground change without dropping slideshow settings', () => {
+    store.set({
+      general: { terminalBackground: { slideshow: { enabled: true, folderPath: '/pics' } } }
+    });
+    store.set({ general: { terminalBackground: { opacity: 0.5 } } });
+    const s = store.get();
+    expect(s.general.terminalBackground.opacity).toBe(0.5);
+    expect(s.general.terminalBackground.slideshow.enabled).toBe(true);
+    expect(s.general.terminalBackground.slideshow.folderPath).toBe('/pics');
+    expect(s.general.terminalBackground.slideshow.intervalSeconds).toBe(60); // default preserved
+  });
+
   it('returns kanban defaults for a fresh store', () => {
     const s = store.get();
     expect(s.kanban.dispatcher.intervalMs).toBe(5000);

--- a/src/main/__tests__/slideshow-scanner.test.ts
+++ b/src/main/__tests__/slideshow-scanner.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { scanImageFolder } from '../slideshow-scanner';
+
+describe('scanImageFolder', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'fleet-slideshow-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns image files sorted by name with absolute paths', async () => {
+    await writeFile(join(dir, 'b.png'), '');
+    await writeFile(join(dir, 'a.jpg'), '');
+    await writeFile(join(dir, 'c.webp'), '');
+    const result = await scanImageFolder(dir);
+    expect(result).toEqual([join(dir, 'a.jpg'), join(dir, 'b.png'), join(dir, 'c.webp')]);
+  });
+
+  it('filters out non-image files and directories', async () => {
+    await writeFile(join(dir, 'notes.txt'), '');
+    await writeFile(join(dir, 'pic.PNG'), '');
+    await mkdir(join(dir, 'sub.png'));
+    const result = await scanImageFolder(dir);
+    expect(result).toEqual([join(dir, 'pic.PNG')]);
+  });
+
+  it('returns [] for a missing folder', async () => {
+    expect(await scanImageFolder(join(dir, 'does-not-exist'))).toEqual([]);
+  });
+
+  it('returns [] for an empty folder path', async () => {
+    expect(await scanImageFolder('')).toEqual([]);
+  });
+});

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -46,6 +46,7 @@ import type { SettingsStore } from './settings-store';
 import type { CwdPoller } from './cwd-poller';
 import type { ActivityTracker } from './activity-tracker';
 import { toError } from './errors';
+import { scanImageFolder } from './slideshow-scanner';
 import type { GitService } from './git-service';
 import type { WorktreeService } from './worktree-service';
 import type { AnnotationStore } from './annotation-store';
@@ -523,6 +524,13 @@ export function registerIpcHandlers(
       return { success: false, error: toError(err).message, entries: [] };
     }
   });
+
+  // List image files in a folder for the terminal background slideshow
+  ipcMain.handle(
+    IPC_CHANNELS.FILE_SCAN_IMAGE_FOLDER,
+    async (_event, { folderPath }: { folderPath: string }): Promise<string[]> =>
+      scanImageFolder(folderPath)
+  );
 
   // Check which entries in a directory are gitignored (returns ignored names)
   ipcMain.handle(

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -25,7 +25,11 @@ export class SettingsStore {
         ...saved.general,
         terminalBackground: {
           ...DEFAULT_SETTINGS.general.terminalBackground,
-          ...saved.general?.terminalBackground
+          ...saved.general?.terminalBackground,
+          slideshow: {
+            ...DEFAULT_SETTINGS.general.terminalBackground.slideshow,
+            ...saved.general?.terminalBackground?.slideshow
+          }
         }
       },
       notifications: { ...DEFAULT_SETTINGS.notifications, ...saved.notifications },
@@ -61,7 +65,18 @@ export class SettingsStore {
     const merged = {
       ...current,
       ...partial,
-      general: { ...current.general, ...(partial.general ?? {}) },
+      general: {
+        ...current.general,
+        ...(partial.general ?? {}),
+        terminalBackground: {
+          ...current.general.terminalBackground,
+          ...(partial.general?.terminalBackground ?? {}),
+          slideshow: {
+            ...current.general.terminalBackground.slideshow,
+            ...(partial.general?.terminalBackground?.slideshow ?? {})
+          }
+        }
+      },
       notifications: { ...current.notifications, ...(partial.notifications ?? {}) },
       socketApi: { ...current.socketApi, ...(partial.socketApi ?? {}) },
       visualizer: {

--- a/src/main/slideshow-scanner.ts
+++ b/src/main/slideshow-scanner.ts
@@ -1,0 +1,21 @@
+import { readdir } from 'fs/promises';
+import { extname, join } from 'path';
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.bmp']);
+
+/**
+ * List image files in a folder (non-recursive), sorted by name.
+ * Returns [] for a missing or unreadable folder — never throws.
+ */
+export async function scanImageFolder(folderPath: string): Promise<string[]> {
+  if (!folderPath) return [];
+  try {
+    const entries = await readdir(folderPath, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && IMAGE_EXTENSIONS.has(extname(e.name).toLowerCase()))
+      .map((e) => join(folderPath, e.name))
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -309,6 +309,8 @@ const fleetApi = {
       typedInvoke(IPC_CHANNELS.FILE_GREP, req),
     searchRecentImages: async (): Promise<RecentImagesResponse> =>
       typedInvoke(IPC_CHANNELS.FILE_RECENT_IMAGES),
+    scanImageFolder: async (folderPath: string): Promise<string[]> =>
+      typedInvoke(IPC_CHANNELS.FILE_SCAN_IMAGE_FOLDER, { folderPath }),
     checkIgnored: async (dirPath: string): Promise<string[]> =>
       typedInvoke(IPC_CHANNELS.FILE_CHECK_IGNORED, { dirPath })
   },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -53,6 +53,7 @@ import { useKanbanAttention } from './hooks/useKanbanAttention';
 import { getAccentCssVars } from './lib/theme';
 import { tooltipAnim, popperAnim } from './lib/motion';
 import { useAppThemeVars } from './hooks/use-app-theme';
+import { useSlideshow } from './hooks/use-slideshow';
 
 type PiPlanModalEntry = PiPlanOpenPayload & { modalId: string };
 
@@ -625,6 +626,10 @@ export function App(): React.JSX.Element {
   const appThemeVars = useAppThemeVars(settings?.general.theme, settings?.general.terminalTheme);
   const themeVars = { ...accentVars, ...appThemeVars };
 
+  // One global slideshow clock so every pane (including hidden background
+  // workspaces) shows the same image and crossfades in sync.
+  const slideshowFrame = useSlideshow(settings?.general.terminalBackground);
+
   return (
     <div
       className="flex flex-col h-screen w-screen bg-fleet-bg text-fleet-text overflow-hidden"
@@ -954,6 +959,7 @@ export function App(): React.JSX.Element {
                         fontSize={settings?.general.fontSize}
                         terminalTheme={settings?.general.terminalTheme}
                         terminalBackground={settings?.general.terminalBackground}
+                        slideshowFrame={slideshowFrame}
                       />
                     )}
                   </div>
@@ -981,6 +987,7 @@ export function App(): React.JSX.Element {
                     fontSize={settings?.general.fontSize}
                     terminalTheme={settings?.general.terminalTheme}
                     terminalBackground={settings?.general.terminalBackground}
+                    slideshowFrame={slideshowFrame}
                   />
                 </div>
               ))

--- a/src/renderer/src/components/BackgroundLayer.tsx
+++ b/src/renderer/src/components/BackgroundLayer.tsx
@@ -1,0 +1,104 @@
+import type { CSSProperties } from 'react';
+import type { TerminalBackground } from '../../../shared/types';
+import type { SlideshowFrame } from '../hooks/use-slideshow';
+
+const FIT_STYLES: Record<TerminalBackground['fit'], { size: string; repeat: string }> = {
+  cover: { size: 'cover', repeat: 'no-repeat' },
+  contain: { size: 'contain', repeat: 'no-repeat' },
+  center: { size: 'auto', repeat: 'no-repeat' },
+  tile: { size: 'auto', repeat: 'repeat' }
+};
+
+// Feather the pane edges to transparent so an image smaller than the pane blends
+// into the terminal background instead of ending at a hard border. `fadeX` fades
+// the left/right edges, `fadeY` the top/bottom (each a fraction of the pane). When
+// both are active the gradients are intersected so the corners fade too.
+function edgeFadeStyle(fadeX: number, fadeY: number): CSSProperties {
+  if (!fadeX && !fadeY) return {};
+  const ramp = (dir: string, fade: number): string => {
+    const start = `${(fade * 100).toFixed(1)}%`;
+    const end = `${(100 - fade * 100).toFixed(1)}%`;
+    return `linear-gradient(to ${dir}, transparent, #000 ${start}, #000 ${end}, transparent)`;
+  };
+  const layers: string[] = [];
+  if (fadeX) layers.push(ramp('right', fadeX));
+  if (fadeY) layers.push(ramp('bottom', fadeY));
+  return {
+    maskImage: layers.join(', '),
+    ...(layers.length > 1 ? { maskComposite: 'intersect' } : {})
+  };
+}
+
+const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+type BackgroundLayerProps = {
+  background: TerminalBackground;
+  /** Shared slideshow frame from the global useSlideshow clock in App. */
+  frame?: SlideshowFrame;
+};
+
+/**
+ * The image layer(s) behind a terminal pane. Static mode renders one layer;
+ * during a slideshow transition the outgoing image fades out under the
+ * incoming one. CSS animations (not transitions) are used because keyed
+ * remounts restart them reliably from the first keyframe — a `transition`
+ * would not animate on the element's mount frame.
+ */
+export function BackgroundLayer({
+  background,
+  frame
+}: BackgroundLayerProps): React.JSX.Element | null {
+  const slideshowOn = background.slideshow.enabled;
+  const currentSrc = slideshowOn && frame?.currentPath ? frame.currentPath : background.imagePath;
+  if (!currentSrc) return null;
+
+  const fadeMs = reducedMotionQuery.matches ? 0 : background.slideshow.transitionMs;
+  const previousSrc =
+    slideshowOn && fadeMs > 0 && frame?.previousPath !== currentSrc
+      ? (frame?.previousPath ?? null)
+      : null;
+
+  const layerStyle = (src: string): CSSProperties => ({
+    // Over-extend when blurred so the blur's soft edge doesn't reveal the pane border.
+    inset: background.blur > 0 ? -background.blur * 2 : 0,
+    // encodeURI so paths with spaces/special chars survive the CSS url() parser.
+    backgroundImage: `url("${encodeURI(`fleet-image://${src}`)}")`,
+    backgroundSize: FIT_STYLES[background.fit].size,
+    backgroundRepeat: FIT_STYLES[background.fit].repeat,
+    backgroundPosition: 'center',
+    filter: background.blur > 0 ? `blur(${background.blur}px)` : undefined,
+    ...edgeFadeStyle(background.edgeFadeX, background.edgeFadeY)
+  });
+
+  return (
+    <>
+      {previousSrc && (
+        <div
+          key={`out-${previousSrc}`}
+          aria-hidden
+          className="absolute z-0 pointer-events-none"
+          style={{
+            ...layerStyle(previousSrc),
+            ['--fleet-bg-opacity' as string]: background.opacity,
+            animation: `fleet-bg-fade-out ${fadeMs}ms ease-in-out both`
+          }}
+        />
+      )}
+      <div
+        key={`in-${currentSrc}`}
+        aria-hidden
+        className="absolute z-0 pointer-events-none"
+        style={{
+          ...layerStyle(currentSrc),
+          opacity: background.opacity,
+          ...(previousSrc
+            ? {
+                ['--fleet-bg-opacity' as string]: background.opacity,
+                animation: `fleet-bg-fade-in ${fadeMs}ms ease-in-out both`
+              }
+            : {})
+        }}
+      />
+    </>
+  );
+}

--- a/src/renderer/src/components/PaneGrid.tsx
+++ b/src/renderer/src/components/PaneGrid.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import type { PaneNode, PaneLeaf, TerminalBackground } from '../../../shared/types';
 import type { TerminalThemeId } from '../../../shared/theme-presets';
+import type { SlideshowFrame } from '../hooks/use-slideshow';
 import { TerminalPane } from './TerminalPane';
 import { PaneHeader } from './PaneHeader';
 import { ImageViewerPane } from './ImageViewerPane';
@@ -126,6 +127,7 @@ type PaneGridProps = {
   fontSize?: number;
   terminalTheme?: TerminalThemeId;
   terminalBackground?: TerminalBackground;
+  slideshowFrame?: SlideshowFrame;
 };
 
 export function PaneGrid({
@@ -136,7 +138,8 @@ export function PaneGrid({
   fontFamily,
   fontSize,
   terminalTheme,
-  terminalBackground
+  terminalBackground,
+  slideshowFrame
 }: PaneGridProps): React.JSX.Element {
   const { splitPane, closePane } = useWorkspaceStore();
   const gridRef = useRef<HTMLDivElement>(null);
@@ -207,6 +210,7 @@ export function PaneGrid({
                 fontSize={fontSize}
                 terminalTheme={terminalTheme}
                 terminalBackground={terminalBackground}
+                slideshowFrame={slideshowFrame}
                 onSplitHorizontal={() => splitPane(leaf.id, 'horizontal')}
                 onSplitVertical={() => splitPane(leaf.id, 'vertical')}
                 onClose={() => closePane(leaf.id)}

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -1,6 +1,8 @@
-import { useRef, useState, useEffect, type CSSProperties } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useTerminal } from '../hooks/use-terminal';
 import { useTerminalDrop } from '../hooks/use-terminal-drop';
+import type { SlideshowFrame } from '../hooks/use-slideshow';
+import { BackgroundLayer } from './BackgroundLayer';
 import { PaneToolbar } from './PaneToolbar';
 import { SearchBar } from './SearchBar';
 import { openAnnotateModal } from '../lib/annotate-modal-bridge';
@@ -21,39 +23,13 @@ type TerminalPaneProps = {
   fontSize?: number;
   terminalTheme?: TerminalThemeId;
   terminalBackground?: TerminalBackground;
+  slideshowFrame?: SlideshowFrame;
   onSplitHorizontal?: () => void;
   onSplitVertical?: () => void;
   onClose?: () => void;
   shellProfileId?: string;
   cmd?: string;
 };
-
-const FIT_STYLES: Record<TerminalBackground['fit'], { size: string; repeat: string }> = {
-  cover: { size: 'cover', repeat: 'no-repeat' },
-  contain: { size: 'contain', repeat: 'no-repeat' },
-  center: { size: 'auto', repeat: 'no-repeat' },
-  tile: { size: 'auto', repeat: 'repeat' }
-};
-
-// Feather the pane edges to transparent so an image smaller than the pane blends
-// into the terminal background instead of ending at a hard border. `fadeX` fades
-// the left/right edges, `fadeY` the top/bottom (each a fraction of the pane). When
-// both are active the gradients are intersected so the corners fade too.
-function edgeFadeStyle(fadeX: number, fadeY: number): CSSProperties {
-  if (!fadeX && !fadeY) return {};
-  const ramp = (dir: string, fade: number): string => {
-    const start = `${(fade * 100).toFixed(1)}%`;
-    const end = `${(100 - fade * 100).toFixed(1)}%`;
-    return `linear-gradient(to ${dir}, transparent, #000 ${start}, #000 ${end}, transparent)`;
-  };
-  const layers: string[] = [];
-  if (fadeX) layers.push(ramp('right', fadeX));
-  if (fadeY) layers.push(ramp('bottom', fadeY));
-  return {
-    maskImage: layers.join(', '),
-    ...(layers.length > 1 ? { maskComposite: 'intersect' } : {})
-  };
-}
 
 export function TerminalPane({
   paneId,
@@ -65,6 +41,7 @@ export function TerminalPane({
   fontSize,
   terminalTheme,
   terminalBackground,
+  slideshowFrame,
   onSplitHorizontal,
   onSplitVertical,
   onClose,
@@ -74,7 +51,10 @@ export function TerminalPane({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const workspaceId = useWorkspaceStore((s) => s.workspace.id);
-  const hasBackgroundImage = !!terminalBackground?.imagePath;
+  // Mirrors BackgroundLayer's source resolution: slideshow image when active,
+  // else the static image. Keeps xterm transparent whenever a layer is visible.
+  const slideshowActive = !!terminalBackground?.slideshow.enabled && !!slideshowFrame?.currentPath;
+  const hasBackgroundImage = slideshowActive || !!terminalBackground?.imagePath;
   const { focus, scrollToBottom, search, searchPrevious, clearSearch } = useTerminal(containerRef, {
     paneId,
     cwd,
@@ -168,23 +148,8 @@ export function TerminalPane({
       }}
       {...dragHandlers}
     >
-      {terminalBackground?.imagePath && (
-        <div
-          aria-hidden
-          className="absolute z-0 pointer-events-none"
-          style={{
-            // Over-extend when blurred so the blur's soft edge doesn't reveal the pane border.
-            inset: terminalBackground.blur > 0 ? -terminalBackground.blur * 2 : 0,
-            // encodeURI so paths with spaces/special chars survive the CSS url() parser.
-            backgroundImage: `url("${encodeURI(`fleet-image://${terminalBackground.imagePath}`)}")`,
-            backgroundSize: FIT_STYLES[terminalBackground.fit].size,
-            backgroundRepeat: FIT_STYLES[terminalBackground.fit].repeat,
-            backgroundPosition: 'center',
-            opacity: terminalBackground.opacity,
-            filter: terminalBackground.blur > 0 ? `blur(${terminalBackground.blur}px)` : undefined,
-            ...edgeFadeStyle(terminalBackground.edgeFadeX, terminalBackground.edgeFadeY)
-          }}
-        />
+      {terminalBackground && (
+        <BackgroundLayer background={terminalBackground} frame={slideshowFrame} />
       )}
       <PaneToolbar
         visible={hovered}

--- a/src/renderer/src/components/settings/GeneralSection.tsx
+++ b/src/renderer/src/components/settings/GeneralSection.tsx
@@ -3,7 +3,8 @@ import { useSettingsStore } from '../../store/settings-store';
 import { useShellProfilesStore } from '../../store/shell-profiles-store';
 import { useDebouncedCallback } from '../../hooks/use-debounced-callback';
 import { SettingRow } from './SettingRow';
-import type { FontSelection, TerminalBackground } from '../../../../shared/types';
+import { TerminalBackgroundSettings } from './TerminalBackgroundSettings';
+import type { FontSelection } from '../../../../shared/types';
 import { resolveFontFamily } from '../../../../shared/types';
 import {
   ACCENT_COLORS,
@@ -175,44 +176,7 @@ export function GeneralSection(): React.JSX.Element {
     });
   }, 300);
 
-  const bg = settings?.general.terminalBackground;
-  const [localOpacity, setLocalOpacity] = useState(bg?.opacity ?? 0.15);
-  const [localBlur, setLocalBlur] = useState(bg?.blur ?? 0);
-  const [localEdgeFadeX, setLocalEdgeFadeX] = useState(bg?.edgeFadeX ?? 0);
-  const [localEdgeFadeY, setLocalEdgeFadeY] = useState(bg?.edgeFadeY ?? 0);
-
-  // Sync the slider locals to stored values when an image is (re)loaded — covers
-  // the case where settings finish loading after this component first mounted.
-  useEffect(() => {
-    if (bg?.imagePath) {
-      setLocalOpacity(bg.opacity);
-      setLocalBlur(bg.blur);
-      setLocalEdgeFadeX(bg.edgeFadeX);
-      setLocalEdgeFadeY(bg.edgeFadeY);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bg?.imagePath]);
-
-  // The settings merge is shallow within `general`, so always send the full
-  // terminalBackground object (read fresh from the store to avoid stale closures).
-  const saveBackground = (patch: Partial<TerminalBackground>): void => {
-    const current = useSettingsStore.getState().settings;
-    if (!current) return;
-    void updateSettings({
-      general: { terminalBackground: { ...current.general.terminalBackground, ...patch } }
-    });
-  };
-  const debouncedSaveBackground = useDebouncedCallback(saveBackground, 150);
-
-  const pickBackgroundImage = async (): Promise<void> => {
-    const paths = await window.fleet.file.openDialog({
-      multi: false,
-      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp'] }]
-    });
-    if (paths[0]) saveBackground({ imagePath: paths[0] });
-  };
-
-  if (!settings || !bg) return <></>;
+  if (!settings) return <></>;
 
   return (
     <div className="space-y-4">
@@ -354,135 +318,7 @@ export function GeneralSection(): React.JSX.Element {
           })}
         </div>
       </SettingRow>
-      <div className="space-y-3 pt-3 border-t border-fleet-border">
-        <SettingRow label="Terminal Background">
-          <div className="flex items-center gap-2">
-            {bg.imagePath && (
-              <span
-                className="text-xs text-fleet-text-subtle max-w-[150px] truncate"
-                title={bg.imagePath}
-              >
-                {bg.imagePath.split('/').pop()}
-              </span>
-            )}
-            <button
-              type="button"
-              onClick={() => void pickBackgroundImage()}
-              className="bg-fleet-surface-2 text-fleet-text text-sm rounded px-2 py-1 border border-fleet-border-strong hover:border-fleet-text-subtle transition active:scale-[0.97]"
-            >
-              {bg.imagePath ? 'Change…' : 'Browse…'}
-            </button>
-            {bg.imagePath && (
-              <button
-                type="button"
-                onClick={() => saveBackground({ imagePath: null })}
-                className="text-fleet-text-secondary text-sm rounded px-2 py-1 border border-fleet-border-strong hover:border-fleet-text-subtle transition active:scale-[0.97]"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-        </SettingRow>
-        {bg.imagePath && (
-          <>
-            <SettingRow label="Opacity">
-              <div className="flex items-center gap-2">
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.05"
-                  value={localOpacity}
-                  onChange={(e) => {
-                    const v = parseFloat(e.target.value);
-                    setLocalOpacity(v);
-                    debouncedSaveBackground({ opacity: v });
-                  }}
-                  className="w-40"
-                />
-                <span className="text-xs text-fleet-text-subtle w-8 text-right">
-                  {Math.round(localOpacity * 100)}%
-                </span>
-              </div>
-            </SettingRow>
-            <SettingRow label="Blur">
-              <div className="flex items-center gap-2">
-                <input
-                  type="range"
-                  min="0"
-                  max="20"
-                  step="1"
-                  value={localBlur}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value);
-                    setLocalBlur(v);
-                    debouncedSaveBackground({ blur: v });
-                  }}
-                  className="w-40"
-                />
-                <span className="text-xs text-fleet-text-subtle w-8 text-right">{localBlur}px</span>
-              </div>
-            </SettingRow>
-            <SettingRow label="Fade Left/Right">
-              <div className="flex items-center gap-2">
-                <input
-                  type="range"
-                  min="0"
-                  max="0.5"
-                  step="0.05"
-                  value={localEdgeFadeX}
-                  onChange={(e) => {
-                    const v = parseFloat(e.target.value);
-                    setLocalEdgeFadeX(v);
-                    debouncedSaveBackground({ edgeFadeX: v });
-                  }}
-                  className="w-40"
-                />
-                <span className="text-xs text-fleet-text-subtle w-8 text-right">
-                  {Math.round(localEdgeFadeX * 100)}%
-                </span>
-              </div>
-            </SettingRow>
-            <SettingRow label="Fade Top/Bottom">
-              <div className="flex items-center gap-2">
-                <input
-                  type="range"
-                  min="0"
-                  max="0.5"
-                  step="0.05"
-                  value={localEdgeFadeY}
-                  onChange={(e) => {
-                    const v = parseFloat(e.target.value);
-                    setLocalEdgeFadeY(v);
-                    debouncedSaveBackground({ edgeFadeY: v });
-                  }}
-                  className="w-40"
-                />
-                <span className="text-xs text-fleet-text-subtle w-8 text-right">
-                  {Math.round(localEdgeFadeY * 100)}%
-                </span>
-              </div>
-            </SettingRow>
-            <SettingRow label="Fit">
-              <select
-                value={bg.fit}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  if (v === 'cover' || v === 'contain' || v === 'center' || v === 'tile') {
-                    saveBackground({ fit: v });
-                  }
-                }}
-                className="bg-fleet-surface-2 text-fleet-text text-sm rounded px-2 py-1 border border-fleet-border-strong"
-              >
-                <option value="cover">Cover</option>
-                <option value="contain">Contain</option>
-                <option value="center">Center</option>
-                <option value="tile">Tile</option>
-              </select>
-            </SettingRow>
-          </>
-        )}
-      </div>
+      <TerminalBackgroundSettings />
     </div>
   );
 }

--- a/src/renderer/src/components/settings/TerminalBackgroundSettings.tsx
+++ b/src/renderer/src/components/settings/TerminalBackgroundSettings.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useState } from 'react';
+import { useSettingsStore } from '../../store/settings-store';
+import { useDebouncedCallback } from '../../hooks/use-debounced-callback';
+import { SettingRow } from './SettingRow';
+import type { TerminalBackground, TerminalBackgroundSlideshow } from '../../../../shared/types';
+
+const IMAGE_FILTERS = [
+  { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp'] }
+];
+
+const BUTTON_CLASS =
+  'bg-fleet-surface-2 text-fleet-text text-sm rounded px-2 py-1 border border-fleet-border-strong hover:border-fleet-text-subtle transition active:scale-[0.97]';
+
+function formatInterval(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return rem ? `${minutes}m${rem}s` : `${minutes}m`;
+}
+
+export function TerminalBackgroundSettings(): React.JSX.Element | null {
+  const { settings, updateSettings } = useSettingsStore();
+  const bg = settings?.general.terminalBackground;
+
+  const [localOpacity, setLocalOpacity] = useState(bg?.opacity ?? 0.15);
+  const [localBlur, setLocalBlur] = useState(bg?.blur ?? 0);
+  const [localEdgeFadeX, setLocalEdgeFadeX] = useState(bg?.edgeFadeX ?? 0);
+  const [localEdgeFadeY, setLocalEdgeFadeY] = useState(bg?.edgeFadeY ?? 0);
+  const [localInterval, setLocalInterval] = useState(bg?.slideshow.intervalSeconds ?? 60);
+  const [localTransitionMs, setLocalTransitionMs] = useState(bg?.slideshow.transitionMs ?? 1000);
+
+  const adjustmentsVisible = !!bg && (!!bg.imagePath || bg.slideshow.enabled);
+
+  // Sync the slider locals to stored values when the controls (re)appear —
+  // covers the case where settings finish loading after this component mounted.
+  useEffect(() => {
+    if (!adjustmentsVisible) return;
+    const current = useSettingsStore.getState().settings;
+    if (!current) return;
+    const tb = current.general.terminalBackground;
+    setLocalOpacity(tb.opacity);
+    setLocalBlur(tb.blur);
+    setLocalEdgeFadeX(tb.edgeFadeX);
+    setLocalEdgeFadeY(tb.edgeFadeY);
+    setLocalInterval(tb.slideshow.intervalSeconds);
+    setLocalTransitionMs(tb.slideshow.transitionMs);
+  }, [adjustmentsVisible]);
+
+  // The settings merge is shallow within `general`, so always send the full
+  // terminalBackground object (read fresh from the store to avoid stale closures).
+  const saveBackground = (patch: Partial<TerminalBackground>): void => {
+    const current = useSettingsStore.getState().settings;
+    if (!current) return;
+    void updateSettings({
+      general: { terminalBackground: { ...current.general.terminalBackground, ...patch } }
+    });
+  };
+  const debouncedSaveBackground = useDebouncedCallback(saveBackground, 150);
+
+  const saveSlideshow = (patch: Partial<TerminalBackgroundSlideshow>): void => {
+    const current = useSettingsStore.getState().settings;
+    if (!current) return;
+    const tb = current.general.terminalBackground;
+    saveBackground({ slideshow: { ...tb.slideshow, ...patch } });
+  };
+  const debouncedSaveSlideshow = useDebouncedCallback(saveSlideshow, 150);
+
+  const pickBackgroundImage = async (): Promise<void> => {
+    const paths = await window.fleet.file.openDialog({ multi: false, filters: IMAGE_FILTERS });
+    if (paths[0]) saveBackground({ imagePath: paths[0] });
+  };
+
+  const pickSlideshowFolder = async (): Promise<void> => {
+    const folder = await window.fleet.showFolderPicker();
+    if (folder) saveSlideshow({ source: 'folder', folderPath: folder });
+  };
+
+  const pickSlideshowFiles = async (): Promise<void> => {
+    const paths = await window.fleet.file.openDialog({ multi: true, filters: IMAGE_FILTERS });
+    if (paths.length > 0) saveSlideshow({ source: 'files', filePaths: paths });
+  };
+
+  if (!bg) return null;
+  const ss = bg.slideshow;
+
+  return (
+    <div className="space-y-3 pt-3 border-t border-fleet-border">
+      <SettingRow label="Terminal Background">
+        <div className="flex items-center gap-2">
+          {bg.imagePath && (
+            <span
+              className="text-xs text-fleet-text-subtle max-w-[150px] truncate"
+              title={bg.imagePath}
+            >
+              {bg.imagePath.split('/').pop()}
+            </span>
+          )}
+          <button type="button" onClick={() => void pickBackgroundImage()} className={BUTTON_CLASS}>
+            {bg.imagePath ? 'Change…' : 'Browse…'}
+          </button>
+          {bg.imagePath && (
+            <button
+              type="button"
+              onClick={() => saveBackground({ imagePath: null })}
+              className="text-fleet-text-secondary text-sm rounded px-2 py-1 border border-fleet-border-strong hover:border-fleet-text-subtle transition active:scale-[0.97]"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </SettingRow>
+      <SettingRow label="Slideshow">
+        <input
+          type="checkbox"
+          checked={ss.enabled}
+          onChange={(e) => saveSlideshow({ enabled: e.target.checked })}
+          className="fleet-accent-input"
+        />
+      </SettingRow>
+      {ss.enabled && (
+        <>
+          <SettingRow label="Source">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="slideshowSource"
+                  checked={ss.source === 'folder'}
+                  onChange={() => saveSlideshow({ source: 'folder' })}
+                  className="fleet-accent-input"
+                />
+                <span className="text-sm text-fleet-text-secondary">Folder</span>
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="slideshowSource"
+                  checked={ss.source === 'files'}
+                  onChange={() => saveSlideshow({ source: 'files' })}
+                  className="fleet-accent-input"
+                />
+                <span className="text-sm text-fleet-text-secondary">Files</span>
+              </label>
+            </div>
+          </SettingRow>
+          {ss.source === 'folder' ? (
+            <SettingRow label="Image Folder">
+              <div className="flex items-center gap-2">
+                {ss.folderPath && (
+                  <span
+                    className="text-xs text-fleet-text-subtle max-w-[150px] truncate"
+                    title={ss.folderPath}
+                  >
+                    {ss.folderPath.split('/').pop()}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void pickSlideshowFolder()}
+                  className={BUTTON_CLASS}
+                >
+                  {ss.folderPath ? 'Change…' : 'Choose Folder…'}
+                </button>
+              </div>
+            </SettingRow>
+          ) : (
+            <SettingRow label="Images">
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-fleet-text-subtle">
+                  {ss.filePaths.length} file{ss.filePaths.length === 1 ? '' : 's'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void pickSlideshowFiles()}
+                  className={BUTTON_CLASS}
+                >
+                  {ss.filePaths.length > 0 ? 'Change…' : 'Select Files…'}
+                </button>
+              </div>
+            </SettingRow>
+          )}
+          <SettingRow label="Order">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="slideshowOrder"
+                  checked={ss.shuffle}
+                  onChange={() => saveSlideshow({ shuffle: true })}
+                  className="fleet-accent-input"
+                />
+                <span className="text-sm text-fleet-text-secondary">Shuffle</span>
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="radio"
+                  name="slideshowOrder"
+                  checked={!ss.shuffle}
+                  onChange={() => saveSlideshow({ shuffle: false })}
+                  className="fleet-accent-input"
+                />
+                <span className="text-sm text-fleet-text-secondary">Sequential</span>
+              </label>
+            </div>
+          </SettingRow>
+          <SettingRow label="Interval">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="10"
+                max="1800"
+                step="10"
+                value={localInterval}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value);
+                  setLocalInterval(v);
+                  debouncedSaveSlideshow({ intervalSeconds: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-12 text-right">
+                {formatInterval(localInterval)}
+              </span>
+            </div>
+          </SettingRow>
+          <SettingRow label="Transition">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="200"
+                max="5000"
+                step="100"
+                value={localTransitionMs}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value);
+                  setLocalTransitionMs(v);
+                  debouncedSaveSlideshow({ transitionMs: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-12 text-right">
+                {(localTransitionMs / 1000).toFixed(1)}s
+              </span>
+            </div>
+          </SettingRow>
+        </>
+      )}
+      {adjustmentsVisible && (
+        <>
+          <SettingRow label="Opacity">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.05"
+                value={localOpacity}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  setLocalOpacity(v);
+                  debouncedSaveBackground({ opacity: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-8 text-right">
+                {Math.round(localOpacity * 100)}%
+              </span>
+            </div>
+          </SettingRow>
+          <SettingRow label="Blur">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="0"
+                max="20"
+                step="1"
+                value={localBlur}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value);
+                  setLocalBlur(v);
+                  debouncedSaveBackground({ blur: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-8 text-right">{localBlur}px</span>
+            </div>
+          </SettingRow>
+          <SettingRow label="Fade Left/Right">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="0"
+                max="0.5"
+                step="0.05"
+                value={localEdgeFadeX}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  setLocalEdgeFadeX(v);
+                  debouncedSaveBackground({ edgeFadeX: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-8 text-right">
+                {Math.round(localEdgeFadeX * 100)}%
+              </span>
+            </div>
+          </SettingRow>
+          <SettingRow label="Fade Top/Bottom">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min="0"
+                max="0.5"
+                step="0.05"
+                value={localEdgeFadeY}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  setLocalEdgeFadeY(v);
+                  debouncedSaveBackground({ edgeFadeY: v });
+                }}
+                className="w-40"
+              />
+              <span className="text-xs text-fleet-text-subtle w-8 text-right">
+                {Math.round(localEdgeFadeY * 100)}%
+              </span>
+            </div>
+          </SettingRow>
+          <SettingRow label="Fit">
+            <select
+              value={bg.fit}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === 'cover' || v === 'contain' || v === 'center' || v === 'tile') {
+                  saveBackground({ fit: v });
+                }
+              }}
+              className="bg-fleet-surface-2 text-fleet-text text-sm rounded px-2 py-1 border border-fleet-border-strong"
+            >
+              <option value="cover">Cover</option>
+              <option value="contain">Contain</option>
+              <option value="center">Center</option>
+              <option value="tile">Tile</option>
+            </select>
+          </SettingRow>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/hooks/use-slideshow.ts
+++ b/src/renderer/src/hooks/use-slideshow.ts
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState } from 'react';
+import type { TerminalBackground } from '../../../shared/types';
+import { buildQueue } from '../lib/slideshow-order';
+
+export type SlideshowFrame = {
+  /** Image currently shown (fading in while previousPath is set). */
+  currentPath: string | null;
+  /** Image fading out beneath the current one; cleared when the fade ends. */
+  previousPath: string | null;
+};
+
+const IDLE_FRAME: SlideshowFrame = { currentPath: null, previousPath: null };
+
+// Decode through Chromium's image cache so the crossfade never reveals a
+// half-loaded image. Resolves on error too — a missing file just renders
+// as an empty layer and the show moves on.
+async function preloadImage(path: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve();
+    img.onerror = () => resolve();
+    img.src = encodeURI(`fleet-image://${path}`);
+  });
+}
+
+/**
+ * Single global slideshow clock for the terminal background. Called once in
+ * App; every pane consumes the returned frame so all panes transition in sync.
+ */
+export function useSlideshow(bg: TerminalBackground | undefined): SlideshowFrame {
+  const [frame, setFrame] = useState<SlideshowFrame>(IDLE_FRAME);
+
+  const queueRef = useRef<string[]>([]);
+  const lastShownRef = useRef<string | null>(null);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Read at fade time via a ref so moving the transition slider doesn't
+  // restart the interval (and postpone the next image).
+  const transitionMsRef = useRef(1000);
+  transitionMsRef.current = bg?.slideshow.transitionMs ?? 1000;
+
+  const slideshow = bg?.slideshow;
+  const enabled = slideshow?.enabled ?? false;
+  const source = slideshow?.source ?? 'folder';
+  const folderPath = slideshow?.folderPath ?? '';
+  const filePathsKey = (slideshow?.filePaths ?? []).join('\n');
+  const intervalSeconds = slideshow?.intervalSeconds ?? 60;
+  const shuffle = slideshow?.shuffle ?? true;
+
+  useEffect(() => {
+    if (!enabled) {
+      queueRef.current = [];
+      lastShownRef.current = null;
+      setFrame(IDLE_FRAME);
+      return;
+    }
+
+    const run = { cancelled: false, advancing: false };
+    const filePaths = filePathsKey ? filePathsKey.split('\n') : [];
+
+    // Re-resolves the source list on every advance so files added to or
+    // removed from a folder are picked up without a settings change.
+    const advance = async (initial: boolean): Promise<void> => {
+      // If a slow scan/preload outlives the interval, skip this tick rather
+      // than dequeue a second image the first call would then clobber.
+      if (run.advancing) return;
+      run.advancing = true;
+      try {
+        await advanceInner(initial);
+      } finally {
+        run.advancing = false;
+      }
+    };
+
+    const advanceInner = async (initial: boolean): Promise<void> => {
+      const paths =
+        source === 'folder' ? await window.fleet.file.scanImageFolder(folderPath) : filePaths;
+      if (run.cancelled) return;
+      if (paths.length === 0) {
+        queueRef.current = [];
+        setFrame(IDLE_FRAME);
+        return;
+      }
+      // On (re)start — first show or a settings change — keep the image already
+      // on screen rather than jumping, as long as it still exists in the list.
+      const lastShown = lastShownRef.current;
+      if (initial && lastShown && paths.includes(lastShown)) {
+        setFrame({ currentPath: lastShown, previousPath: null });
+        return;
+      }
+      queueRef.current = queueRef.current.filter((p) => paths.includes(p));
+      if (queueRef.current.length === 0) {
+        queueRef.current = buildQueue(paths, shuffle, lastShownRef.current);
+      }
+      const next = queueRef.current.shift();
+      if (!next || (next === lastShownRef.current && !initial)) return;
+      await preloadImage(next);
+      // The cleanup can flip this during the await; the linter can't see that.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (run.cancelled) return;
+      lastShownRef.current = next;
+      setFrame((prev) => ({
+        currentPath: next,
+        previousPath: initial ? null : prev.currentPath
+      }));
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = setTimeout(() => {
+        setFrame((prev) => ({ ...prev, previousPath: null }));
+      }, transitionMsRef.current + 80);
+    };
+
+    void advance(true);
+    const interval = setInterval(() => void advance(false), intervalSeconds * 1000);
+    return () => {
+      run.cancelled = true;
+      clearInterval(interval);
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+    };
+  }, [enabled, source, folderPath, filePathsKey, intervalSeconds, shuffle]);
+
+  return frame;
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -133,6 +133,25 @@ body,
   background: #2dd4bf66;
 }
 
+/* Terminal background slideshow crossfade. The layers' max opacity is the
+   user's background opacity setting, passed in via --fleet-bg-opacity. */
+@keyframes fleet-bg-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: var(--fleet-bg-opacity, 1);
+  }
+}
+@keyframes fleet-bg-fade-out {
+  from {
+    opacity: var(--fleet-bg-opacity, 1);
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse {
     animation: none !important;

--- a/src/renderer/src/lib/__tests__/slideshow-order.test.ts
+++ b/src/renderer/src/lib/__tests__/slideshow-order.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildQueue } from '../slideshow-order';
+
+const PATHS = ['/a.png', '/b.png', '/c.png', '/d.png'];
+
+describe('buildQueue', () => {
+  it('returns [] for an empty list', () => {
+    expect(buildQueue([], false, null)).toEqual([]);
+    expect(buildQueue([], true, '/a.png')).toEqual([]);
+  });
+
+  it('sequential: preserves order from the start when nothing was shown', () => {
+    expect(buildQueue(PATHS, false, null)).toEqual(PATHS);
+  });
+
+  it('sequential: rotates to continue after the last shown image', () => {
+    expect(buildQueue(PATHS, false, '/b.png')).toEqual(['/c.png', '/d.png', '/a.png', '/b.png']);
+  });
+
+  it('sequential: starts over when lastShown is no longer in the list', () => {
+    expect(buildQueue(PATHS, false, '/gone.png')).toEqual(PATHS);
+  });
+
+  it('shuffle: returns a permutation of all paths', () => {
+    const queue = buildQueue(PATHS, true, null);
+    expect([...queue].sort()).toEqual([...PATHS].sort());
+  });
+
+  it('shuffle: never starts with the last shown image (100 rolls)', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(buildQueue(PATHS, true, '/c.png')[0]).not.toBe('/c.png');
+    }
+  });
+
+  it('shuffle: single image still returns that image', () => {
+    expect(buildQueue(['/only.png'], true, '/only.png')).toEqual(['/only.png']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...PATHS];
+    buildQueue(input, true, null);
+    expect(input).toEqual(PATHS);
+  });
+});

--- a/src/renderer/src/lib/slideshow-order.ts
+++ b/src/renderer/src/lib/slideshow-order.ts
@@ -1,0 +1,24 @@
+/**
+ * Build the next play-through queue for the background slideshow.
+ *
+ * Sequential: filename order, rotated so playback continues after `lastShown`.
+ * Shuffle: Fisher-Yates, re-rolled each cycle; guarantees `lastShown` is not
+ * first so the same image never shows twice in a row (when there are 2+ images).
+ */
+export function buildQueue(paths: string[], shuffle: boolean, lastShown: string | null): string[] {
+  if (paths.length === 0) return [];
+  if (!shuffle) {
+    const start = lastShown ? paths.indexOf(lastShown) + 1 : 0;
+    return start > 0 ? [...paths.slice(start), ...paths.slice(0, start)] : [...paths];
+  }
+  const queue = [...paths];
+  for (let i = queue.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [queue[i], queue[j]] = [queue[j], queue[i]];
+  }
+  if (queue.length > 1 && queue[0] === lastShown) {
+    const k = 1 + Math.floor(Math.random() * (queue.length - 1));
+    [queue[0], queue[k]] = [queue[k], queue[0]];
+  }
+  return queue;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -45,7 +45,16 @@ export const DEFAULT_SETTINGS: FleetSettings = {
       blur: 0,
       edgeFadeX: 0,
       edgeFadeY: 0,
-      fit: 'cover'
+      fit: 'cover',
+      slideshow: {
+        enabled: false,
+        source: 'folder',
+        folderPath: '',
+        filePaths: [],
+        intervalSeconds: 60,
+        shuffle: true,
+        transitionMs: 1000
+      }
     }
   },
   notifications: {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -49,6 +49,7 @@ export const IPC_CHANNELS = {
   FILE_SEARCH: 'file:search',
   FILE_GREP: 'file:grep',
   FILE_RECENT_IMAGES: 'file:recent-images',
+  FILE_SCAN_IMAGE_FOLDER: 'file:scan-image-folder',
   FILE_CHECK_IGNORED: 'file:check-ignored',
   CLIPBOARD_HISTORY: 'clipboard:history',
   CLIPBOARD_CHANGED: 'clipboard:changed',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -207,6 +207,25 @@ export const DEFAULT_ORCHESTRATOR_INSTRUCTIONS =
 
 export type TerminalBackgroundFit = 'cover' | 'contain' | 'center' | 'tile';
 
+export type SlideshowSourceKind = 'folder' | 'files';
+
+export type TerminalBackgroundSlideshow = {
+  enabled: boolean;
+  /** Which source list is active. Both folderPath and filePaths are kept so
+   * switching kinds doesn't discard the other's value. */
+  source: SlideshowSourceKind;
+  /** Folder scanned (non-recursively) for image files. */
+  folderPath: string;
+  /** Explicit list of image file paths. */
+  filePaths: string[];
+  /** Seconds each image is shown before advancing. */
+  intervalSeconds: number;
+  /** Random order (no repeats until all images shown) vs filename order. */
+  shuffle: boolean;
+  /** Crossfade duration in milliseconds. */
+  transitionMs: number;
+};
+
 export type TerminalBackground = {
   /** Absolute path to the image on disk, served via the fleet-image:// protocol. */
   imagePath: string | null;
@@ -221,6 +240,7 @@ export type TerminalBackground = {
    * top/bottom edges to transparent so a too-short image blends into the background. */
   edgeFadeY: number;
   fit: TerminalBackgroundFit;
+  slideshow: TerminalBackgroundSlideshow;
 };
 
 export type FleetSettings = {


### PR DESCRIPTION
## Summary

Adds an opt-in **slideshow mode** to the terminal background. The existing single-image background is unchanged and remains the default.

- **Sources:** a folder (rescanned each cycle, so images added later are picked up) or an explicit multi-selected file list
- **Playback:** shuffle (no repeats until all images shown) or sequential order; configurable interval (10s–30min)
- **Transition:** crossfade with configurable duration (0.2–5s); instant swap under `prefers-reduced-motion`
- **Sync:** one global clock in `App` drives every pane — split panes and hidden background workspaces all show the same image and fade together
- Existing adjustments (opacity, blur, edge fades, fit) apply to whichever image is showing

## Implementation

- `general.terminalBackground.slideshow` settings sub-object, deep-merged in both `SettingsStore.get()` and `set()` so partial patches can't drop it
- `FILE_SCAN_IMAGE_FOLDER` IPC backed by a main-process folder scanner (`slideshow-scanner.ts`)
- `use-slideshow` hook: builds play queues via the pure `buildQueue` helper, preloads each image before fading, and guards against overlapping ticks when a scan outlives the interval
- `BackgroundLayer` component extracted from `TerminalPane`: two keyed layers animated with CSS `@keyframes` (keyed remounts restart animations reliably; a CSS `transition` would not animate on the mount frame)
- Terminal Background settings extracted from the ~490-line `GeneralSection` into `TerminalBackgroundSettings`, with the new slideshow controls

## Testing

- 13 new tests: folder scanner (filtering, sorting, missing folder), play-queue ordering (shuffle no-repeat guarantee, sequential rotation), and a settings-merge regression test
- `npm run typecheck`, `npm run lint` (clean on all touched files), and `npm test` (1039 passing)
- Manual smoke test suggested: enable slideshow in Settings → General against a wallpaper folder with a short interval; check split panes fade in unison

🤖 Generated with [Claude Code](https://claude.com/claude-code)