### PR TITLE
fix(telescope): hide recent files that no longer exist

### DIFF
--- a/src/renderer/src/components/Telescope/modes/files-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/files-mode.ts
@@ -41,18 +41,30 @@ export function createFilesMode(cwd: string, activePaneId: string | null): Teles
 
     onSearch: async (query: string): Promise<TelescopeItem[]> => {
       if (!query) {
-        // Return recent files (first 15)
+        // Return recent files (first 15), skipping any that no longer exist on disk
         const recentFiles = useWorkspaceStore.getState().recentFiles.slice(0, 15);
-        return recentFiles.map((filePath) => {
-          const name = filePath.split('/').pop() ?? filePath;
-          return {
-            id: filePath,
-            icon: getFileIcon(name),
-            title: name,
-            subtitle: filePath,
-            data: { filePath }
-          };
-        });
+        const checks = await Promise.all(
+          recentFiles.map(async (filePath) => ({
+            filePath,
+            exists: (await window.fleet.file.stat(filePath)).success
+          }))
+        );
+        const missing = checks.filter((c) => !c.exists).map((c) => c.filePath);
+        if (missing.length > 0) {
+          useWorkspaceStore.getState().removeRecentFiles(missing);
+        }
+        return checks
+          .filter((c) => c.exists)
+          .map(({ filePath }) => {
+            const name = filePath.split('/').pop() ?? filePath;
+            return {
+              id: filePath,
+              icon: getFileIcon(name),
+              title: name,
+              subtitle: filePath,
+              data: { filePath }
+            };
+          });
       }
 
       // Ensure cache is populated (may have been set by pre-load)

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -283,6 +283,7 @@ type WorkspaceStore = {
     files: Array<{ path: string; paneType: 'file' | 'image' | 'markdown' | 'pdf'; label: string }>
   ) => void;
   addRecentFile: (filePath: string) => void;
+  removeRecentFiles: (filePaths: string[]) => void;
   addRecentFolder: (folderPath: string) => void;
   setFileDirty: (paneId: string, isDirty: boolean) => void;
   setPaneDirty: (paneId: string, dirty: boolean) => void;
@@ -1246,6 +1247,17 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     set((state) => {
       const filtered = state.recentFiles.filter((f) => f !== filePath);
       const updated = [filePath, ...filtered].slice(0, MAX_RECENT_FILES);
+      saveRecentFiles(updated);
+      return { recentFiles: updated };
+    });
+  },
+
+  removeRecentFiles: (filePaths) => {
+    if (filePaths.length === 0) return;
+    const toRemove = new Set(filePaths);
+    set((state) => {
+      const updated = state.recentFiles.filter((f) => !toRemove.has(f));
+      if (updated.length === state.recentFiles.length) return {};
       saveRecentFiles(updated);
       return { recentFiles: updated };
     });


### PR DESCRIPTION
## Problem

The Telescope **Files** mode (empty query) listed recent files straight from the `localStorage`-persisted `recentFiles` list without ever checking them against disk. Files that had been deleted or moved kept showing up in the results indefinitely, and selecting one would fail to open.

## Fix

- `files-mode.ts` — the empty-query branch now `stat`s each recent file in parallel (`window.fleet.file.stat`), returns only files that still exist, and reports the missing ones to the store for pruning.
- `workspace-store.ts` — added a `removeRecentFiles(filePaths)` action that drops stale paths and re-persists, so dead entries self-clean from `localStorage` rather than being re-checked on every open.

The existence checks run concurrently over the ≤15 recent entries, so there's no noticeable latency.

## Verification

- `npm run typecheck` passes
- No new lint findings in the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)