### PR TITLE
feat(kanban): integrate() stage + resolve run mode (autopilot phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.67.0
+
+- **Kanban integration autopilot (phase 2)** — completed feature tasks now integrate themselves. When a worktree task in a feature reaches review, the dispatcher auto-merges its branch into the feature's integration branch and marks it done (no review click needed). On a merge conflict it spawns a bounded **resolve run**: a worker merges the target branch into the worktree, resolves conflicts, verifies, commits, and returns the task to review for a retry — capped at 2 attempts, after which the task blocks with a notification. Once every task in a feature is done, its integration branch is auto-synced with main (conflicts handed to a resolve run on a system task). Clicking **Merge to base** on a conflicting standalone task now also spawns a resolve run instead of only commenting. Gated by a new **Auto-integrate** setting (default on). All git work is local — pushing the feature branch and opening the PR remain manual for now.
+
 ## v2.66.0
 
 - **Kanban projects registry** — register project folders per board to ground the PM agent in real code. A new **Projects** dialog in the board toolbar lets you add projects (first becomes the default), and the board-scoped PM reads these to route new tickets to the right repo, distinguish feature repos from implementation projects, and understand project structure. (Requires Rune ≥ v0.6.0.)

--- a/docs/superpowers/plans/2026-06-11-kanban-integrate-resolve.md
+++ b/docs/superpowers/plans/2026-06-11-kanban-integrate-resolve.md
@@ -1,0 +1,1174 @@
+# Kanban `integrate()` Stage + `resolve` Run Mode Implementation Plan (#228)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-merge completed feature kanban tasks into their feature integration branch, resolve merge conflicts with a bounded agent-driven `resolve` run, and keep a completed feature's integration branch synced with main — all inside the existing synchronous dispatcher tick, with no origin push or PR (that is #229).
+
+**Architecture:** A new `integrate()` dispatcher stage (gated on a new `autoIntegrate` setting, default on) runs after `claimAndSpawn()`. It has two parts: `integrateTasks()` merges each `review` feature-worktree task into the feature's integration branch (clean → `done` + prune; conflict → spawn a `resolve` run; conflict past a cap of 2 → `blocked`), and `integrateFeatures()` syncs a fully-done feature's integration branch with main (conflict → a synthetic `feature_sync` system task dispatched in `resolve` mode). A new `RunMode='resolve'` reuses the whole worker/claim/heartbeat pipeline; its worker merges the target branch into the task's worktree, resolves conflicts, verifies, commits, and calls `kanban_complete` (→ back to `review`, merge retried next tick). All git work is **local only** — every origin push / `gh pr` call is deferred to #229.
+
+**Tech Stack:** Electron main process, better-sqlite3 (`KanbanStore`), TypeScript, Vitest. Reuses existing `workspace.ts` git helpers (`ensureFeatureBranch`, `checkMergeConflicts`, `mergeWorktreeToBase`, `updateIntegrationBranchFromMain`, `removeWorktree`, `isBranchMerged`) — all synchronous, all merge-only (never push to origin).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md` §1–2, §8–9.
+
+---
+
+## Scope & phase boundary (read first)
+
+This is **phase 2** of the autopilot. It does **local git only**:
+
+- `integrateTasks()` merges a task branch into the **local** feature integration branch via `mergeWorktreeToBase` (which does `git push <repoPath> HEAD:refs/heads/<base>` — a *local* ref update, **never** origin).
+- `integrateFeatures()` syncs via `updateIntegrationBranchFromMain` (fetches `origin/<base>` for freshness but merges **locally**, no push).
+- **No** `createFeaturePr`, **no** `git push origin`, **no** `gh pr ready`, **no** PrPoller changes, **no** draft-PR lifecycle. Those are #229.
+- **No** auto-grouping / feature suggestions / `feature_suggestions` table. That is #230.
+
+`PendingMode` is **not** extended with `'resolve'` (following the #227 precedent: a single synchronous tick makes a flag-then-claim handshake redundant; the dispatcher claims directly via a CAS). Only `RunMode` gains `'resolve'`.
+
+### Constants (define where indicated)
+
+- `RESOLVE_ATTEMPT_CAP = 2` — resolve runs per task before `blocked` + notify. (Independent of the work-phase `failureLimit`; tracked in the new `resolve_attempts` column, not `consecutive_failures`.)
+- `MAX_INTEGRATE_PER_TICK = 3` — max merges + resolve-spawns processed per tick so the tick stays fast.
+
+---
+
+## File structure
+
+| File | Change |
+|---|---|
+| `src/main/kanban/schema.ts` | `SCHEMA_VERSION` 10 → 11 |
+| `src/shared/kanban-types.ts` | `RunMode` += `'resolve'`; `Task` += `resolveAttempts`, `systemKind`; `CreateTaskInput` += `systemKind` |
+| `src/main/kanban/kanban-store.ts` | v11 migration; `rowToTask`/`createTask` for new columns; new query/claim/attempt methods; rollup exclusion |
+| `src/shared/types.ts` | `KanbanSettings.dispatcher` += `autoIntegrate` |
+| `src/shared/constants.ts` | `DEFAULT_SETTINGS.kanban.dispatcher.autoIntegrate = true` |
+| `src/main/kanban/kanban-dispatcher.ts` | `DispatcherConfig.autoIntegrate`; `DispatcherDeps.integration` (test seam); `spawnResolve`, `integrate`, `integrateTasks`, `integrateFeatures`, `requestResolve`; consts; wire into `tick()` |
+| `src/main/kanban/spawn-worker.ts` | `buildPrompt` `resolve` branch; `requireToolsForMode` `resolve`; `BuildWorkerInput.resolveTarget` |
+| `src/main/kanban/kanban-mcp-server.ts` | `RESOLVE_TOOLS`; `toolsForMode` `resolve` branch |
+| `src/main/index.ts` | `buildDispatcherConfig` += `autoIntegrate`; `spawnWorker` `resolve` branch (worker profile + `resolveTarget`) |
+| `src/renderer/src/components/settings/kanban/KanbanSection.tsx` | "Auto-integrate" checkbox |
+| `src/main/__tests__/*.test.ts` | tests per task; `autoIntegrate: false` added to existing dispatcher config literals |
+
+---
+
+## Task 1: Data model — migration v11 + types
+
+**Files:**
+- Modify: `src/main/kanban/schema.ts` (the `SCHEMA_VERSION` line)
+- Modify: `src/shared/kanban-types.ts:15` (`RunMode`), `:135-184` (`Task`), `:282-304` (`CreateTaskInput`)
+- Modify: `src/main/kanban/kanban-store.ts` (migration block; `rowToTask`; `createTask` INSERT)
+- Test: `src/main/__tests__/kanban-store.test.ts`
+
+- [ ] **Step 1: Write the failing test** in `kanban-store.test.ts` (mirror the existing `makeStore`/`beforeEach` harness in that file — do NOT invent a helper):
+
+```typescript
+it('defaults resolve_attempts to 0 and system_kind to null on new tasks', () => {
+  const t = store.createTask({ title: 'x' });
+  const got = store.getTask(t.id)!;
+  expect(got.resolveAttempts).toBe(0);
+  expect(got.systemKind).toBeNull();
+});
+
+it('persists system_kind when provided to createTask', () => {
+  const t = store.createTask({ title: 'sync', systemKind: 'feature_sync' });
+  expect(store.getTask(t.id)!.systemKind).toBe('feature_sync');
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts -t 'resolve_attempts'`
+Expected: FAIL — `resolveAttempts`/`systemKind` undefined.
+
+- [ ] **Step 3: Bump schema version** in `src/main/kanban/schema.ts`: change `export const SCHEMA_VERSION = 10;` to `= 11;`.
+
+- [ ] **Step 4: Add the v11 migration** in `kanban-store.ts`, in the migration ladder (after the `if (current < 10)` block — find it by searching `current < 10`), mirroring the v8/v9 additive pattern:
+
+```typescript
+if (current < 11) {
+  // Phase-2 autopilot: bounded resolve-run budget + synthetic system-task marker.
+  this.addColumnIfMissing('tasks', 'resolve_attempts', 'INTEGER NOT NULL DEFAULT 0');
+  this.addColumnIfMissing('tasks', 'system_kind', 'TEXT');
+}
+```
+
+- [ ] **Step 5: Extend the types** in `src/shared/kanban-types.ts`:
+  - `RunMode`: `export type RunMode = 'work' | 'decompose' | 'specify' | 'assign' | 'resolve';` and update the doc comment to mention `'resolve'`.
+  - `Task` interface: after `consecutiveFailures: number;` add `resolveAttempts: number;` and after `worktreePruned: boolean;` add `systemKind: string | null;` with a doc comment: `/** Non-null marks a dispatcher-created system task (e.g. 'feature_sync'); excluded from feature roll-ups. */`
+  - `CreateTaskInput`: after `scheduledFrom?: string | null;` add `systemKind?: string | null;`
+
+- [ ] **Step 6: Map the columns in `rowToTask`** (search `rowToTask(` in kanban-store.ts). Add, alongside the existing numeric/string field mappings:
+
+```typescript
+resolveAttempts: Number(r.resolve_attempts ?? 0),
+systemKind: (r.system_kind as string | null) ?? null,
+```
+
+- [ ] **Step 7: Write `system_kind` in `createTask`.** In the `createTask` INSERT (search `INSERT INTO tasks`), add the `system_kind` column + binding. The column list, placeholders, and the params object/array must all stay aligned — add `system_kind` to the column list, a matching placeholder, and bind `input.systemKind ?? null`. (`resolve_attempts` needs no INSERT entry — its `DEFAULT 0` covers new rows.)
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts`
+Expected: PASS (new tests + all existing store tests).
+
+- [ ] **Step 9: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no new errors; `RunMode` switch exhaustiveness in spawn-worker/mcp handled in Tasks 4–5).
+
+> NOTE: extending `RunMode` may surface `switch` exhaustiveness or default-branch warnings in `spawn-worker.ts`/`kanban-mcp-server.ts`. Those files get their `'resolve'` cases in Tasks 4–5; if typecheck flags an unhandled case now, it is expected and resolved by those tasks. Do not silence it here.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/main/kanban/schema.ts src/shared/kanban-types.ts src/main/kanban/kanban-store.ts src/main/__tests__/kanban-store.test.ts
+git commit -m "feat(kanban): schema v11 — resolve_attempts + system_kind, RunMode 'resolve'"
+```
+
+---
+
+## Task 2: Settings — `autoIntegrate` (default on) + UI
+
+**Files:**
+- Modify: `src/shared/types.ts` (`KanbanSettings.dispatcher`, near `autoAssign`)
+- Modify: `src/shared/constants.ts` (`DEFAULT_SETTINGS.kanban.dispatcher`, near `autoAssign`)
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`DispatcherConfig`)
+- Modify: `src/main/index.ts` (`buildDispatcherConfig`)
+- Modify: `src/renderer/src/components/settings/kanban/KanbanSection.tsx`
+- Test: `src/main/__tests__/settings-kanban-notifications.test.ts` OR wherever default-settings are asserted (search `autoAssign` in `src/main/__tests__` and `src/shared/__tests__`)
+
+- [ ] **Step 1: Write the failing test.** Find the existing test that asserts `DEFAULT_SETTINGS.kanban.dispatcher.autoAssign` (search `autoAssign` under `__tests__`). Add an adjacent assertion:
+
+```typescript
+expect(DEFAULT_SETTINGS.kanban.dispatcher.autoIntegrate).toBe(true);
+```
+
+If no such test exists, add one to `src/shared/__tests__/` (a tiny `constants` import test mirroring the file's style).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run -t 'autoIntegrate'`
+Expected: FAIL — property missing.
+
+- [ ] **Step 3: Add the type** in `src/shared/types.ts`. In `KanbanSettings.dispatcher`, immediately after `autoAssign: boolean;` add:
+
+```typescript
+/** Auto-merge completed feature tasks into their integration branch; spawn resolve runs on conflict. */
+autoIntegrate: boolean;
+```
+
+- [ ] **Step 4: Add the default** in `src/shared/constants.ts`. In `DEFAULT_SETTINGS.kanban.dispatcher`, after `autoAssign: true,` add `autoIntegrate: true,`.
+
+- [ ] **Step 5: Add to `DispatcherConfig`** in `kanban-dispatcher.ts`, after `autoAssign: boolean;`:
+
+```typescript
+autoIntegrate: boolean; // auto-merge feature review tasks into the integration branch + resolve runs
+```
+
+- [ ] **Step 6: Wire `buildDispatcherConfig`** in `src/main/index.ts` (around line 856): after `autoAssign: d.autoAssign,` add `autoIntegrate: d.autoIntegrate,`.
+
+- [ ] **Step 7: Add the UI row** in `KanbanSection.tsx`. Find the "Auto-assign unassigned tasks" `SettingRow` and add an identical one below it:
+
+```tsx
+<SettingRow label="Auto-integrate completed feature tasks" description="Merge finished feature tasks into the feature branch; resolve conflicts automatically.">
+  <input
+    type="checkbox"
+    className="h-4 w-4"
+    checked={k.dispatcher.autoIntegrate}
+    onChange={(e) => patch({ dispatcher: { ...k.dispatcher, autoIntegrate: e.target.checked } })}
+  />
+</SettingRow>
+```
+
+(Match the exact `SettingRow`/prop shape used by the autoAssign row in this file — copy it verbatim and change label/description/checked/patch key.)
+
+- [ ] **Step 8: Add `autoIntegrate: false` to existing dispatcher config literals.** Search `autoAssign:` across `src/main/__tests__/kanban-dispatcher.test.ts`, `kanban-commands.test.ts`, `kanban-mcp-server.test.ts`. Every inline `DispatcherConfig` object literal (the ones NOT using `...baseConfig`) needs `autoIntegrate: false` added next to `autoAssign`. Also add `autoIntegrate: false` to the `baseConfig` object (`kanban-dispatcher.test.ts:378`). `...baseConfig` spreads inherit it automatically.
+
+- [ ] **Step 9: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts && npm run typecheck`
+Expected: PASS — typecheck is the real gate that every `DispatcherConfig` literal now has `autoIntegrate`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "feat(kanban): autoIntegrate setting (default on) + KanbanSection toggle"
+```
+
+---
+
+## Task 3: Store — integrate/resolve queries, claim, attempts, rollup exclusion
+
+**Files:**
+- Modify: `src/main/kanban/kanban-store.ts`
+- Test: `src/main/__tests__/kanban-store.test.ts`
+
+Add these methods (place each near a sibling: queries near `readyTasks`/`unassignedReadyTasks`; the CAS near `claimForAssign`; attempt mutators near `clearFailures`; rollup edits in `featureRollup`/`listFeatureTasks`).
+
+- [ ] **Step 1: Write failing tests** in `kanban-store.test.ts`:
+
+```typescript
+it('reviewWorktreeFeatureTasks returns only review + worktree + featured + non-system tasks', () => {
+  const f = store.createFeature({ boardId: 'default', name: 'F' });
+  const a = store.createTask({ title: 'a', featureId: f.id, workspaceKind: 'worktree' });
+  store.setWorkspace(a.id, '/tmp/a', 'br-a', 'main');
+  store.reviewTask(a.id, null);
+  // excluded: no feature
+  const b = store.createTask({ title: 'b', workspaceKind: 'worktree' });
+  store.setWorkspace(b.id, '/tmp/b', 'br-b', 'main');
+  store.reviewTask(b.id, null);
+  // excluded: system task
+  const sys = store.createTask({ title: 's', featureId: f.id, workspaceKind: 'worktree', systemKind: 'feature_sync' });
+  store.setWorkspace(sys.id, '/tmp/s', 'br-s', 'main');
+  store.reviewTask(sys.id, null);
+  const ids = store.reviewWorktreeFeatureTasks().map((t) => t.id);
+  expect(ids).toEqual([a.id]);
+});
+
+it('claimForResolve atomically moves a review task to running', () => {
+  const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+  store.reviewTask(t.id, null);
+  expect(store.claimForResolve(t.id, 'L1', 1000)).toBe(true);
+  expect(store.getTask(t.id)!.status).toBe('running');
+  // second claim loses (already running)
+  expect(store.claimForResolve(t.id, 'L2', 1000)).toBe(false);
+});
+
+it('increment/reset resolve attempts', () => {
+  const t = store.createTask({ title: 'x' });
+  store.incrementResolveAttempts(t.id);
+  store.incrementResolveAttempts(t.id);
+  expect(store.getTask(t.id)!.resolveAttempts).toBe(2);
+  store.resetResolveAttempts(t.id);
+  expect(store.getTask(t.id)!.resolveAttempts).toBe(0);
+});
+
+it('openSystemTask finds a non-terminal feature_sync task for a feature', () => {
+  const f = store.createFeature({ boardId: 'default', name: 'F' });
+  expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull();
+  const sys = store.createTask({ title: 's', featureId: f.id, systemKind: 'feature_sync', status: 'review' });
+  expect(store.openSystemTask(f.id, 'feature_sync')?.id).toBe(sys.id);
+  store.completeTask(sys.id, null);
+  expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull(); // done = terminal
+});
+
+it('featureRollup and listFeatureTasks exclude system tasks', () => {
+  const f = store.createFeature({ boardId: 'default', name: 'F' });
+  const a = store.createTask({ title: 'a', featureId: f.id, status: 'done' });
+  store.createTask({ title: 's', featureId: f.id, systemKind: 'feature_sync', status: 'running' });
+  expect(store.featureRollup(f.id).total).toBe(1);
+  expect(store.featureRollup(f.id).done).toBe(1);
+  expect(store.listFeatureTasks(f.id).map((t) => t.id)).toEqual([a.id]);
+});
+```
+
+> Confirm the real signatures of `createFeature`/`setWorkspace`/`reviewTask` in `kanban-store.ts` and adapt the test calls to match (the snippets above assume `createFeature({ boardId, name })` and `setWorkspace(id, path, branch, base)` — fix if the actual API differs).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts -t 'resolve|reviewWorktreeFeature|openSystemTask|exclude system'`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3: Add `reviewWorktreeFeatureTasks`** (near `readyTasks`):
+
+```typescript
+/** Review-column feature tasks with a live worktree, eligible for auto-integration. Excludes system tasks. */
+reviewWorktreeFeatureTasks(): Task[] {
+  const rows = this.db
+    .prepare(
+      `SELECT * FROM tasks
+       WHERE status='review' AND feature_id IS NOT NULL AND system_kind IS NULL
+         AND workspace_kind='worktree' AND workspace_path IS NOT NULL
+         AND branch_name IS NOT NULL AND base_branch IS NOT NULL
+       ORDER BY priority DESC, created_at ASC`
+    )
+    .all() as Array<Record<string, unknown>>;
+  return rows.map((r) => this.rowToTask(r));
+}
+```
+
+- [ ] **Step 4: Add `claimForResolve`** (near `claimForAssign`), atomic CAS `review → running`:
+
+```typescript
+/** Atomically claim a review task for a resolve run (review → running). Returns false if it lost the race. */
+claimForResolve(taskId: string, lock: string, ttlMs: number): boolean {
+  const ts = this.now();
+  const res = this.db
+    .prepare(
+      `UPDATE tasks SET status='running', claim_lock=@lock, claim_expires=@expires,
+         last_heartbeat_at=@ts, updated_at=@ts
+       WHERE id=@id AND status='review'
+         AND (claim_lock IS NULL OR claim_expires <= @ts)`
+    )
+    .run({ id: taskId, lock, expires: ts + ttlMs, ts });
+  return res.changes === 1;
+}
+```
+
+- [ ] **Step 5: Add attempt mutators** (near `clearFailures`):
+
+```typescript
+incrementResolveAttempts(taskId: string): void {
+  this.db
+    .prepare('UPDATE tasks SET resolve_attempts = resolve_attempts + 1, updated_at=? WHERE id=?')
+    .run(this.now(), taskId);
+}
+
+resetResolveAttempts(taskId: string): void {
+  this.db.prepare('UPDATE tasks SET resolve_attempts = 0, updated_at=? WHERE id=?').run(this.now(), taskId);
+}
+```
+
+- [ ] **Step 6: Add `openSystemTask`** (near `listFeatureTasks`):
+
+```typescript
+/** A non-terminal (not done/archived) system task of the given kind for a feature, or null. */
+openSystemTask(featureId: string, kind: string): Task | null {
+  const row = this.db
+    .prepare(
+      `SELECT * FROM tasks WHERE feature_id=? AND system_kind=?
+         AND status NOT IN ('done','archived') ORDER BY created_at ASC LIMIT 1`
+    )
+    .get(featureId, kind) as Record<string, unknown> | undefined;
+  return row ? this.rowToTask(row) : null;
+}
+```
+
+- [ ] **Step 7: Exclude system tasks from roll-ups.** In `featureRollup` add `AND system_kind IS NULL` to the `WHERE feature_id=?` clause. In `listFeatureTasks` add the same to its `WHERE feature_id=?`.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npx vitest run src/main/__tests__/kanban-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/kanban/kanban-store.ts src/main/__tests__/kanban-store.test.ts
+git commit -m "feat(kanban): store queries for integrate/resolve + system-task rollup exclusion"
+```
+
+---
+
+## Task 4: `resolve` run plumbing — spawn-worker prompt + tool gate
+
+**Files:**
+- Modify: `src/main/kanban/spawn-worker.ts` (`BuildWorkerInput`, `buildPrompt`, `requireToolsForMode`)
+- Test: `src/main/__tests__/kanban-spawn-worker.test.ts`
+
+The resolve worker merges a target branch into its own worktree, resolves conflicts, verifies, commits, and completes. It needs to know the **target branch**, passed via a new optional `resolveTarget` on `BuildWorkerInput` (computed by the caller in Task 6).
+
+- [ ] **Step 1: Write failing tests** in `kanban-spawn-worker.test.ts` (mirror the existing assign-mode tests in this file):
+
+```typescript
+it('resolve mode prompt instructs merging the target branch and completing', () => {
+  const out = buildWorkerInvocation({
+    ...baseInput,
+    mode: 'resolve',
+    resolveTarget: 'fleet/feature-abc',
+    task: { ...baseInput.task, id: 'T1', title: 'Fix X', body: '' }
+  });
+  expect(out.args.join(' ')).toContain('fleet/feature-abc');
+  expect(out.args.join(' ')).toMatch(/resolve/i);
+});
+
+it('resolve mode requires kanban_complete', () => {
+  const out = buildWorkerInvocation({ ...baseInput, mode: 'resolve', resolveTarget: 'main' });
+  const i = out.args.indexOf('--require-tool');
+  expect(i).toBeGreaterThan(-1);
+  expect(out.args[i + 1]).toContain('kanban_complete');
+});
+```
+
+> Adapt `baseInput`/`buildWorkerInvocation` to the real harness in this test file (find how the existing `assign`/`work` tests build their input).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-spawn-worker.test.ts -t 'resolve'`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `resolveTarget` to `BuildWorkerInput`** (find the interface in `spawn-worker.ts`): add `resolveTarget?: string;` with a comment `/** Branch to merge into the worktree for a resolve run (integration branch, or base for a feature_sync task). */`.
+
+- [ ] **Step 4: Add the resolve branch to `buildPrompt`** (after the `if (mode === 'assign')` block, before the final `work` return):
+
+```typescript
+if (mode === 'resolve') {
+  const target = input.resolveTarget ?? task.baseBranch ?? 'the base branch';
+  return (
+    `resolve merge conflicts for kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+    `Merge \`${target}\` into your current branch. Resolve every conflict, preserving the intent of ` +
+    `both sides. Verify your resolution (run the project's typecheck/build per the board docs if present). ` +
+    `Commit the merge. Then call kanban_complete with a one-line summary. If the conflicts cannot be ` +
+    `resolved safely, call kanban_block with the reason instead.`
+  );
+}
+```
+
+- [ ] **Step 5: Add the resolve case to `requireToolsForMode`** — add to the `case 'work':`/`case 'decompose':` group so it returns `'kanban_complete,kanban_block'`:
+
+```typescript
+case 'work':
+case 'decompose':
+case 'resolve':
+  return 'kanban_complete,kanban_block';
+```
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-spawn-worker.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kanban/spawn-worker.ts src/main/__tests__/kanban-spawn-worker.test.ts
+git commit -m "feat(kanban): resolve-mode worker prompt + terminal tool"
+```
+
+---
+
+## Task 5: MCP tool gating for `resolve`
+
+**Files:**
+- Modify: `src/main/kanban/kanban-mcp-server.ts` (`RESOLVE_TOOLS`, `toolsForMode`)
+- Test: `src/main/__tests__/kanban-mcp-server.test.ts`
+
+Resolve tools per spec §2: `kanban_show`, `kanban_comment`, `kanban_heartbeat`, `kanban_complete`, `kanban_block`. All already exist in `WORKER_TOOLS`.
+
+- [ ] **Step 1: Write a failing test** in `kanban-mcp-server.test.ts` (find how existing tests assert `toolsForMode`/exposed tools; if `toolsForMode` is not exported, assert via the same mechanism the assign-mode test uses — e.g. listing tools for a registered resolve run):
+
+```typescript
+it('resolve mode exposes show/comment/heartbeat/complete/block and not kanban_create', () => {
+  const names = toolNamesForMode('resolve'); // use the file's existing test accessor
+  expect(names).toEqual(expect.arrayContaining(['kanban_show','kanban_comment','kanban_heartbeat','kanban_complete','kanban_block']));
+  expect(names).not.toContain('kanban_create');
+  expect(names).not.toContain('kanban_assign');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts -t 'resolve mode exposes'`
+Expected: FAIL — resolve falls through to `WORKER_TOOLS` (which may include `kanban_create`/`kanban_artifact`), so the negative assertions fail.
+
+- [ ] **Step 3: Add `RESOLVE_TOOLS`** (after `ASSIGN_TOOLS`, ~line 244), built by filtering `WORKER_TOOLS` to the five names:
+
+```typescript
+const RESOLVE_TOOLS: McpTool[] = WORKER_TOOLS.filter((t) =>
+  ['kanban_show', 'kanban_comment', 'kanban_heartbeat', 'kanban_complete', 'kanban_block'].includes(t.name)
+);
+```
+
+- [ ] **Step 4: Add the branch to `toolsForMode`** (line ~422): after `if (mode === 'assign') return ASSIGN_TOOLS;` add `if (mode === 'resolve') return RESOLVE_TOOLS;`.
+
+- [ ] **Step 5: Verify the `kanban_complete` handler routes a resolve run to `review`.** Find the `kanban_complete` handler. It calls `reviewTask` for worktree tasks (→ `review`) and must **not** prune the worktree (the worktree is needed for the retry merge). Confirm this is already the case — if `kanban_complete` special-cases by run mode, ensure `resolve` lands in the same `review` path as `work`. Add a regression test asserting a resolve-run `kanban_complete` leaves the task in `review`:
+
+```typescript
+it('kanban_complete on a resolve run returns the task to review', async () => {
+  // register a resolve run for a worktree task, call kanban_complete, assert status === 'review'
+  // (mirror the existing kanban_complete test setup, with mode: 'resolve')
+});
+```
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kanban/kanban-mcp-server.ts src/main/__tests__/kanban-mcp-server.test.ts
+git commit -m "feat(kanban): MCP resolve-mode tool gating"
+```
+
+---
+
+## Task 6: Dispatcher — integration deps seam + `spawnResolve` + `index.ts` resolve wiring
+
+**Files:**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (consts, `DispatcherDeps.integration`, `spawnResolve`)
+- Modify: `src/main/index.ts` (`spawnWorker` resolve branch: worker profile + `resolveTarget`)
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+The dispatcher's git ops become an injectable bag so `integrate()` is unit-testable with fakes. In production the bag defaults to the real `workspace.ts` imports, so `index.ts` needs no new wiring for the ops.
+
+- [ ] **Step 1: Write failing tests** in `kanban-dispatcher.test.ts`. Add a `fakeIntegration` helper near `baseConfig` and tests for `spawnResolve` via a thin public entry (`requestResolve`, added here and reused in Task 8):
+
+```typescript
+function fakeIntegration(over: Partial<IntegrationOps> = {}): IntegrationOps {
+  return {
+    ensureFeatureBranch: () => ({ ok: true }),
+    checkMergeConflicts: () => ({ state: 'clean', files: [] }),
+    mergeWorktreeToBase: () => ({ ok: true }),
+    updateIntegrationBranchFromMain: () => ({ ok: true, alreadyUpToDate: true }),
+    removeWorktree: () => ({ branchKept: false }),
+    isBranchMerged: () => false,
+    ...over
+  };
+}
+
+it('requestResolve spawns a resolve run and increments attempts', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+  store.setWorkspace(t.id, '/tmp/x', 'br-x', 'main');
+  store.reviewTask(t.id, null);
+  const spawned: SpawnWorkerArgs[] = [];
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true,
+    spawnWorker: (a) => { spawned.push(a); return 4242; },
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration()
+  });
+  disp.requestResolve(t.id);
+  expect(spawned[0]?.mode).toBe('resolve');
+  expect(store.getTask(t.id)!.status).toBe('running');
+  expect(store.getTask(t.id)!.resolveAttempts).toBe(1);
+  store.close();
+});
+
+it('requestResolve blocks past the attempt cap instead of spawning', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+  store.setWorkspace(t.id, '/tmp/x', 'br-x', 'main');
+  store.reviewTask(t.id, null);
+  store.incrementResolveAttempts(t.id);
+  store.incrementResolveAttempts(t.id); // at cap (2)
+  const spawned: SpawnWorkerArgs[] = [];
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true,
+    spawnWorker: (a) => { spawned.push(a); return 1; },
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration()
+  });
+  disp.requestResolve(t.id);
+  expect(spawned).toHaveLength(0);
+  expect(store.getTask(t.id)!.status).toBe('blocked');
+  store.close();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts -t 'requestResolve'`
+Expected: FAIL — `requestResolve`/`integration` not defined.
+
+- [ ] **Step 3: Add imports + an `IntegrationOps` type + constants** in `kanban-dispatcher.ts`. Extend the existing `workspace` import:
+
+```typescript
+import {
+  finalizeWorktree, isBranchMerged, removeWorktree,
+  ensureFeatureBranch, checkMergeConflicts, mergeWorktreeToBase, updateIntegrationBranchFromMain
+} from './workspace';
+```
+
+Add (near the other module consts):
+
+```typescript
+/** Resolve runs attempted per task before it is blocked. Tracked in tasks.resolve_attempts (independent of failureLimit). */
+const RESOLVE_ATTEMPT_CAP = 2;
+/** Max task merges + resolve spawns processed per integrate() tick, so the tick stays fast. */
+const MAX_INTEGRATE_PER_TICK = 3;
+
+/** Git ops used by integrate(); injectable so the stage is unit-testable. Defaults to the real workspace.ts fns. */
+export interface IntegrationOps {
+  ensureFeatureBranch: typeof ensureFeatureBranch;
+  checkMergeConflicts: typeof checkMergeConflicts;
+  mergeWorktreeToBase: typeof mergeWorktreeToBase;
+  updateIntegrationBranchFromMain: typeof updateIntegrationBranchFromMain;
+  removeWorktree: typeof removeWorktree;
+  isBranchMerged: typeof isBranchMerged;
+}
+
+const DEFAULT_INTEGRATION_OPS: IntegrationOps = {
+  ensureFeatureBranch, checkMergeConflicts, mergeWorktreeToBase,
+  updateIntegrationBranchFromMain, removeWorktree, isBranchMerged
+};
+```
+
+Add `integration?: IntegrationOps;` to `DispatcherDeps` (optional; comment: `/** Git ops for integrate(); injected in tests, defaults to real workspace.ts fns. */`).
+
+Add a private accessor on the class: `private get ops(): IntegrationOps { return this.deps.integration ?? DEFAULT_INTEGRATION_OPS; }`
+
+- [ ] **Step 4: Add `integrationBranchFor(task)` + `resolveTargetFor(task)` private helpers** on the dispatcher (used by spawnResolve and integrate):
+
+```typescript
+/** The feature integration branch a task merges into (or null for a standalone task). */
+private integrationBranchFor(featureId: string | null): string | null {
+  if (!featureId) return null;
+  const f = this.store.getFeature(featureId);
+  if (!f) return null;
+  return f.integrationBranch ?? `fleet/feature-${f.id}`;
+}
+```
+
+- [ ] **Step 5: Add `spawnResolve` + public `requestResolve`.** `spawnResolve` is the shared engine (used by `integrateTasks`, `integrateFeatures`, and `requestResolve`):
+
+```typescript
+/**
+ * Spawn a resolve run for a review task (or block it past the cap). Returns true if a run was spawned.
+ * The worker merges `target` into the task's worktree, resolves, commits, and completes (→ review).
+ */
+private spawnResolve(task: Task, target: string): boolean {
+  const attempts = task.resolveAttempts ?? 0;
+  if (attempts >= RESOLVE_ATTEMPT_CAP) {
+    const note = `merge conflicts unresolved after ${RESOLVE_ATTEMPT_CAP} resolve attempt(s)`;
+    this.store.blockTask(task.id, note);
+    this.store.appendEvent(task.id, null, 'blocked', { reason: note });
+    log.warn('resolve gave up', { taskId: task.id, attempts });
+    return false;
+  }
+  const lock = this.nextLock();
+  if (!this.store.claimForResolve(task.id, lock, this.deps.config.claimTtlMs)) return false; // lost race
+  let runId: number | null = null;
+  try {
+    const workspace = task.workspacePath ?? '';
+    const run = this.store.startRun(task.id, task.assignee ?? 'worker', null, 'resolve');
+    runId = run.id;
+    this.store.incrementResolveAttempts(task.id);
+    const pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode: 'resolve' });
+    if (pid != null) this.store.setWorkerPid(task.id, run.id, pid);
+    this.store.appendEvent(task.id, run.id, 'spawned', { pid: pid ?? null, mode: 'resolve', target, attempt: attempts + 1 });
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    this.store.recordFailure(task.id, msg);
+    if (runId != null) this.store.finishRun(runId, 'spawn_failed', { error: msg });
+    this.store.appendEvent(task.id, runId, 'spawn_failed', { error: msg, mode: 'resolve' });
+    this.store.setStatusCleared(task.id, 'review'); // hand back to review so a later tick retries
+    log.error('resolve spawn failed', { taskId: task.id, error: msg });
+    return false;
+  }
+}
+
+/**
+ * Public entry for the standalone manual-merge-conflict path (KanbanCommands.mergeReviewTask).
+ * Resolves against the task's merge target (its integration branch for a feature task, else its base).
+ */
+requestResolve(taskId: string): boolean {
+  const task = this.store.getTask(taskId);
+  if (!task || task.status !== 'review') return false;
+  const target = this.integrationBranchFor(task.featureId) ?? task.baseBranch;
+  if (!target) return false;
+  return this.spawnResolve(task, target);
+}
+```
+
+- [ ] **Step 6: Wire the `index.ts` `spawnWorker` resolve branch.** In `src/main/index.ts` `spawnWorker` (line ~931), `resolve` must run under a **worker** profile (it writes code) and receive a `resolveTarget`:
+  - Change the profile-selection condition from `if (mode === 'work')` to `if (mode === 'work' || mode === 'resolve')` so resolve uses `resolveWorkProfile(profiles, task.assignee)` (the worker persona that calls `kanban_complete`).
+  - Before building the worker invocation, compute the target:
+
+```typescript
+let resolveTarget: string | undefined;
+if (mode === 'resolve') {
+  if (task.systemKind === 'feature_sync') {
+    // The system task's branch IS the integration branch; merge main (base) into it.
+    resolveTarget = task.baseBranch ?? undefined;
+  } else if (task.featureId) {
+    const f = kanbanStore!.getFeature(task.featureId);
+    resolveTarget = (f?.integrationBranch ?? (f ? `fleet/feature-${f.id}` : undefined)) ?? undefined;
+  } else {
+    resolveTarget = task.baseBranch ?? undefined;
+  }
+}
+```
+
+  - Pass `resolveTarget` into the object handed to `buildWorkerInvocation`.
+  - The `if (mode !== 'assign')` orchestrator-assignee write is in the `else` (orchestrator) branch; since resolve now takes the work-like branch, it won't overwrite the assignee. Confirm this.
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main/kanban/kanban-dispatcher.ts src/main/index.ts src/main/__tests__/kanban-dispatcher.test.ts
+git commit -m "feat(kanban): dispatcher spawnResolve + integration deps seam + index resolve wiring"
+```
+
+---
+
+## Task 7: Dispatcher — `integrateTasks()` (task-level auto-merge)
+
+**Files:**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`integrate`, `integrateTasks`, `tick`)
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+- [ ] **Step 1: Write failing tests** in `kanban-dispatcher.test.ts`:
+
+```typescript
+function reviewFeatureTask(store: KanbanStore) {
+  const f = store.createFeature({ boardId: 'default', name: 'F' });
+  store.updateFeature(f.id, { integrationBranch: `fleet/feature-${f.id}`, repoPath: '/repo', baseBranch: 'main' });
+  const t = store.createTask({ title: 't', featureId: f.id, workspaceKind: 'worktree', repoPath: '/repo', baseBranch: 'main' });
+  store.setWorkspace(t.id, '/tmp/t', 'br-t', 'main');
+  store.reviewTask(t.id, null);
+  return { f, t };
+}
+
+it('integrate: clean feature task → merged, done, pruned, attempts reset', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { t } = reviewFeatureTask(store);
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({ checkMergeConflicts: () => ({ state: 'clean', files: [] }), mergeWorktreeToBase: () => ({ ok: true }) })
+  });
+  disp.integrate();
+  const got = store.getTask(t.id)!;
+  expect(got.status).toBe('done');
+  expect(got.worktreePruned).toBe(true);
+  expect(got.resolveAttempts).toBe(0);
+  store.close();
+});
+
+it('integrate: conflicting feature task → resolve run spawned (not merged)', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { t } = reviewFeatureTask(store);
+  const spawned: SpawnWorkerArgs[] = [];
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: (a) => { spawned.push(a); return 7; },
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({ checkMergeConflicts: () => ({ state: 'conflicts', files: ['a.ts'] }) })
+  });
+  disp.integrate();
+  expect(spawned[0]?.mode).toBe('resolve');
+  expect(store.getTask(t.id)!.status).toBe('running');
+  store.close();
+});
+
+it('integrate: autoIntegrate off → no-op', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { t } = reviewFeatureTask(store);
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+    config: { ...baseConfig, autoIntegrate: false }, integration: fakeIntegration()
+  });
+  disp.integrate();
+  expect(store.getTask(t.id)!.status).toBe('review');
+  store.close();
+});
+
+it('integrate: conflicting task at the resolve cap → blocked', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { t } = reviewFeatureTask(store);
+  store.incrementResolveAttempts(t.id);
+  store.incrementResolveAttempts(t.id); // at cap
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({ checkMergeConflicts: () => ({ state: 'conflicts', files: ['a.ts'] }) })
+  });
+  disp.integrate();
+  expect(store.getTask(t.id)!.status).toBe('blocked');
+  store.close();
+});
+```
+
+> Confirm `createFeature`/`updateFeature` signatures; adapt the helper to the real API. `updateFeature` must accept `repoPath`/`baseBranch`/`integrationBranch` (see `UpdateFeatureInput`).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts -t 'integrate:'`
+Expected: FAIL — `integrate` not defined.
+
+- [ ] **Step 3: Implement `integrate` + `integrateTasks`:**
+
+```typescript
+/** Auto-integrate completed feature tasks and sync completed features. Local git only — no push/PR (that is #229). */
+integrate(): void {
+  if (!this.deps.config.autoIntegrate) return;
+  const budget = this.integrateTasks(MAX_INTEGRATE_PER_TICK);
+  this.integrateFeatures(budget); // Task 8
+}
+
+/** Merge each review feature task into its integration branch; spawn a resolve run on conflict. Returns remaining budget. */
+private integrateTasks(budget: number): number {
+  for (const task of this.store.reviewWorktreeFeatureTasks()) {
+    if (budget <= 0) break;
+    if (!task.repoPath || !task.branchName || !task.baseBranch || !task.workspacePath) continue;
+    const integrationBranch = this.integrationBranchFor(task.featureId);
+    if (!integrationBranch) continue;
+
+    const ensured = this.ops.ensureFeatureBranch({
+      repoPath: task.repoPath, integrationBranch, baseBranch: task.baseBranch
+    });
+    if (!ensured.ok) {
+      this.store.appendEvent(task.id, null, 'merge_failed', { base: integrationBranch, error: ensured.error });
+      continue;
+    }
+
+    const pred = this.ops.checkMergeConflicts({
+      repoPath: task.repoPath, baseBranch: integrationBranch, branchName: task.branchName
+    });
+    if (pred.state === 'error') continue; // can't predict — leave in review for a human
+    if (pred.state === 'conflicts') {
+      if (this.spawnResolve(task, integrationBranch)) budget -= 1;
+      continue;
+    }
+    // clean prediction → real merge into the (local) integration branch
+    const res = this.ops.mergeWorktreeToBase({
+      repoPath: task.repoPath, branchName: task.branchName, baseBranch: integrationBranch,
+      worktreeParentDir: dirname(task.workspacePath), taskId: task.id, title: task.title
+    });
+    if (res.ok) {
+      this.store.completeTask(task.id, task.result);
+      this.store.appendEvent(task.id, null, 'merged', { base: integrationBranch, branch: task.branchName, by: 'integrate' });
+      this.ops.removeWorktree({
+        repoPath: task.repoPath, workspacePath: task.workspacePath,
+        branchName: task.branchName, baseBranch: integrationBranch
+      });
+      this.store.setWorktreePruned(task.id);
+      this.store.appendEvent(task.id, null, 'worktree_pruned', { branch: task.branchName, by: 'integrate' });
+      this.store.resetResolveAttempts(task.id);
+      budget -= 1;
+    } else if (res.conflict) {
+      // prediction raced (clean → dirty); fall back to a resolve run
+      if (this.spawnResolve(task, integrationBranch)) budget -= 1;
+    } else {
+      this.store.appendEvent(task.id, null, 'merge_failed', { base: integrationBranch, error: res.error });
+    }
+  }
+  return budget;
+}
+```
+
+- [ ] **Step 4: Add the `dirname` import** at the top of `kanban-dispatcher.ts`: `import { dirname } from 'path';`
+
+- [ ] **Step 5: Add a temporary `integrateFeatures` stub** so this task typechecks/tests in isolation (replaced fully in Task 8):
+
+```typescript
+private integrateFeatures(_budget: number): void { /* implemented in Task 8 */ }
+```
+
+- [ ] **Step 6: Wire into `tick()`** — add `this.integrate();` after `this.claimAndSpawn();` and before `this.sweepArtifacts();`:
+
+```typescript
+tick(): void {
+  this.reclaim();
+  this.fireSchedules();
+  this.decompose();
+  this.autoAssign();
+  this.promote();
+  this.claimAndSpawn();
+  this.integrate();
+  this.sweepArtifacts();
+  this.sweepMergedWorktrees();
+}
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main/kanban/kanban-dispatcher.ts src/main/__tests__/kanban-dispatcher.test.ts
+git commit -m "feat(kanban): integrate() task-level auto-merge + resolve dispatch"
+```
+
+---
+
+## Task 8: Dispatcher — `integrateFeatures()` (completion sync + feature-sync system task)
+
+**Files:**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (replace the `integrateFeatures` stub; add `createFeatureSyncTask`)
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+Behavior: for each `active` feature whose member tasks (system tasks excluded) are all `done`/`archived` and whose integration branch is ahead of base (something merged), sync the integration branch with main. Clean → done (mark `mergeState='in_progress'` so it fires once); conflict → a `feature_sync` system task dispatched in resolve mode. A running/blocked system task gates re-entry.
+
+- [ ] **Step 1: Write failing tests** in `kanban-dispatcher.test.ts`:
+
+```typescript
+function doneFeature(store: KanbanStore) {
+  const f = store.createFeature({ boardId: 'default', name: 'F' });
+  store.updateFeature(f.id, { integrationBranch: `fleet/feature-${f.id}`, repoPath: '/repo', baseBranch: 'main' });
+  const a = store.createTask({ title: 'a', featureId: f.id, status: 'done', repoPath: '/repo', baseBranch: 'main' });
+  return { f, a };
+}
+
+it('integrateFeatures: all done + clean sync → no system task, fires once', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { f } = doneFeature(store);
+  let syncCalls = 0;
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({
+      isBranchMerged: () => false, // integration ahead of base → something merged
+      updateIntegrationBranchFromMain: () => { syncCalls++; return { ok: true }; }
+    })
+  });
+  disp.integrate();
+  disp.integrate(); // second tick must NOT re-sync
+  expect(syncCalls).toBe(1);
+  expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull();
+  store.close();
+});
+
+it('integrateFeatures: sync conflict → feature_sync system task spawned in resolve mode', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { f } = doneFeature(store);
+  const spawned: SpawnWorkerArgs[] = [];
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: (a) => { spawned.push(a); return 9; },
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({ isBranchMerged: () => false, updateIntegrationBranchFromMain: () => ({ ok: false, conflict: true }) })
+  });
+  disp.integrate();
+  const sys = store.openSystemTask(f.id, 'feature_sync');
+  expect(sys).not.toBeNull();
+  expect(sys!.systemKind).toBe('feature_sync');
+  expect(spawned[0]?.mode).toBe('resolve');
+  expect(store.featureRollup(f.id).total).toBe(1); // system task excluded
+  store.close();
+});
+
+it('integrateFeatures: nothing merged (integration == base) → skip', () => {
+  const clock = { t: 1000 };
+  const store = makeStore(clock);
+  const { f } = doneFeature(store);
+  let syncCalls = 0;
+  const disp = new KanbanDispatcher(store, {
+    now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+    config: { ...baseConfig, autoIntegrate: true },
+    integration: fakeIntegration({ isBranchMerged: () => true, updateIntegrationBranchFromMain: () => { syncCalls++; return { ok: true }; } })
+  });
+  disp.integrate();
+  expect(syncCalls).toBe(0);
+  store.close();
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts -t 'integrateFeatures'`
+Expected: FAIL — stub is a no-op.
+
+- [ ] **Step 3: Replace the stub** with the real `integrateFeatures` + `createFeatureSyncTask`:
+
+```typescript
+/** Sync each fully-done feature's integration branch with main; spawn a feature_sync resolve task on conflict. */
+private integrateFeatures(budget: number): void {
+  for (const feature of this.store.listFeatures({ status: 'active' })) {
+    if (budget <= 0) break;
+    if (!feature.repoPath || !feature.baseBranch) continue;
+    const integrationBranch = feature.integrationBranch ?? `fleet/feature-${feature.id}`;
+
+    const rollup = this.store.featureRollup(feature.id); // system tasks already excluded
+    const allDone = rollup.total > 0 && rollup.done + rollup.archived === rollup.total;
+    if (!allDone) continue;
+
+    // Only act once integration actually contains merged work (branch ahead of base).
+    if (this.ops.isBranchMerged({ repoPath: feature.repoPath, branchName: integrationBranch, baseBranch: feature.baseBranch })) {
+      continue;
+    }
+
+    const open = this.store.openSystemTask(feature.id, 'feature_sync');
+    if (open?.status === 'running') continue; // a resolve is already in flight
+
+    // Fire-once guard for the clean path: 'in_progress' means "integration synced, awaiting #229 ship".
+    if (!open && (feature.mergeState === 'in_progress' || feature.mergeState === 'merged')) continue;
+
+    const sync = this.ops.updateIntegrationBranchFromMain({
+      repoPath: feature.repoPath, integrationBranch, baseBranch: feature.baseBranch
+    });
+
+    if (sync.ok) {
+      if (open) { // a prior conflict was resolved by the system task → close it out
+        this.store.completeTask(open.id, 'synced with main');
+        this.store.appendEvent(open.id, null, 'merged', { base: feature.baseBranch, by: 'feature_sync' });
+      }
+      this.store.updateFeature(feature.id, { mergeState: 'in_progress' });
+    } else if (sync.conflict) {
+      this.store.updateFeature(feature.id, { mergeState: 'conflict' });
+      const target = feature.baseBranch;
+      if (open?.status === 'review') {
+        if (this.spawnResolve(open, target)) budget -= 1;
+      } else if (!open) {
+        const sys = this.createFeatureSyncTask(feature, integrationBranch);
+        if (sys && this.spawnResolve(sys, target)) budget -= 1;
+      }
+    }
+    // sync error (e.g. base not found): leave for next tick
+  }
+}
+
+/**
+ * Create the synthetic system task whose worktree checks out the integration branch itself,
+ * so a resolve run can merge main into it. Excluded from feature roll-ups via system_kind.
+ */
+private createFeatureSyncTask(feature: Feature, integrationBranch: string): Task | null {
+  if (!feature.repoPath || !feature.baseBranch) return null;
+  const task = this.store.createTask({
+    title: `Sync ${feature.name} with main`,
+    body: `Merge ${feature.baseBranch} into ${integrationBranch} and resolve any conflicts so the feature can ship.`,
+    status: 'review', // spawnResolve claims from review
+    boardId: feature.boardId,
+    featureId: feature.id,
+    systemKind: 'feature_sync',
+    workspaceKind: 'worktree',
+    repoPath: feature.repoPath,
+    branchName: integrationBranch, // the worktree checks out the integration branch
+    baseBranch: feature.baseBranch
+  });
+  // The system task's worktree must check out the integration branch. prepareWorkspaceFn
+  // (index.ts) branches from branchName when workspace_path is null; persist the intended branch now.
+  this.store.appendEvent(task.id, null, 'task_created', { by: 'dispatcher', system: 'feature_sync' });
+  return task;
+}
+```
+
+- [ ] **Step 4: Add the `Feature` type import** to `kanban-dispatcher.ts`: extend the `kanban-types` import to include `Feature` (and `Task` is already imported).
+
+- [ ] **Step 5: Verify the system task's worktree is created on the integration branch.** The system task has `workspacePath == null`, so when `spawnResolve` calls `spawnWorker`, `index.ts` `prepareWorkspaceFn` runs first (in the dispatcher's `claimAndSpawn`? No — resolve bypasses prepareWorkspaceFn). **Important:** `spawnResolve` passes `workspace: task.workspacePath ?? ''`. For a freshly-created system task that is empty. The system task needs its worktree prepared. Handle this in `spawnResolve`: if `task.workspacePath == null` and `this.deps.prepareWorkspaceFn` exists, call it to create the worktree first, then use the returned path. Update `spawnResolve` Step 5 (Task 6) accordingly:
+
+```typescript
+// inside spawnResolve, replace `const workspace = task.workspacePath ?? '';` with:
+let workspace = task.workspacePath ?? '';
+if (!workspace && this.deps.prepareWorkspaceFn) {
+  workspace = this.deps.prepareWorkspaceFn(task); // creates the worktree on task.branchName
+}
+```
+
+  `prepareWorkspace` (index.ts) uses `startPoint: task.baseBranch ?? featureStartPoint` and `branchName: task.branchName`. For the system task, `branchName` is the integration branch (an existing branch), so prepareWorkspace checks it out. Confirm `prepareWorkspace` checks out an existing `branchName` rather than erroring. If it always creates a new branch, the system-task worktree setup needs `prepareWorkspace` to support an existing branch — verify in `workspace.ts prepareWorkspace` and adjust the plan note if needed. (In tests, `prepareWorkspaceFn` is absent, so the fake path `''` is used and `spawnWorker` is the injected fake — the worktree mechanics are exercised manually, not in unit tests.)
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kanban/kanban-dispatcher.ts src/main/__tests__/kanban-dispatcher.test.ts
+git commit -m "feat(kanban): integrateFeatures() completion sync + feature_sync system task"
+```
+
+---
+
+## Task 9: Standalone manual-merge → resolve
+
+**Files:**
+- Modify: `src/main/kanban/kanban-commands.ts` (`mergeReviewTask` conflict branch)
+- Test: `src/main/__tests__/kanban-commands.test.ts`
+
+When the human clicks "Merge to base" on a standalone (or feature) worktree task and the merge **conflicts**, spawn a resolve run instead of only commenting. `KanbanCommands` already holds `this.dispatcher` (it calls `this.dispatcher.tick()`).
+
+- [ ] **Step 1: Write a failing test** in `kanban-commands.test.ts`. Find how this file constructs `KanbanCommands` with a dispatcher (or a stub). Stub `dispatcher.requestResolve` and assert it is called on a conflicting merge:
+
+```typescript
+it('mergeReviewTask on conflict requests a resolve run', () => {
+  // Arrange a review worktree task whose mergeWorktreeToBase returns { ok:false, conflict:true }.
+  // (mock the workspace merge fn the same way other commands tests stub git, OR point repoPath at a
+  //  fixture that conflicts — follow the existing pattern in this file.)
+  const calls: string[] = [];
+  commands.setDispatcher({ tick: () => {}, requestResolve: (id: string) => { calls.push(id); return true; } } as unknown as KanbanDispatcher);
+  const res = commands.mergeReviewTask(task.id);
+  expect(res.ok).toBe(false);
+  expect(res.conflict).toBe(true);
+  expect(calls).toEqual([task.id]);
+});
+```
+
+> Match the file's actual dispatcher-injection mechanism (constructor arg, a setter, or a stub object). If conflicts are hard to simulate via real git in this test file, follow whatever stubbing the existing `mergeReviewTask` tests use.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/main/__tests__/kanban-commands.test.ts -t 'requests a resolve'`
+Expected: FAIL — no `requestResolve` call.
+
+- [ ] **Step 3: Update `mergeReviewTask`'s conflict branch** (kanban-commands.ts:656-665). In the `if (!result.ok)` block, when `result.conflict` is true, after the existing comment + `merge_failed` event, request a resolve run:
+
+```typescript
+if (!result.ok) {
+  const reason = result.conflict
+    ? `merge conflict against ${task.baseBranch}; spawning a resolve run`
+    : (result.error ?? 'merge failed');
+  this.store.addComment(id, 'human', `merge to ${task.baseBranch} failed: ${reason}`);
+  this.store.appendEvent(id, null, 'merge_failed', { base: task.baseBranch, conflict: !!result.conflict });
+  if (result.conflict) this.dispatcher.requestResolve(id);
+  return { ok: false, conflict: result.conflict, error: reason };
+}
+```
+
+(The task is still in `review` when `mergeReviewTask` runs, so `requestResolve`'s `status === 'review'` guard and `claimForResolve` CAS both hold.)
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `npx vitest run src/main/__tests__/kanban-commands.test.ts && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kanban/kanban-commands.ts src/main/__tests__/kanban-commands.test.ts
+git commit -m "feat(kanban): manual merge conflict spawns a resolve run"
+```
+
+---
+
+## Task 10: Full verification + UI badge (optional polish) + changelog
+
+**Files:**
+- Modify: `src/renderer/src/components/kanban/...` (resolve badge — only if a low-risk existing badge pattern exists)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Resolve/attempt badge (light touch).** The board already renders run-mode/event badges (spec §7). If the card/drawer has an existing badge driven by run mode or the latest event, add a `resolve` case showing e.g. `resolving conflicts — attempt N/2` (N = `task.resolveAttempts`). If no clean seam exists, SKIP this step and note it as a #229/follow-up — do not build new UI plumbing here. Add a test only if you touch renderer logic with existing test coverage.
+
+- [ ] **Step 2: Full typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Full kanban test suite**
+
+Run: `npx vitest run src/main/__tests__/kanban-*.test.ts src/shared/__tests__/kanban-*.test.ts`
+Expected: PASS (all green).
+
+- [ ] **Step 4: Lint (net-zero check).** Repo lint is pre-existing-red in `kanban-store.ts`/`kanban-mcp-server.ts`. Confirm this change adds **no new** lint errors:
+
+Run: `npm run lint`
+Then compare the per-file error counts for touched files against `main`. Expected: net-zero new errors. No `as` casts (use the existing `.all() as Array<Record<string, unknown>>` query-cast convention only), no `eslint-disable` in `src`.
+
+- [ ] **Step 5: Build**
+
+Run: `npm run build`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Add a CHANGELOG entry** under a new `## vX.Y.Z` heading (next patch/minor — check current version in `package.json`), e.g.:
+
+```markdown
+## v2.67.0
+
+- Kanban autopilot phase 2: completed feature tasks now auto-merge into their feature integration branch; merge conflicts spawn a bounded agent-driven resolve run (max 2 attempts, then the task blocks with a notification). Completed features auto-sync their integration branch with main. New `autoIntegrate` setting (default on). (#228)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "docs(kanban): changelog for integrate/resolve (autopilot phase 2, #228)"
+```
+
+---
+
+## Final review
+
+After all tasks: dispatch a final whole-branch code review (per subagent-driven-development), then use `superpowers:finishing-a-development-branch` to open the PR (`Closes #228`). Verify against the issue's "Done when":
+
+1. A feature task completing with a clean merge reaches `done` with no human click. ✓ (Task 7)
+2. A conflicting task gets a resolve run, then merges; after 2 failed attempts it blocks with a notification. ✓ (Tasks 6–7; `blocked` event → notification via `classifyKanbanEvent`)
+3. Vitest coverage per spec §9. ✓ (Tasks 1–9)
+
+**Phase boundary reminder for the PR description:** #228 is local-git only. No origin push, no `gh pr` — draft-PR lifecycle, `gh pr ready`, and the feature-ready notification are #229.

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -24,6 +24,7 @@ function makeCommands(): { store: KanbanStore; commands: KanbanCommands } {
       claimTtlMs: 1000,
       autoDecompose: false,
       autoAssign: false,
+      autoIntegrate: false,
       maxDecompose: 1,
       artifactRetentionDays: 0
     }
@@ -274,6 +275,7 @@ describe('KanbanCommands comment/link/log/dispatch', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -309,6 +311,7 @@ describe('KanbanCommands replyAndResume', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 0,
         artifactRetentionDays: 0
       }
@@ -617,6 +620,7 @@ describe('KanbanCommands.createSwarm', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -470,6 +470,83 @@ describe('KanbanCommands archive worktree teardown', () => {
   });
 });
 
+describe('KanbanCommands mergeReviewTask conflict', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('mergeReviewTask on conflict requests a resolve run', () => {
+    const store = new KanbanStore(
+      join(TEST_DIR, `merge-conflict-${Math.random().toString(36).slice(2)}.db`)
+    );
+    const dispatcher = new KanbanDispatcher(store, {
+      now: () => 0,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: {
+        failureLimit: 2,
+        claimGraceMs: 0,
+        maxInProgress: 3,
+        claimTtlMs: 1000,
+        autoDecompose: false,
+        autoAssign: false,
+        autoIntegrate: false,
+        maxDecompose: 1,
+        artifactRetentionDays: 0
+      }
+    });
+    // Record requestResolve calls; return false so no real resolve run spawns.
+    const calls: string[] = [];
+    dispatcher.requestResolve = (taskId: string): boolean => {
+      calls.push(taskId);
+      return false;
+    };
+    const commands = new KanbanCommands(store, dispatcher, () => ({
+      workspaceKind: 'scratch',
+      maxRuntimeSeconds: null
+    }));
+
+    // A repo whose main branch already has a tracked file.
+    const repo = makeRepo('cmd-merge-conflict');
+    writeFileSync(join(repo, 'shared.txt'), 'base\n');
+    execFileSync('git', ['-C', repo, 'add', '-A']);
+    execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'add shared']);
+
+    const task = store.createTask({
+      title: 'conflicting task',
+      status: 'todo',
+      workspaceKind: 'worktree',
+      repoPath: repo
+    });
+    const wt = prepareWorkspace({
+      kind: 'worktree',
+      taskId: task.id,
+      workspacesRoot: TEST_DIR,
+      worktreesRoot: join(TEST_DIR, 'worktrees'),
+      repoPath: repo
+    });
+    store.setWorkspace(task.id, wt.path, wt.branchName, wt.baseBranch);
+
+    // Diverge: the branch and main both edit shared.txt differently → merge conflicts.
+    writeFileSync(join(wt.path, 'shared.txt'), 'branch change\n');
+    execFileSync('git', ['-C', wt.path, 'add', '-A']);
+    execFileSync('git', ['-C', wt.path, 'commit', '-q', '-m', 'branch edit']);
+    writeFileSync(join(repo, 'shared.txt'), 'main change\n');
+    execFileSync('git', ['-C', repo, 'add', '-A']);
+    execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'main edit']);
+
+    commands.setManualStatus(task.id, 'review');
+
+    const res = commands.mergeReviewTask(task.id);
+    expect(res.ok).toBe(false);
+    expect(res.conflict).toBe(true);
+    expect(calls).toEqual([task.id]);
+  });
+});
+
 describe('KanbanCommands attachments', () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -1051,6 +1051,59 @@ describe('KanbanDispatcher.integrate', () => {
     store.close();
   });
 
+  it('integrate: conflict prediction errors -> task stays in review, no spawn, no merge', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    const spawned: SpawnWorkerArgs[] = [];
+    let merges = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 1;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        checkMergeConflicts: () => ({ state: 'error', files: [] }),
+        mergeWorktreeToBase: () => {
+          merges++;
+          return { ok: true };
+        }
+      })
+    });
+    disp.integrate();
+    expect(spawned).toHaveLength(0);
+    expect(merges).toBe(0);
+    expect(store.getTask(t.id)!.status).toBe('review');
+    store.close();
+  });
+
+  it('integrate: clean prediction but merge races dirty -> resolve run spawned', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 8;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        checkMergeConflicts: () => ({ state: 'clean', files: [] }),
+        mergeWorktreeToBase: () => ({ ok: false, conflict: true })
+      })
+    });
+    disp.integrate();
+    expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.getTask(t.id)!.status).toBe('running');
+    store.close();
+  });
+
   function doneFeature(store: KanbanStore) {
     const f = store.createFeature({ boardId: 'default', name: 'F' });
     store.updateFeature(f.id, {
@@ -1107,7 +1160,9 @@ describe('KanbanDispatcher.integrate', () => {
       },
       config: { ...baseConfig, autoIntegrate: true },
       integration: fakeIntegration({
-        isBranchMerged: () => false,
+        // ahead-check on the integration branch → false (something merged);
+        // synced-check would be on 'main' but no review task exists yet.
+        isBranchMerged: ({ branchName }) => branchName === 'main',
         updateIntegrationBranchFromMain: () => ({ ok: false, conflict: true })
       })
     });
@@ -1116,6 +1171,7 @@ describe('KanbanDispatcher.integrate', () => {
     expect(sys).not.toBeNull();
     expect(sys!.systemKind).toBe('feature_sync');
     expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.getFeature(f.id)!.mergeState).toBe('conflict');
     expect(store.featureRollup(f.id).total).toBe(1); // system task excluded
     store.close();
   });
@@ -1140,6 +1196,114 @@ describe('KanbanDispatcher.integrate', () => {
     });
     disp.integrate();
     expect(syncCalls).toBe(0);
+    store.close();
+  });
+
+  it('integrateFeatures: sync error (no conflict) -> no system task, mergeState unchanged', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { f } = doneFeature(store);
+    expect(store.getFeature(f.id)!.mergeState).toBeNull(); // baseline
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 1;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        // ahead-check on the integration branch → false (something merged).
+        isBranchMerged: ({ branchName }) => branchName === 'main',
+        updateIntegrationBranchFromMain: () => ({ ok: false }) // e.g. base branch not found
+      })
+    });
+    disp.integrate();
+    expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull();
+    expect(store.getFeature(f.id)!.mergeState).toBeNull(); // not 'conflict', not 'in_progress'
+    expect(spawned).toHaveLength(0);
+    store.close();
+  });
+
+  // A feature in 'conflict' whose feature_sync resolve worker has finished (status 'review').
+  function conflictedFeatureWithReviewSync(store: KanbanStore) {
+    const { f, a } = doneFeature(store);
+    store.updateFeature(f.id, { mergeState: 'conflict' });
+    const integrationBranch = `fleet/feature-${f.id}`;
+    const sys = store.createTask({
+      title: `Sync F with main`,
+      featureId: f.id,
+      systemKind: 'feature_sync',
+      workspaceKind: 'worktree',
+      status: 'review',
+      repoPath: '/repo',
+      branchName: integrationBranch,
+      baseBranch: 'main'
+    });
+    store.setWorkspace(sys.id, '/tmp/sync', integrationBranch, 'main');
+    return { f, a, sys, integrationBranch };
+  }
+
+  it('integrateFeatures: review feature_sync that synced -> completed + worktree pruned + in_progress', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { f, sys } = conflictedFeatureWithReviewSync(store);
+    let removeCalls = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        // ahead-check on the integration branch → false (it's ahead of base);
+        // synced-check on 'main' (base) → true (base now an ancestor of integration).
+        isBranchMerged: ({ branchName }) => branchName === 'main',
+        removeWorktree: () => {
+          removeCalls++;
+          return { branchKept: true };
+        }
+      })
+    });
+    disp.integrate();
+    const got = store.getTask(sys.id)!;
+    expect(got.status).toBe('done');
+    expect(got.worktreePruned).toBe(true);
+    expect(removeCalls).toBe(1);
+    expect(store.getFeature(f.id)!.mergeState).toBe('in_progress');
+    store.close();
+  });
+
+  it('integrateFeatures: review feature_sync that did NOT sync -> respawns resolve, then blocks at cap', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { sys } = conflictedFeatureWithReviewSync(store);
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => {
+        spawned.push(args);
+        return 5;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        // ahead-check false; synced-check on 'main' → false (worker did NOT merge).
+        isBranchMerged: () => false
+      })
+    });
+    // First tick: a resolve run is spawned and attempts increment.
+    disp.integrate();
+    expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.getTask(sys.id)!.resolveAttempts).toBe(1);
+
+    // Drive to the cap: each tick the worker hands the task back to review unresolved.
+    store.setStatusCleared(sys.id, 'review');
+    disp.integrate(); // second resolve (attempts → 2, at cap)
+    expect(store.getTask(sys.id)!.resolveAttempts).toBe(2);
+    store.setStatusCleared(sys.id, 'review');
+    disp.integrate(); // at cap → blocked instead of spawning
+    expect(store.getTask(sys.id)!.status).toBe('blocked');
     store.close();
   });
 });

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -1050,4 +1050,96 @@ describe('KanbanDispatcher.integrate', () => {
     expect(store.getTask(t.id)!.status).toBe('blocked');
     store.close();
   });
+
+  function doneFeature(store: KanbanStore) {
+    const f = store.createFeature({ boardId: 'default', name: 'F' });
+    store.updateFeature(f.id, {
+      integrationBranch: `fleet/feature-${f.id}`,
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    const a = store.createTask({
+      title: 'a',
+      featureId: f.id,
+      status: 'done',
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    return { f, a };
+  }
+
+  it('integrateFeatures: all done + clean sync -> no system task, fires once', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { f } = doneFeature(store);
+    let syncCalls = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        isBranchMerged: () => false, // integration ahead of base → something merged
+        updateIntegrationBranchFromMain: () => {
+          syncCalls++;
+          return { ok: true };
+        }
+      })
+    });
+    disp.integrate();
+    disp.integrate(); // second tick must NOT re-sync
+    expect(syncCalls).toBe(1);
+    expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull();
+    store.close();
+  });
+
+  it('integrateFeatures: sync conflict -> feature_sync system task spawned in resolve mode', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { f } = doneFeature(store);
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 9;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        isBranchMerged: () => false,
+        updateIntegrationBranchFromMain: () => ({ ok: false, conflict: true })
+      })
+    });
+    disp.integrate();
+    const sys = store.openSystemTask(f.id, 'feature_sync');
+    expect(sys).not.toBeNull();
+    expect(sys!.systemKind).toBe('feature_sync');
+    expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.featureRollup(f.id).total).toBe(1); // system task excluded
+    store.close();
+  });
+
+  it('integrateFeatures: nothing merged (integration == base) -> skip', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    doneFeature(store);
+    let syncCalls = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        isBranchMerged: () => true,
+        updateIntegrationBranchFromMain: () => {
+          syncCalls++;
+          return { ok: true };
+        }
+      })
+    });
+    disp.integrate();
+    expect(syncCalls).toBe(0);
+    store.close();
+  });
 });

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -35,6 +35,7 @@ describe('KanbanDispatcher.reclaim', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -64,6 +65,7 @@ describe('KanbanDispatcher.reclaim', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -205,6 +207,7 @@ describe('KanbanDispatcher.reclaim', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -236,6 +239,7 @@ describe('KanbanDispatcher.promote', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -262,6 +266,7 @@ describe('KanbanDispatcher.promote', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -295,6 +300,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -332,6 +338,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -359,6 +366,7 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -382,6 +390,7 @@ const baseConfig = {
   claimTtlMs: 1000,
   autoDecompose: false,
   autoAssign: false,
+  autoIntegrate: false,
   maxDecompose: 1,
   artifactRetentionDays: 0
 };
@@ -660,6 +669,7 @@ describe('KanbanDispatcher.fireSchedules', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -751,6 +761,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }
@@ -766,6 +777,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       },
@@ -788,6 +800,7 @@ describe('KanbanDispatcher.reconfigure', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       };
@@ -836,6 +849,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           claimTtlMs: 1000,
           autoDecompose: false,
           autoAssign: false,
+          autoIntegrate: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },
@@ -849,6 +863,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           claimTtlMs: 1000,
           autoDecompose: false,
           autoAssign: false,
+          autoIntegrate: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -3,7 +3,11 @@ import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { KanbanStore } from '../kanban/kanban-store';
-import { KanbanDispatcher } from '../kanban/kanban-dispatcher';
+import {
+  KanbanDispatcher,
+  type SpawnWorkerArgs,
+  type IntegrationOps
+} from '../kanban/kanban-dispatcher';
 
 const TEST_DIR = join(tmpdir(), `fleet-kanban-disp-test-${Date.now()}`);
 
@@ -394,6 +398,18 @@ const baseConfig = {
   maxDecompose: 1,
   artifactRetentionDays: 0
 };
+
+function fakeIntegration(over: Partial<IntegrationOps> = {}): IntegrationOps {
+  return {
+    ensureFeatureBranch: () => ({ ok: true }),
+    checkMergeConflicts: () => ({ state: 'clean', files: [] }),
+    mergeWorktreeToBase: () => ({ ok: true }),
+    updateIntegrationBranchFromMain: () => ({ ok: true, alreadyUpToDate: true }),
+    removeWorktree: () => ({ branchKept: false }),
+    isBranchMerged: () => false,
+    ...over
+  };
+}
 
 describe('KanbanDispatcher.decompose', () => {
   beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
@@ -874,5 +890,59 @@ describe('KanbanDispatcher.reconfigure', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('KanbanDispatcher.requestResolve', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('requestResolve spawns a resolve run and increments attempts', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+    store.setWorkspace(t.id, '/tmp/x', 'br-x', 'main');
+    store.reviewTask(t.id, null);
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 4242;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration()
+    });
+    disp.requestResolve(t.id);
+    expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.getTask(t.id)!.status).toBe('running');
+    expect(store.getTask(t.id)!.resolveAttempts).toBe(1);
+    store.close();
+  });
+
+  it('requestResolve blocks past the attempt cap instead of spawning', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+    store.setWorkspace(t.id, '/tmp/x', 'br-x', 'main');
+    store.reviewTask(t.id, null);
+    store.incrementResolveAttempts(t.id);
+    store.incrementResolveAttempts(t.id); // at cap (2)
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 1;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration()
+    });
+    disp.requestResolve(t.id);
+    expect(spawned).toHaveLength(0);
+    expect(store.getTask(t.id)!.status).toBe('blocked');
+    store.close();
   });
 });

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -946,3 +946,108 @@ describe('KanbanDispatcher.requestResolve', () => {
     store.close();
   });
 });
+
+describe('KanbanDispatcher.integrate', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  function reviewFeatureTask(store: KanbanStore) {
+    const f = store.createFeature({ boardId: 'default', name: 'F' });
+    store.updateFeature(f.id, {
+      integrationBranch: `fleet/feature-${f.id}`,
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    const t = store.createTask({
+      title: 't',
+      featureId: f.id,
+      workspaceKind: 'worktree',
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    store.setWorkspace(t.id, '/tmp/t', 'br-t', 'main');
+    store.reviewTask(t.id, null);
+    return { f, t };
+  }
+
+  it('integrate: clean feature task -> merged, done, pruned, attempts reset', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        checkMergeConflicts: () => ({ state: 'clean', files: [] }),
+        mergeWorktreeToBase: () => ({ ok: true })
+      })
+    });
+    disp.integrate();
+    const got = store.getTask(t.id)!;
+    expect(got.status).toBe('done');
+    expect(got.worktreePruned).toBe(true);
+    expect(got.resolveAttempts).toBe(0);
+    store.close();
+  });
+
+  it('integrate: conflicting feature task -> resolve run spawned (not merged)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    const spawned: SpawnWorkerArgs[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (a) => {
+        spawned.push(a);
+        return 7;
+      },
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        checkMergeConflicts: () => ({ state: 'conflicts', files: ['a.ts'] })
+      })
+    });
+    disp.integrate();
+    expect(spawned[0]?.mode).toBe('resolve');
+    expect(store.getTask(t.id)!.status).toBe('running');
+    store.close();
+  });
+
+  it('integrate: autoIntegrate off -> no-op', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: false },
+      integration: fakeIntegration()
+    });
+    disp.integrate();
+    expect(store.getTask(t.id)!.status).toBe('review');
+    store.close();
+  });
+
+  it('integrate: conflicting task at the resolve cap -> blocked', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const { t } = reviewFeatureTask(store);
+    store.incrementResolveAttempts(t.id);
+    store.incrementResolveAttempts(t.id); // at cap
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig, autoIntegrate: true },
+      integration: fakeIntegration({
+        checkMergeConflicts: () => ({ state: 'conflicts', files: ['a.ts'] })
+      })
+    });
+    disp.integrate();
+    expect(store.getTask(t.id)!.status).toBe('blocked');
+    store.close();
+  });
+});

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -530,6 +530,26 @@ describe('KanbanDispatcher.decompose', () => {
     expect(store.getTask(t.id)?.status).toBe('triage');
     store.close();
   });
+
+  it('reclaim returns a dead resolve run to review (not triage) so integrate retries it', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+    store.setWorkspace(t.id, '/tmp/x', 'br-x', 'main');
+    store.reviewTask(t.id, null);
+    store.claimForResolve(t.id, 'L', 100); // expires 1100, moves to running
+    store.startRun(t.id, 'worker', 9999, 'resolve');
+    clock.t = 2000; // claim expired
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
+      config: { ...baseConfig }
+    });
+    disp.reclaim();
+    expect(store.getTask(t.id)?.status).toBe('review');
+    store.close();
+  });
 });
 
 describe('KanbanDispatcher.autoAssign', () => {

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -169,6 +169,49 @@ describe('KanbanMcpServer', () => {
     expect(names).not.toContain('kanban_update');
   });
 
+  it('resolve mode exposes show/comment/heartbeat/complete/block and not create/assign', async () => {
+    const t = store.createTask({ title: 'fix conflicts', status: 'running' });
+    const run = store.startRun(t.id, 'r', 1, 'resolve');
+    server.registerRun('rstok', { kind: 'task', taskId: t.id, runId: run.id, mode: 'resolve' }, 'L');
+    const r = await rpc(`${base}?run=rstok`, 'tools/list');
+    const names = r.result.tools.map((x: { name: string }) => x.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'kanban_show',
+        'kanban_comment',
+        'kanban_heartbeat',
+        'kanban_complete',
+        'kanban_block'
+      ])
+    );
+    expect(names).not.toContain('kanban_create');
+    expect(names).not.toContain('kanban_assign');
+    // resolve is a tightly scoped retry — no swarm/artifact tooling.
+    expect(names).not.toContain('kanban_artifact');
+    expect(names).not.toContain('kanban_swarm_read');
+  });
+
+  it('kanban_complete on a resolve run returns the task to review', async () => {
+    const t = store.createTask({
+      title: 'retry merge',
+      status: 'running',
+      workspaceKind: 'worktree',
+      workspacePath: join(TEST_DIR, 'no-such-worktree')
+    });
+    store.claimTask(t.id, 'LOCK', 100000);
+    const run = store.startRun(t.id, 'r', 1, 'resolve');
+    server.registerRun(
+      'rctok',
+      { kind: 'task', taskId: t.id, runId: run.id, mode: 'resolve' },
+      'LOCK'
+    );
+    await rpc(`${base}?run=rctok`, 'tools/call', {
+      name: 'kanban_complete',
+      arguments: { summary: 'resolved' }
+    });
+    expect(store.getTask(t.id)?.status).toBe('review');
+  });
+
   it('a worker-mode token cannot call kanban_create', async () => {
     const t = store.createTask({ title: 'x', status: 'running', assignee: 'r' });
     const run = store.startRun(t.id, 'r', 1, 'work');

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -519,6 +519,7 @@ describe('KanbanMcpServer board scope (PM chat)', () => {
         claimTtlMs: 1000,
         autoDecompose: false,
         autoAssign: false,
+        autoIntegrate: false,
         maxDecompose: 1,
         artifactRetentionDays: 0
       }

--- a/src/main/__tests__/kanban-spawn-worker.test.ts
+++ b/src/main/__tests__/kanban-spawn-worker.test.ts
@@ -358,6 +358,42 @@ describe('buildWorkerInvocation', () => {
     expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_assign');
   });
 
+  it('resolve mode prompt instructs merging the target branch and completing', () => {
+    const workspace = join(ROOT, 'wsresolve');
+    mkdirSync(workspace, { recursive: true });
+    const inv = buildWorkerInvocation({
+      task: { id: 'T1', title: 'Fix X', body: '', assignee: null, modelOverride: null },
+      workspace,
+      mcpPort: 1234,
+      runToken: 'tok',
+      logPath: join(ROOT, 'resolve.log'),
+      mode: 'resolve',
+      resolveTarget: 'fleet/feature-abc'
+    });
+    expect(inv.args.join(' ')).toContain('fleet/feature-abc');
+    expect(inv.args.join(' ')).toMatch(/resolve/i);
+    const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
+    expect(prompt).toContain('kanban_complete');
+    expect(prompt).toContain('kanban_block');
+  });
+
+  it('resolve mode requires kanban_complete', () => {
+    const workspace = join(ROOT, 'wsresolve2');
+    mkdirSync(workspace, { recursive: true });
+    const inv = buildWorkerInvocation({
+      task: { id: 'T2', title: 't', body: '', assignee: null, modelOverride: null },
+      workspace,
+      mcpPort: 1,
+      runToken: 'x',
+      logPath: join(ROOT, 'resolve2.log'),
+      mode: 'resolve',
+      resolveTarget: 'main'
+    });
+    const i = inv.args.indexOf('--require-tool');
+    expect(i).toBeGreaterThan(-1);
+    expect(inv.args[i + 1]).toContain('kanban_complete');
+  });
+
   it('does not include attachments in decompose mode', () => {
     const workspace = join(ROOT, 'wsc');
     mkdirSync(workspace, { recursive: true });

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -25,28 +25,40 @@ describe('KanbanStore', () => {
 
   it('creates the db file and runs migrations', () => {
     expect(existsSync(DB_PATH)).toBe(true);
-    expect(store.schemaVersion()).toBe(10);
+    expect(store.schemaVersion()).toBe(11);
   });
 
-  it('fresh db is created at v10 with the new columns', () => {
-    // Fresh store is already v10; assert the new columns exist and are nullable/defaulted.
+  it('fresh db is created at v11 with the new columns', () => {
+    // Fresh store is already v11; assert the new columns exist and are nullable/defaulted.
     const t = store.createTask({ title: 'x' });
     expect(store.getTask(t.id)?.pendingMode).toBeNull();
     const run = store.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(store.schemaVersion()).toBe(10);
+    expect(store.schemaVersion()).toBe(11);
   });
 
-  it('fresh db is created at v10 and persists repoPath', () => {
+  it('fresh db is created at v11 and persists repoPath', () => {
     const t = store.createTask({ title: 'wt', workspaceKind: 'worktree', repoPath: '/src/repo' });
     expect(store.getTask(t.id)?.repoPath).toBe('/src/repo');
     expect(store.getTask(t.id)?.workspaceKind).toBe('worktree');
-    expect(store.schemaVersion()).toBe(10);
+    expect(store.schemaVersion()).toBe(11);
   });
 
   it('repoPath defaults to null when omitted', () => {
     const t = store.createTask({ title: 'plain' });
     expect(store.getTask(t.id)?.repoPath).toBeNull();
+  });
+
+  it('defaults resolve_attempts to 0 and system_kind to null on new tasks', () => {
+    const t = store.createTask({ title: 'x' });
+    const got = store.getTask(t.id)!;
+    expect(got.resolveAttempts).toBe(0);
+    expect(got.systemKind).toBeNull();
+  });
+
+  it('persists system_kind when provided to createTask', () => {
+    const t = store.createTask({ title: 'sync', systemKind: 'feature_sync' });
+    expect(store.getTask(t.id)!.systemKind).toBe('feature_sync');
   });
 
   it('upgrades a v2 db to v3 (adds repo_path)', () => {
@@ -60,7 +72,7 @@ describe('KanbanStore', () => {
     const s = new KanbanStore(v2Path);
     const t = s.createTask({ title: 'x', workspaceKind: 'worktree', repoPath: '/r' });
     expect(s.getTask(t.id)?.repoPath).toBe('/r');
-    expect(s.schemaVersion()).toBe(10);
+    expect(s.schemaVersion()).toBe(11);
     s.close();
   });
 
@@ -85,7 +97,7 @@ describe('KanbanStore', () => {
     raw.close();
 
     const s = new KanbanStore(preV5Path);
-    expect(s.schemaVersion()).toBe(10);
+    expect(s.schemaVersion()).toBe(11);
     expect(s.getTask('abc')?.boardId).toBe('default');
     expect(s.listBoards().map((b) => b.slug)).toEqual(['default']);
     s.close();
@@ -106,11 +118,32 @@ describe('KanbanStore', () => {
 
     // Opening the store must run the ALTER-based upgrade path (+ idempotent SCHEMA_SQL).
     const s = new KanbanStore(v9Path);
-    expect(s.schemaVersion()).toBe(10);
+    expect(s.schemaVersion()).toBe(11);
     expect(s.getTask('pre10')?.docs).toEqual([]); // pre-migration row gets the default
     const t = s.createTask({ title: 'x', docs: ['guide.md'] });
     expect(s.getTask(t.id)?.docs).toEqual(['guide.md']);
     expect(s.listProjects('default')).toEqual([]);
+    s.close();
+  });
+
+  it('upgrades a v10 db to v11 (adds resolve_attempts and system_kind)', () => {
+    const v10Path = join(TEST_DIR, 'v10.db');
+    // Simulate a v10 DB: full current schema minus the v11 additions.
+    const raw = new Database(v10Path);
+    raw.exec(SCHEMA_SQL);
+    raw.exec('ALTER TABLE tasks DROP COLUMN resolve_attempts');
+    raw.exec('ALTER TABLE tasks DROP COLUMN system_kind');
+    raw.exec(
+      "INSERT INTO tasks (id,title,status,created_at,updated_at) VALUES ('pre11','old task','todo',1,1)"
+    );
+    raw.pragma('user_version = 10');
+    raw.close();
+
+    // Opening the store must run the ALTER-based upgrade path.
+    const s = new KanbanStore(v10Path);
+    expect(s.schemaVersion()).toBe(11);
+    expect(s.getTask('pre11')?.resolveAttempts).toBe(0); // pre-migration row gets the default
+    expect(s.getTask('pre11')?.systemKind).toBeNull();
     s.close();
   });
 
@@ -130,7 +163,7 @@ describe('KanbanStore', () => {
     expect(s.getTask(t.id)?.pendingMode).toBeNull();
     const run = s.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(s.schemaVersion()).toBe(10);
+    expect(s.schemaVersion()).toBe(11);
     s.close();
   });
 
@@ -557,7 +590,7 @@ describe('KanbanStore schema v6 migration', () => {
     raw.close();
 
     const store = new KanbanStore(dbPath, { now: () => 1000 });
-    expect(store.schemaVersion()).toBe(10);
+    expect(store.schemaVersion()).toBe(11);
     const t = store.getTask('legacy1');
     expect(t?.title).toBe('old task');
     expect(t?.scheduleKind).toBeNull();
@@ -981,7 +1014,7 @@ describe('projects schema (v10)', () => {
   });
 
   it('migrates to v10 with a projects table and tasks.docs column', () => {
-    expect(store.schemaVersion()).toBe(10);
+    expect(store.schemaVersion()).toBe(11);
     const t = store.createTask({ title: 'x' });
     expect(t.docs).toEqual([]);
     expect(store.listProjects('default')).toEqual([]);

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -1060,3 +1060,75 @@ describe('projects schema (v10)', () => {
     expect(store.listProjects(b.slug)).toEqual([]);
   });
 });
+
+describe('KanbanStore integrate/resolve (autopilot phase 2)', () => {
+  let store: KanbanStore;
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    store = new KanbanStore(DB_PATH);
+  });
+  afterEach(() => {
+    store.close();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('reviewWorktreeFeatureTasks returns only review + worktree + featured + non-system tasks', () => {
+    const f = store.createFeature({ boardId: 'default', name: 'F' });
+    const a = store.createTask({ title: 'a', featureId: f.id, workspaceKind: 'worktree' });
+    store.setWorkspace(a.id, '/tmp/a', 'br-a', 'main');
+    store.reviewTask(a.id, null);
+    const b = store.createTask({ title: 'b', workspaceKind: 'worktree' }); // excluded: no feature
+    store.setWorkspace(b.id, '/tmp/b', 'br-b', 'main');
+    store.reviewTask(b.id, null);
+    const sys = store.createTask({
+      title: 's',
+      featureId: f.id,
+      workspaceKind: 'worktree',
+      systemKind: 'feature_sync'
+    }); // excluded: system
+    store.setWorkspace(sys.id, '/tmp/s', 'br-s', 'main');
+    store.reviewTask(sys.id, null);
+    const ids = store.reviewWorktreeFeatureTasks().map((t) => t.id);
+    expect(ids).toEqual([a.id]);
+  });
+
+  it('claimForResolve atomically moves a review task to running', () => {
+    const t = store.createTask({ title: 'x', workspaceKind: 'worktree' });
+    store.reviewTask(t.id, null);
+    expect(store.claimForResolve(t.id, 'L1', 1000)).toBe(true);
+    expect(store.getTask(t.id)!.status).toBe('running');
+    expect(store.claimForResolve(t.id, 'L2', 1000)).toBe(false); // already running
+  });
+
+  it('increment/reset resolve attempts', () => {
+    const t = store.createTask({ title: 'x' });
+    store.incrementResolveAttempts(t.id);
+    store.incrementResolveAttempts(t.id);
+    expect(store.getTask(t.id)!.resolveAttempts).toBe(2);
+    store.resetResolveAttempts(t.id);
+    expect(store.getTask(t.id)!.resolveAttempts).toBe(0);
+  });
+
+  it('openSystemTask finds a non-terminal feature_sync task for a feature', () => {
+    const f = store.createFeature({ boardId: 'default', name: 'F' });
+    expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull();
+    const sys = store.createTask({
+      title: 's',
+      featureId: f.id,
+      systemKind: 'feature_sync',
+      status: 'review'
+    });
+    expect(store.openSystemTask(f.id, 'feature_sync')?.id).toBe(sys.id);
+    store.completeTask(sys.id, null);
+    expect(store.openSystemTask(f.id, 'feature_sync')).toBeNull(); // done = terminal
+  });
+
+  it('featureRollup and listFeatureTasks exclude system tasks', () => {
+    const f = store.createFeature({ boardId: 'default', name: 'F' });
+    const a = store.createTask({ title: 'a', featureId: f.id, status: 'done' });
+    store.createTask({ title: 's', featureId: f.id, systemKind: 'feature_sync', status: 'running' });
+    expect(store.featureRollup(f.id).total).toBe(1);
+    expect(store.featureRollup(f.id).done).toBe(1);
+    expect(store.listFeatureTasks(f.id).map((t) => t.id)).toEqual([a.id]);
+  });
+});

--- a/src/main/__tests__/kanban-workspace.test.ts
+++ b/src/main/__tests__/kanban-workspace.test.ts
@@ -7,7 +7,8 @@ import {
   prepareWorkspace,
   cleanupWorkspace,
   removeWorktree,
-  mergeWorktreeToBase
+  mergeWorktreeToBase,
+  checkoutBranchWorktree
 } from '../kanban/workspace';
 
 const ROOT = join(tmpdir(), `fleet-kanban-ws-test-${process.pid}`);
@@ -123,6 +124,33 @@ describe('kanban workspace', () => {
     });
     expect(existsSync(path)).toBe(true);
     expect(branchName).toBe('kanban/t3');
+  });
+
+  it('checkoutBranchWorktree checks out an existing branch (not a new kanban/ branch)', () => {
+    const repo = makeRepo('repo-cobw');
+    // Create the integration branch with a distinct commit so it differs from main.
+    execFileSync('git', ['-C', repo, 'branch', 'fleet/feature-x']);
+    execFileSync('git', ['-C', repo, 'checkout', '-q', 'fleet/feature-x']);
+    writeFileSync(join(repo, 'feat.txt'), 'feature work');
+    execFileSync('git', ['-C', repo, 'add', '-A']);
+    execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'feature commit']);
+    execFileSync('git', ['-C', repo, 'checkout', '-q', 'main']);
+
+    const { path, branchName } = checkoutBranchWorktree({
+      repoPath: repo,
+      branchName: 'fleet/feature-x',
+      worktreesRoot: WT_ROOT,
+      taskId: 'sync-1'
+    });
+    expect(path).toBe(join(WT_ROOT, 'sync-1'));
+    expect(existsSync(path)).toBe(true);
+    expect(branchName).toBe('fleet/feature-x');
+    const head = execFileSync('git', ['-C', path, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8'
+    }).trim();
+    expect(head).toBe('fleet/feature-x');
+    // The integration branch's own commit must be present in the worktree.
+    expect(existsSync(join(path, 'feat.txt'))).toBe(true);
   });
 
   it('recovers on a later attempt after a failed worktree add left a dir behind', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,7 @@ import type { DispatcherConfig, WorkerExit } from './kanban/kanban-dispatcher';
 import { setKanbanSettingsApplier } from './kanban/kanban-settings-bridge';
 import { KanbanMcpServer } from './kanban/kanban-mcp-server';
 import { PmChatService } from './kanban/pm-chat-service';
-import { prepareWorkspace, ensureFeatureBranch } from './kanban/workspace';
+import { prepareWorkspace, ensureFeatureBranch, checkoutBranchWorktree } from './kanban/workspace';
 import { PrPoller } from './kanban/pr-poller';
 import { loadTaskDocs, pmDocsDir } from './kanban/pm-paths';
 import {
@@ -876,6 +876,24 @@ void app.whenReady().then(async () => {
       }
     },
     prepareWorkspaceFn: (task) => {
+      // A feature_sync system task must check out the integration branch ITSELF (no new
+      // -b branch), so its resolve run merges main into the real integration branch.
+      if (
+        task.systemKind === 'feature_sync' &&
+        task.workspaceKind === 'worktree' &&
+        task.repoPath &&
+        task.branchName &&
+        task.workspacePath == null
+      ) {
+        const wt = checkoutBranchWorktree({
+          repoPath: task.repoPath,
+          branchName: task.branchName,
+          worktreesRoot: join(KANBAN_HOME, 'worktrees'),
+          taskId: task.id
+        });
+        kanbanStore!.setWorkspace(task.id, wt.path, wt.branchName, task.baseBranch ?? null);
+        return wt.path;
+      }
       // A worktree task in a feature branches off the feature's integration branch
       // (`fleet/feature-<id>`), created on first use. The captured base then cascades:
       // the task merges back into integration, and decompose children inherit it.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -855,6 +855,7 @@ void app.whenReady().then(async () => {
       claimTtlMs: d.claimTtlMs,
       autoDecompose: d.autoDecompose,
       autoAssign: d.autoAssign,
+      autoIntegrate: d.autoIntegrate,
       maxDecompose: d.maxDecompose,
       artifactRetentionDays: settingsStore.get().kanban.artifactRetentionDays
     };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -941,7 +941,7 @@ void app.whenReady().then(async () => {
       const profiles = settingsStore.get().kanban.profiles;
       let profile: WorkerProfile | null;
       let roster: Array<{ name: string; description: string }> | undefined;
-      if (mode === 'work') {
+      if (mode === 'work' || mode === 'resolve') {
         const resolved = resolveWorkProfile(profiles, task.assignee);
         profile = resolved.profile;
         if (resolved.fellBack) {
@@ -972,6 +972,17 @@ void app.whenReady().then(async () => {
           kanbanStore!.updateTask(task.id, { assignee: profile?.name ?? 'orchestrator' });
         }
       }
+      let resolveTarget: string | undefined;
+      if (mode === 'resolve') {
+        if (task.systemKind === 'feature_sync') {
+          resolveTarget = task.baseBranch ?? undefined; // system task's branch IS the integration branch; merge base in
+        } else if (task.featureId) {
+          const f = kanbanStore!.getFeature(task.featureId);
+          resolveTarget = f ? (f.integrationBranch ?? `fleet/feature-${f.id}`) : undefined;
+        } else {
+          resolveTarget = task.baseBranch ?? undefined;
+        }
+      }
       const logPath = join(KANBAN_HOME, 'logs', `${runToken}.log`);
       const spawnedAt = Date.now();
       return spawnRuneWorker(
@@ -984,6 +995,7 @@ void app.whenReady().then(async () => {
             modelOverride: task.modelOverride
           },
           workspace,
+          resolveTarget,
           mcpPort: kanbanMcpPort,
           runToken,
           logPath,

--- a/src/main/kanban/kanban-commands.ts
+++ b/src/main/kanban/kanban-commands.ts
@@ -655,13 +655,16 @@ export class KanbanCommands {
     });
     if (!result.ok) {
       const reason = result.conflict
-        ? `merge conflict against ${task.baseBranch}; resolve manually or unblock to retry`
+        ? `merge conflict against ${task.baseBranch}; spawning a resolve run`
         : (result.error ?? 'merge failed');
       this.store.addComment(id, 'human', `merge to ${task.baseBranch} failed: ${reason}`);
       this.store.appendEvent(id, null, 'merge_failed', {
         base: task.baseBranch,
         conflict: !!result.conflict
       });
+      // A conflicting manual merge hands off to a resolve run (the task is still in
+      // 'review' here, so requestResolve's guard + claimForResolve CAS both hold).
+      if (result.conflict) this.dispatcher.requestResolve(id);
       return { ok: false, conflict: result.conflict, error: reason };
     }
     this.store.completeTask(id, task.result);

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -195,9 +195,12 @@ export class KanbanDispatcher {
         log.warn('task gave up', { taskId: task.id, failures });
       } else {
         const mode = task.currentRunId != null ? this.store.runMode(task.currentRunId) : 'work';
-        // assign is also a non-work orchestrator mode — this branch MUST stay before the
-        // generic non-work branch below, or a dead assign run would wrongly route to triage.
+        // assign and resolve are non-work modes that run on a real task (ready/review), not a
+        // triage card — they MUST be routed before the generic non-work branch below, or a dead
+        // run would wrongly land in triage. A resolve run returns to review so the next
+        // integrate() pass re-evaluates it (retry within the cap, or block).
         if (mode === 'assign') this.store.returnToReady(task.id);
+        else if (mode === 'resolve') this.store.setStatusCleared(task.id, 'review');
         else if (mode && mode !== 'work') this.store.setStatusCleared(task.id, 'triage');
         else this.store.returnToReady(task.id);
       }

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -395,7 +395,7 @@ export class KanbanDispatcher {
    * The worker merges `target` into the task's worktree, resolves, commits, and completes (-> review).
    */
   private spawnResolve(task: Task, target: string): boolean {
-    const attempts = task.resolveAttempts ?? 0;
+    const attempts = task.resolveAttempts;
     if (attempts >= RESOLVE_ATTEMPT_CAP) {
       const note = `merge conflicts unresolved after ${RESOLVE_ATTEMPT_CAP} resolve attempt(s)`;
       this.store.blockTask(task.id, note);

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -446,6 +446,89 @@ export class KanbanDispatcher {
     return this.spawnResolve(task, target);
   }
 
+  /** Auto-integrate completed feature tasks and sync completed features. Local git only — no push/PR (that is #229). */
+  integrate(): void {
+    if (!this.deps.config.autoIntegrate) return;
+    const budget = this.integrateTasks(MAX_INTEGRATE_PER_TICK);
+    this.integrateFeatures(budget); // implemented in Task 8
+  }
+
+  /** Merge each review feature task into its integration branch; spawn a resolve run on conflict. Returns remaining budget. */
+  private integrateTasks(budget: number): number {
+    for (const task of this.store.reviewWorktreeFeatureTasks()) {
+      if (budget <= 0) break;
+      if (!task.repoPath || !task.branchName || !task.baseBranch || !task.workspacePath) continue;
+      const integrationBranch = this.integrationBranchFor(task.featureId);
+      if (!integrationBranch) continue;
+
+      const ensured = this.ops.ensureFeatureBranch({
+        repoPath: task.repoPath,
+        integrationBranch,
+        baseBranch: task.baseBranch
+      });
+      if (!ensured.ok) {
+        this.store.appendEvent(task.id, null, 'merge_failed', {
+          base: integrationBranch,
+          error: ensured.error
+        });
+        continue;
+      }
+
+      const pred = this.ops.checkMergeConflicts({
+        repoPath: task.repoPath,
+        baseBranch: integrationBranch,
+        branchName: task.branchName
+      });
+      if (pred.state === 'error') continue; // can't predict — leave in review for a human
+      if (pred.state === 'conflicts') {
+        if (this.spawnResolve(task, integrationBranch)) budget -= 1;
+        continue;
+      }
+      // clean prediction → real merge into the (local) integration branch
+      const res = this.ops.mergeWorktreeToBase({
+        repoPath: task.repoPath,
+        branchName: task.branchName,
+        baseBranch: integrationBranch,
+        worktreeParentDir: dirname(task.workspacePath),
+        taskId: task.id,
+        title: task.title
+      });
+      if (res.ok) {
+        this.store.completeTask(task.id, task.result);
+        this.store.appendEvent(task.id, null, 'merged', {
+          base: integrationBranch,
+          branch: task.branchName,
+          by: 'integrate'
+        });
+        this.ops.removeWorktree({
+          repoPath: task.repoPath,
+          workspacePath: task.workspacePath,
+          branchName: task.branchName,
+          baseBranch: integrationBranch
+        });
+        this.store.setWorktreePruned(task.id);
+        this.store.appendEvent(task.id, null, 'worktree_pruned', {
+          branch: task.branchName,
+          by: 'integrate'
+        });
+        this.store.resetResolveAttempts(task.id);
+        budget -= 1;
+      } else if (res.conflict) {
+        if (this.spawnResolve(task, integrationBranch)) budget -= 1; // prediction raced (clean→dirty)
+      } else {
+        this.store.appendEvent(task.id, null, 'merge_failed', {
+          base: integrationBranch,
+          error: res.error
+        });
+      }
+    }
+    return budget;
+  }
+
+  private integrateFeatures(_budget: number): void {
+    /* implemented in Task 8 */
+  }
+
   /** Purge discarded artifacts past the retention window; surface each deletion as an event. */
   sweepArtifacts(): void {
     const days = this.deps.config.artifactRetentionDays;
@@ -504,6 +587,7 @@ export class KanbanDispatcher {
     this.autoAssign();
     this.promote();
     this.claimAndSpawn();
+    this.integrate();
     this.sweepArtifacts();
     this.sweepMergedWorktrees();
   }

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -525,8 +525,88 @@ export class KanbanDispatcher {
     return budget;
   }
 
-  private integrateFeatures(_budget: number): void {
-    /* implemented in Task 8 */
+  /** Sync each fully-done feature's integration branch with main; spawn a feature_sync resolve task on conflict. */
+  private integrateFeatures(budget: number): void {
+    for (const feature of this.store.listFeatures({ status: 'active' })) {
+      if (budget <= 0) break;
+      if (!feature.repoPath || !feature.baseBranch) continue;
+      const integrationBranch = feature.integrationBranch ?? `fleet/feature-${feature.id}`;
+
+      const rollup = this.store.featureRollup(feature.id); // system tasks already excluded
+      const allDone = rollup.total > 0 && rollup.done + rollup.archived === rollup.total;
+      if (!allDone) continue;
+
+      // Only act once integration actually contains merged work (branch ahead of base).
+      if (
+        this.ops.isBranchMerged({
+          repoPath: feature.repoPath,
+          branchName: integrationBranch,
+          baseBranch: feature.baseBranch
+        })
+      ) {
+        continue;
+      }
+
+      const open = this.store.openSystemTask(feature.id, 'feature_sync');
+      if (open?.status === 'running') continue; // a resolve is already in flight
+
+      // Fire-once guard for the clean path: 'in_progress' means "integration synced, awaiting #229 ship".
+      if (!open && (feature.mergeState === 'in_progress' || feature.mergeState === 'merged'))
+        continue;
+
+      const sync = this.ops.updateIntegrationBranchFromMain({
+        repoPath: feature.repoPath,
+        integrationBranch,
+        baseBranch: feature.baseBranch
+      });
+
+      if (sync.ok) {
+        if (open) {
+          // a prior conflict was resolved by the system task → close it out
+          this.store.completeTask(open.id, 'synced with main');
+          this.store.appendEvent(open.id, null, 'merged', {
+            base: feature.baseBranch,
+            by: 'feature_sync'
+          });
+        }
+        this.store.updateFeature(feature.id, { mergeState: 'in_progress' });
+      } else if (sync.conflict) {
+        this.store.updateFeature(feature.id, { mergeState: 'conflict' });
+        const target = feature.baseBranch;
+        if (open?.status === 'review') {
+          if (this.spawnResolve(open, target)) budget -= 1;
+        } else if (!open) {
+          const sys = this.createFeatureSyncTask(feature, integrationBranch);
+          if (sys && this.spawnResolve(sys, target)) budget -= 1;
+        }
+      }
+      // sync error (e.g. base not found): leave for next tick
+    }
+  }
+
+  /**
+   * Create the synthetic system task whose worktree checks out the integration branch itself,
+   * so a resolve run can merge main into it. Excluded from feature roll-ups via system_kind.
+   */
+  private createFeatureSyncTask(feature: Feature, integrationBranch: string): Task | null {
+    if (!feature.repoPath || !feature.baseBranch) return null;
+    const task = this.store.createTask({
+      title: `Sync ${feature.name} with main`,
+      body: `Merge ${feature.baseBranch} into ${integrationBranch} and resolve any conflicts so the feature can ship.`,
+      status: 'review', // spawnResolve claims from review
+      boardId: feature.boardId,
+      featureId: feature.id,
+      systemKind: 'feature_sync',
+      workspaceKind: 'worktree',
+      repoPath: feature.repoPath,
+      branchName: integrationBranch, // the worktree checks out the integration branch
+      baseBranch: feature.baseBranch
+    });
+    this.store.appendEvent(task.id, null, 'task_created', {
+      by: 'dispatcher',
+      system: 'feature_sync'
+    });
+    return task;
   }
 
   /** Purge discarded artifacts past the retention window; surface each deletion as an event. */

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -450,7 +450,7 @@ export class KanbanDispatcher {
   integrate(): void {
     if (!this.deps.config.autoIntegrate) return;
     const budget = this.integrateTasks(MAX_INTEGRATE_PER_TICK);
-    this.integrateFeatures(budget); // implemented in Task 8
+    this.integrateFeatures(budget);
   }
 
   /** Merge each review feature task into its integration branch; spawn a resolve run on conflict. Returns remaining budget. */
@@ -550,35 +550,53 @@ export class KanbanDispatcher {
       const open = this.store.openSystemTask(feature.id, 'feature_sync');
       if (open?.status === 'running') continue; // a resolve is already in flight
 
-      // Fire-once guard for the clean path: 'in_progress' means "integration synced, awaiting #229 ship".
-      if (!open && (feature.mergeState === 'in_progress' || feature.mergeState === 'merged'))
+      if (open?.status === 'review') {
+        // The resolve worker finished. Did it actually merge base into the integration branch?
+        // (synced check: base is now an ancestor of the integration branch).
+        const synced = this.ops.isBranchMerged({
+          repoPath: feature.repoPath,
+          branchName: feature.baseBranch,
+          baseBranch: integrationBranch
+        });
+        if (synced) {
+          // Free the integration branch (prune the worktree; the branch is ahead of base so it's kept), close the task.
+          if (open.workspacePath && open.branchName) {
+            this.ops.removeWorktree({
+              repoPath: feature.repoPath,
+              workspacePath: open.workspacePath,
+              branchName: open.branchName,
+              baseBranch: feature.baseBranch
+            });
+          }
+          this.store.setWorktreePruned(open.id);
+          this.store.completeTask(open.id, 'synced with main');
+          this.store.appendEvent(open.id, null, 'merged', {
+            base: feature.baseBranch,
+            by: 'feature_sync'
+          });
+          this.store.updateFeature(feature.id, { mergeState: 'in_progress' });
+        } else {
+          // completed without resolving — retry (cap enforced in spawnResolve, then it blocks)
+          if (this.spawnResolve(open, feature.baseBranch)) budget -= 1;
+        }
         continue;
+      }
+
+      // No open system task:
+      if (feature.mergeState === 'in_progress' || feature.mergeState === 'merged') continue; // fire-once
 
       const sync = this.ops.updateIntegrationBranchFromMain({
         repoPath: feature.repoPath,
         integrationBranch,
         baseBranch: feature.baseBranch
       });
-
       if (sync.ok) {
-        if (open) {
-          // a prior conflict was resolved by the system task → close it out
-          this.store.completeTask(open.id, 'synced with main');
-          this.store.appendEvent(open.id, null, 'merged', {
-            base: feature.baseBranch,
-            by: 'feature_sync'
-          });
-        }
         this.store.updateFeature(feature.id, { mergeState: 'in_progress' });
+        budget -= 1; // a sync is a real git op — count it against the tick budget
       } else if (sync.conflict) {
         this.store.updateFeature(feature.id, { mergeState: 'conflict' });
-        const target = feature.baseBranch;
-        if (open?.status === 'review') {
-          if (this.spawnResolve(open, target)) budget -= 1;
-        } else if (!open) {
-          const sys = this.createFeatureSyncTask(feature, integrationBranch);
-          if (sys && this.spawnResolve(sys, target)) budget -= 1;
-        }
+        const sys = this.createFeatureSyncTask(feature, integrationBranch);
+        if (sys && this.spawnResolve(sys, feature.baseBranch)) budget -= 1;
       }
       // sync error (e.g. base not found): leave for next tick
     }

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -1,8 +1,17 @@
+import { dirname } from 'path';
 import { createLogger } from '../logger';
 import type { KanbanStore } from './kanban-store';
-import type { Task, RunMode } from '../../shared/kanban-types';
+import type { Task, RunMode, Feature } from '../../shared/kanban-types';
 import { computeNextRun, taskToScheduleInput } from './schedule';
-import { finalizeWorktree, isBranchMerged, removeWorktree } from './workspace';
+import {
+  ensureFeatureBranch,
+  checkMergeConflicts,
+  finalizeWorktree,
+  isBranchMerged,
+  mergeWorktreeToBase,
+  removeWorktree,
+  updateIntegrationBranchFromMain
+} from './workspace';
 
 const log = createLogger('kanban-dispatcher');
 
@@ -25,6 +34,30 @@ const REVIEW_REQUIRED_EXIT_CODE = 3;
  * a task is ever given up/blocked. At cap=2, failureLimit=3 this holds.
  */
 const ASSIGN_ATTEMPT_CAP = 2;
+
+/** Resolve runs attempted per task before it is blocked. Tracked in tasks.resolve_attempts (independent of failureLimit). */
+const RESOLVE_ATTEMPT_CAP = 2;
+/** Max task merges + resolve spawns processed per integrate() tick, so the tick stays fast. */
+const MAX_INTEGRATE_PER_TICK = 3;
+
+/** Git ops used by integrate(); injectable so the stage is unit-testable. Defaults to the real workspace.ts fns. */
+export interface IntegrationOps {
+  ensureFeatureBranch: typeof ensureFeatureBranch;
+  checkMergeConflicts: typeof checkMergeConflicts;
+  mergeWorktreeToBase: typeof mergeWorktreeToBase;
+  updateIntegrationBranchFromMain: typeof updateIntegrationBranchFromMain;
+  removeWorktree: typeof removeWorktree;
+  isBranchMerged: typeof isBranchMerged;
+}
+
+const DEFAULT_INTEGRATION_OPS: IntegrationOps = {
+  ensureFeatureBranch,
+  checkMergeConflicts,
+  mergeWorktreeToBase,
+  updateIntegrationBranchFromMain,
+  removeWorktree,
+  isBranchMerged
+};
 
 export interface SpawnWorkerArgs {
   task: Task;
@@ -72,6 +105,8 @@ export interface DispatcherDeps {
   clearWorkerExit?: (runId: number) => void;
   /** Worker-role profile names (in profile order), for the auto-assign fast path and fallback. */
   workerProfileNames?: () => string[];
+  /** Git ops for integrate(); injected in tests, defaults to real workspace.ts fns. */
+  integration?: IntegrationOps;
 }
 
 export class KanbanDispatcher {
@@ -83,6 +118,10 @@ export class KanbanDispatcher {
     private store: KanbanStore,
     private deps: DispatcherDeps
   ) {}
+
+  private get ops(): IntegrationOps {
+    return this.deps.integration ?? DEFAULT_INTEGRATION_OPS;
+  }
 
   /** Return expired/dead running tasks to ready, or give up past the failure limit. */
   reclaim(): void {
@@ -341,6 +380,70 @@ export class KanbanDispatcher {
         log.error('assign spawn failed', { taskId: task.id, error: msg });
       }
     }
+  }
+
+  /** The feature integration branch a task merges into (or null for a standalone task / missing feature). */
+  private integrationBranchFor(featureId: string | null): string | null {
+    if (!featureId) return null;
+    const f = this.store.getFeature(featureId);
+    if (!f) return null;
+    return f.integrationBranch ?? `fleet/feature-${f.id}`;
+  }
+
+  /**
+   * Spawn a resolve run for a review task (or block it past the cap). Returns true if a run was spawned.
+   * The worker merges `target` into the task's worktree, resolves, commits, and completes (-> review).
+   */
+  private spawnResolve(task: Task, target: string): boolean {
+    const attempts = task.resolveAttempts ?? 0;
+    if (attempts >= RESOLVE_ATTEMPT_CAP) {
+      const note = `merge conflicts unresolved after ${RESOLVE_ATTEMPT_CAP} resolve attempt(s)`;
+      this.store.blockTask(task.id, note);
+      this.store.appendEvent(task.id, null, 'blocked', { reason: note });
+      log.warn('resolve gave up', { taskId: task.id, attempts });
+      return false;
+    }
+    const lock = this.nextLock();
+    if (!this.store.claimForResolve(task.id, lock, this.deps.config.claimTtlMs)) return false; // lost race
+    let runId: number | null = null;
+    try {
+      let workspace = task.workspacePath ?? '';
+      if (!workspace && this.deps.prepareWorkspaceFn) {
+        workspace = this.deps.prepareWorkspaceFn(task); // creates the worktree (e.g. for a system task)
+      }
+      const run = this.store.startRun(task.id, task.assignee ?? 'worker', null, 'resolve');
+      runId = run.id;
+      this.store.incrementResolveAttempts(task.id);
+      const pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode: 'resolve' });
+      if (pid != null) this.store.setWorkerPid(task.id, run.id, pid);
+      this.store.appendEvent(task.id, run.id, 'spawned', {
+        pid: pid ?? null,
+        mode: 'resolve',
+        target,
+        attempt: attempts + 1
+      });
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.store.recordFailure(task.id, msg);
+      if (runId != null) this.store.finishRun(runId, 'spawn_failed', { error: msg });
+      this.store.appendEvent(task.id, runId, 'spawn_failed', { error: msg, mode: 'resolve' });
+      this.store.setStatusCleared(task.id, 'review'); // hand back to review so a later tick retries
+      log.error('resolve spawn failed', { taskId: task.id, error: msg });
+      return false;
+    }
+  }
+
+  /**
+   * Public entry for the standalone manual-merge-conflict path (KanbanCommands.mergeReviewTask).
+   * Resolves against the task's merge target (its integration branch for a feature task, else its base).
+   */
+  requestResolve(taskId: string): boolean {
+    const task = this.store.getTask(taskId);
+    if (task?.status !== 'review') return false;
+    const target = this.integrationBranchFor(task.featureId) ?? task.baseBranch;
+    if (!target) return false;
+    return this.spawnResolve(task, target);
   }
 
   /** Purge discarded artifacts past the retention window; surface each deletion as an event. */

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -41,6 +41,7 @@ export interface DispatcherConfig {
   claimTtlMs: number; // claim lease length
   autoDecompose: boolean; // automatically arm triage tasks for decompose
   autoAssign: boolean; // automatically assign unassigned ready tasks to a worker profile
+  autoIntegrate: boolean; // auto-merge feature review tasks into the integration branch + resolve runs
   maxDecompose: number; // max concurrent orchestrator runs
   artifactRetentionDays: number; // auto-purge discarded artifacts older than this; 0 disables
 }

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -243,6 +243,12 @@ const ASSIGN_TOOLS: McpTool[] = [
   ...WORKER_TOOLS.filter((t) => t.name === 'kanban_comment' || t.name === 'kanban_heartbeat')
 ];
 
+const RESOLVE_TOOLS: McpTool[] = WORKER_TOOLS.filter((t) =>
+  ['kanban_show', 'kanban_comment', 'kanban_heartbeat', 'kanban_complete', 'kanban_block'].includes(
+    t.name
+  )
+);
+
 /** Statuses the PM may set — mirrors MANUAL_STATUSES (dispatcher owns `running`). */
 const PM_SETTABLE_STATUSES = [
   'triage',
@@ -423,6 +429,7 @@ function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'decompose') return DECOMPOSE_TOOLS;
   if (mode === 'specify') return SPECIFY_TOOLS;
   if (mode === 'assign') return ASSIGN_TOOLS;
+  if (mode === 'resolve') return RESOLVE_TOOLS;
   return WORKER_TOOLS;
 }
 

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -175,6 +175,11 @@ export class KanbanStore {
       // idempotent so existing DBs gain it here.
       this.addColumnIfMissing('tasks', 'docs', "TEXT NOT NULL DEFAULT '[]'");
     }
+    if (current < 11) {
+      // Phase-2 autopilot: bounded resolve-run budget + synthetic system-task marker.
+      this.addColumnIfMissing('tasks', 'resolve_attempts', 'INTEGER NOT NULL DEFAULT 0');
+      this.addColumnIfMissing('tasks', 'system_kind', 'TEXT');
+    }
     // Seed the permanent default board (idempotent: fresh and existing DBs).
     const ts = this.now();
     this.db
@@ -232,6 +237,7 @@ export class KanbanStore {
       currentRunId: (r.current_run_id as number | null) ?? null,
       lastHeartbeatAt: (r.last_heartbeat_at as number | null) ?? null,
       consecutiveFailures: Number(r.consecutive_failures),
+      resolveAttempts: Number(r.resolve_attempts ?? 0),
       lastFailureError: (r.last_failure_error as string | null) ?? null,
       maxRuntimeSeconds: (r.max_runtime_seconds as number | null) ?? null,
       maxRetries: Number(r.max_retries),
@@ -245,6 +251,7 @@ export class KanbanStore {
       conflictState: (r.conflict_state as ConflictState | null) ?? null,
       conflictFiles: JSON.parse(String(r.conflict_files ?? '[]')) as string[],
       worktreePruned: Number(r.worktree_pruned ?? 0) === 1,
+      systemKind: (r.system_kind as string | null) ?? null,
       createdAt: Number(r.created_at),
       updatedAt: Number(r.updated_at)
     };
@@ -257,10 +264,10 @@ export class KanbanStore {
       .prepare(
         `INSERT INTO tasks (id, title, body, assignee, status, priority, tenant,
           workspace_kind, workspace_path, repo_path, branch_name, base_branch, model_override, skills, docs, board_id, feature_id, idempotency_key,
-          scheduled_from, max_runtime_seconds, max_retries, created_at, updated_at)
+          scheduled_from, system_kind, max_runtime_seconds, max_retries, created_at, updated_at)
          VALUES (@id, @title, @body, @assignee, @status, @priority, @tenant,
           @workspace_kind, @workspace_path, @repo_path, @branch_name, @base_branch, @model_override, @skills, @docs, @board_id, @feature_id, @idempotency_key,
-          @scheduled_from, @max_runtime_seconds, @max_retries, @created_at, @updated_at)`
+          @scheduled_from, @system_kind, @max_runtime_seconds, @max_retries, @created_at, @updated_at)`
       )
       .run({
         id,
@@ -282,6 +289,7 @@ export class KanbanStore {
         feature_id: input.featureId ?? null,
         idempotency_key: input.idempotencyKey ?? null,
         scheduled_from: input.scheduledFrom ?? null,
+        system_kind: input.systemKind ?? null,
         max_runtime_seconds: input.maxRuntimeSeconds ?? null,
         max_retries: input.maxRetries ?? 1,
         created_at: ts,

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1043,6 +1043,20 @@ export class KanbanStore {
     return rows.map((r) => this.rowToTask(r));
   }
 
+  /** Review-column feature tasks with a live worktree, eligible for auto-integration. Excludes system tasks. */
+  reviewWorktreeFeatureTasks(): Task[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE status='review' AND feature_id IS NOT NULL AND system_kind IS NULL
+           AND workspace_kind='worktree' AND workspace_path IS NOT NULL
+           AND branch_name IS NOT NULL AND base_branch IS NOT NULL
+         ORDER BY priority DESC, created_at ASC`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
   listBoard(boardSlug?: string): BoardCard[] {
     const tasks = boardSlug
       ? this.listTasks().filter((t) => t.boardId === boardSlug)
@@ -1395,9 +1409,22 @@ export class KanbanStore {
 
   listFeatureTasks(featureId: string): Task[] {
     const rows = this.db
-      .prepare('SELECT * FROM tasks WHERE feature_id=? ORDER BY priority DESC, created_at ASC')
+      .prepare(
+        'SELECT * FROM tasks WHERE feature_id=? AND system_kind IS NULL ORDER BY priority DESC, created_at ASC'
+      )
       .all(featureId) as Array<Record<string, unknown>>;
     return rows.map((r) => this.rowToTask(r));
+  }
+
+  /** A non-terminal (not done/archived) system task of the given kind for a feature, or null. */
+  openSystemTask(featureId: string, kind: string): Task | null {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM tasks WHERE feature_id=? AND system_kind=?
+           AND status NOT IN ('done','archived') ORDER BY created_at ASC LIMIT 1`
+      )
+      .get(featureId, kind) as Record<string, unknown> | undefined;
+    return row ? this.rowToTask(row) : null;
   }
 
   /** Single-query status rollup for a feature (focus banner + Features dashboard). */
@@ -1411,7 +1438,7 @@ export class KanbanStore {
            SUM(CASE WHEN status IN ('blocked','review') THEN 1 ELSE 0 END) AS review,
            SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) AS done,
            SUM(CASE WHEN status='archived' THEN 1 ELSE 0 END) AS archived
-         FROM tasks WHERE feature_id=?`
+         FROM tasks WHERE feature_id=? AND system_kind IS NULL`
       )
       .get(featureId) as Record<string, number | null>;
     return {
@@ -1517,6 +1544,20 @@ export class KanbanStore {
     return res.changes === 1;
   }
 
+  /** Atomically claim a review task for a resolve run (review -> running). Returns false if it lost the race. */
+  claimForResolve(taskId: string, lock: string, ttlMs: number): boolean {
+    const ts = this.now();
+    const res = this.db
+      .prepare(
+        `UPDATE tasks SET status='running', claim_lock=@lock, claim_expires=@expires,
+           last_heartbeat_at=@ts, updated_at=@ts
+         WHERE id=@id AND status='review'
+           AND (claim_lock IS NULL OR claim_expires <= @ts)`
+      )
+      .run({ id: taskId, lock, expires: ts + ttlMs, ts });
+    return res.changes === 1;
+  }
+
   /** Flag up to `limit` un-flagged triage tasks for decompose; returns how many were flagged. */
   armTriageForDecompose(limit: number): number {
     if (limit <= 0) return 0;
@@ -1567,6 +1608,18 @@ export class KanbanStore {
       .prepare(
         'UPDATE tasks SET consecutive_failures=0, last_failure_error=NULL, updated_at=? WHERE id=?'
       )
+      .run(this.now(), taskId);
+  }
+
+  incrementResolveAttempts(taskId: string): void {
+    this.db
+      .prepare('UPDATE tasks SET resolve_attempts = resolve_attempts + 1, updated_at=? WHERE id=?')
+      .run(this.now(), taskId);
+  }
+
+  resetResolveAttempts(taskId: string): void {
+    this.db
+      .prepare('UPDATE tasks SET resolve_attempts = 0, updated_at=? WHERE id=?')
       .run(this.now(), taskId);
   }
 

--- a/src/main/kanban/schema.ts
+++ b/src/main/kanban/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 10;
+export const SCHEMA_VERSION = 11;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS tasks (
@@ -46,6 +46,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   conflict_state TEXT,
   conflict_files TEXT,
   worktree_pruned INTEGER NOT NULL DEFAULT 0,
+  resolve_attempts INTEGER NOT NULL DEFAULT 0,
+  system_kind TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -29,6 +29,8 @@ export interface BuildWorkerInput {
   attachments?: Array<{ filename: string; storedPath: string }>;
   /** Board docs referenced by the task, pre-loaded for prompt inlining. */
   docs?: InlinedDoc[];
+  /** Branch to merge into the worktree for a resolve run (integration branch, or base for a feature_sync task). */
+  resolveTarget?: string;
 }
 
 export interface WorkerInvocation {
@@ -91,6 +93,16 @@ function buildPrompt(input: BuildWorkerInput): string {
       `work yourself.\n\nAvailable worker profiles:\n${roster || '- default: general worker'}`
     );
   }
+  if (mode === 'resolve') {
+    const target = input.resolveTarget ?? 'the base branch';
+    return (
+      `resolve merge conflicts for kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `Merge \`${target}\` into your current branch. Resolve every conflict, preserving the intent of ` +
+      `both sides. Verify your resolution (run the project's typecheck/build per the board docs if present). ` +
+      `Commit the merge. Then call kanban_complete with a one-line summary. If the conflicts cannot be ` +
+      `resolved safely, call kanban_block with the reason instead.`
+    );
+  }
   return (
     `work kanban task ${task.id}: ${task.title}\n\n${task.body}` +
     attachmentsSection(input) +
@@ -130,6 +142,7 @@ function requireToolsForMode(mode: RunMode): string | null {
   switch (mode) {
     case 'work':
     case 'decompose':
+    case 'resolve':
       return 'kanban_complete,kanban_block';
     case 'specify':
       return 'kanban_update';

--- a/src/main/kanban/workspace.ts
+++ b/src/main/kanban/workspace.ts
@@ -124,6 +124,34 @@ export function prepareWorkspace(input: PrepareWorkspaceInput): PreparedWorkspac
   return { path: dir, branchName: branch, baseBranch: base };
 }
 
+/**
+ * Create a worktree that checks out an EXISTING branch by name (no new -b branch).
+ * Used by feature_sync system tasks whose worktree must BE the integration branch itself.
+ */
+export function checkoutBranchWorktree(input: {
+  repoPath: string;
+  branchName: string;
+  worktreesRoot: string;
+  taskId: string;
+}): { path: string; branchName: string } {
+  const dir = join(input.worktreesRoot, input.taskId);
+  mkdirSync(input.worktreesRoot, { recursive: true });
+  try {
+    execFileSync('git', ['-C', input.repoPath, 'worktree', 'add', dir, input.branchName], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    try {
+      execFileSync('git', ['-C', input.repoPath, 'worktree', 'prune'], { stdio: 'ignore' });
+    } catch {
+      /* best-effort */
+    }
+    throw new Error(`checkoutBranchWorktree: git worktree add failed: ${gitStderr(err)}`);
+  }
+  return { path: dir, branchName: input.branchName };
+}
+
 export function cleanupWorkspace(input: { kind: WorkspaceKind; path: string }): void {
   // Only scratch is ephemeral; dir/worktree are preserved.
   if (input.kind === 'scratch') {

--- a/src/renderer/src/components/settings/kanban/KanbanSection.tsx
+++ b/src/renderer/src/components/settings/kanban/KanbanSection.tsx
@@ -119,6 +119,16 @@ export function KanbanSection(): React.JSX.Element | null {
             className="h-4 w-4"
           />
         </SettingRow>
+        <SettingRow label="Auto-integrate completed feature tasks">
+          <input
+            type="checkbox"
+            checked={k.dispatcher.autoIntegrate}
+            onChange={(e) =>
+              patch({ dispatcher: { ...k.dispatcher, autoIntegrate: e.target.checked } })
+            }
+            className="h-4 w-4"
+          />
+        </SettingRow>
         <SettingRow label="Max concurrent orchestrator runs">
           <input
             type="number"

--- a/src/shared/__tests__/kanban-dispatcher-defaults.test.ts
+++ b/src/shared/__tests__/kanban-dispatcher-defaults.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../constants';
+
+describe('kanban dispatcher defaults', () => {
+  it('defaults autoAssign and autoIntegrate to on', () => {
+    expect(DEFAULT_SETTINGS.kanban.dispatcher.autoAssign).toBe(true);
+    expect(DEFAULT_SETTINGS.kanban.dispatcher.autoIntegrate).toBe(true);
+  });
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -109,7 +109,8 @@ export const DEFAULT_SETTINGS: FleetSettings = {
       claimTtlMs: 900_000,
       autoDecompose: false,
       maxDecompose: 1,
-      autoAssign: true
+      autoAssign: true,
+      autoIntegrate: true
     },
     defaults: { workspaceKind: 'scratch', maxRuntimeSeconds: null },
     artifactRetentionDays: 14,

--- a/src/shared/kanban-types.ts
+++ b/src/shared/kanban-types.ts
@@ -11,8 +11,8 @@ export type TaskStatus =
 
 export type WorkspaceKind = 'scratch' | 'dir' | 'worktree';
 
-/** What a run is doing. 'work' = normal worker; orchestrator runs are 'decompose' | 'specify' | 'assign'. */
-export type RunMode = 'work' | 'decompose' | 'specify' | 'assign';
+/** What a run is doing. 'work' = normal worker; orchestrator runs are 'decompose' | 'specify' | 'assign' | 'resolve'. */
+export type RunMode = 'work' | 'decompose' | 'specify' | 'assign' | 'resolve';
 
 /** A triage task can be flagged for an orchestrator run. */
 export type PendingMode = 'decompose' | 'specify';
@@ -162,6 +162,7 @@ export interface Task {
   currentRunId: number | null;
   lastHeartbeatAt: number | null;
   consecutiveFailures: number;
+  resolveAttempts: number;
   lastFailureError: string | null;
   maxRuntimeSeconds: number | null;
   maxRetries: number;
@@ -179,6 +180,8 @@ export interface Task {
   conflictFiles: string[];
   /** True once the worktree has been pruned from disk (Phase 4); the dir no longer exists. */
   worktreePruned: boolean;
+  /** Non-null marks a dispatcher-created system task (e.g. 'feature_sync'); excluded from feature roll-ups. */
+  systemKind: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -301,6 +304,7 @@ export interface CreateTaskInput {
   maxRuntimeSeconds?: number | null;
   maxRetries?: number;
   scheduledFrom?: string | null;
+  systemKind?: string | null;
 }
 
 export interface UpdateTaskFields {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -162,6 +162,7 @@ export type KanbanSettings = {
     autoDecompose: boolean; // when true, the dispatcher auto-flags triage tasks for decompose
     maxDecompose: number; // concurrency cap for orchestrator runs (separate from maxInProgress)
     autoAssign: boolean; // when true, the dispatcher auto-assigns unassigned ready tasks to a worker profile
+    autoIntegrate: boolean; // when true, auto-merges completed feature tasks into the integration branch; spawns resolve runs on conflict
   };
   defaults: {
     workspaceKind: WorkspaceKind;


### PR DESCRIPTION
## Summary

Implements **autopilot phase 2** (issue #228): an `integrate()` dispatcher stage that auto-merges completed feature kanban tasks into their feature integration branch, plus an agent-driven `resolve` run mode for merge conflicts.

**Phase boundary — LOCAL GIT ONLY.** No origin push, no `gh`, no PR creation. Those belong to #229 (draft-PR lifecycle).

## What's delivered

- **Schema v11** — `tasks.resolve_attempts`, `tasks.system_kind`; `RunMode += 'resolve'` (additive migration + canonical `SCHEMA_SQL`).
- **`integrate()` dispatcher stage** (runs after `claimAndSpawn` each tick):
  - *Task-level* (`integrateTasks`): a review feature-worktree task auto-merges into its integration branch → `done` + worktree prune; conflict → bounded **resolve run** (cap `RESOLVE_ATTEMPT_CAP=2` → `blocked` + notification). Bounded `MAX_INTEGRATE_PER_TICK=3`.
  - *Feature-level* (`integrateFeatures`): once all member tasks are done, the integration branch auto-syncs with main (`updateIntegrationBranchFromMain`); a sync conflict spawns a `feature_sync` system task whose worktree checks out the integration branch directly (`checkoutBranchWorktree`), resolved then pruned-on-synced, fire-once via `mergeState='in_progress'`.
- **`resolve` run mode** — worker merges the target branch into its worktree, resolves, verifies, commits, `kanban_complete` → review (prompt + terminal tool + MCP `RESOLVE_TOOLS` + worker-profile spawning).
- **`autoIntegrate` setting** (default on) + KanbanSection toggle.
- Manual **"Merge to base"** conflict now spawns a resolve run (`requestResolve`).
- Git ops injected via `DispatcherDeps.integration` (`IntegrationOps`) for unit-testability; defaults to real `workspace.ts` fns in prod.

## Verification

- ✅ 355 kanban tests pass
- ✅ `npm run typecheck` clean
- ✅ `npm run build` succeeds
- ✅ lint net-zero vs main

## Plan / spec

- Spec: `docs/superpowers/specs/2026-06-10-kanban-integration-autopilot-design.md` (§1–2)
- Plan: `docs/superpowers/plans/2026-06-11-kanban-integrate-resolve.md`

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
