### PR TITLE
fix(notifications): fire permission notification once per request

### DIFF
--- a/docs/learnings/2026-06-12-permission-notification-spam.md
+++ b/docs/learnings/2026-06-12-permission-notification-spam.md
@@ -1,0 +1,50 @@
+# Permission notification fires repeatedly (2026-06-12)
+
+## Problem
+
+When a Claude Code session showed a permission prompt, the OS notification "An
+agent needs your permission" re-fired roughly every 500ms (and the chime played
+continuously) instead of once per request.
+
+## Root cause
+
+Level-triggered detection that should have been edge-triggered.
+`NotificationDetector.checkPermissionPrompt` ran its regexes against **every PTY
+data chunk** (`ipc-handlers.ts` → `scan()`) and was **stateless**. Claude's Ink
+TUI continuously repaints the prompt (spinner, cursor blink, countdown), so each
+repaint chunk re-matched the trigger text and re-emitted a `notification`
+event. Downstream consumers faithfully amplified the stream:
+
+- OS popup coalescer (`index.ts`) only batches **within** a 500ms window, then
+  resets its timer — a sustained stream yields one popup per window.
+- Renderer chime (`use-notifications.ts`) plays per event.
+- `ActivityTracker` churned `working ↔ needs_me` because `onData` reset state to
+  `working` on every chunk, then the next emit re-promoted `needs_me`.
+
+## Fix
+
+Edge-trigger at the single source plus a clean resolution signal:
+
+1. **Per-pane latch in `NotificationDetector`** — emit `permission` once, then
+   suppress redraw re-emits. Re-arm only after the user types into the pane
+   (`onUserInput`) **and** the trigger text stops reappearing within a short
+   grace window (`PERMISSION_RESET_GRACE_MS = 400`). The grace + "matched since
+   input" flag is what distinguishes a genuine answer (prompt gone → re-arm)
+   from arrow-key navigation (prompt repaints → stay latched, no re-ping).
+2. **`ActivityTracker.onData` no longer demotes `needs_me`** — a blocked agent's
+   own redraw output must not clear the blocked state. Only `onUserInput`
+   (new) or `onExit` resolves it.
+3. **Wire `PTY_INPUT`** to call `notificationDetector.onUserInput` and
+   `activityTracker.onUserInput` before writing.
+
+Reset signal choice: user input (not time-decay, not Enter-only). Time-decay
+suppresses Claude's common rapid tool-after-tool prompts; Enter-only misses
+number-key selections (`1`/`2`/`3`) that submit without a carriage return.
+
+## Lesson
+
+Anything that scans a continuous output stream for a state ("needs permission",
+"idle", "done") must be **edge-triggered** — emit on the transition, not on every
+matching chunk. Hold per-source state and define an explicit re-arm signal.
+Downstream coalescers/dedup (the 500ms OS batch, `setState` dedup) only mask
+bursts; they cannot fix a level-triggered source feeding a sustained stream.

--- a/src/main/__tests__/activity-tracker.test.ts
+++ b/src/main/__tests__/activity-tracker.test.ts
@@ -137,6 +137,37 @@ describe('ActivityTracker', () => {
     );
   });
 
+  it('keeps needs_me when a blocked agent keeps emitting output', () => {
+    const callback = vi.fn();
+    eventBus.on('activity-state-change', callback);
+
+    tracker.trackPane('pane-1');
+    tracker.onNeedsMe('pane-1');
+    callback.mockClear();
+
+    // Permission prompt repaints arrive as PTY output — must not clear needs_me.
+    tracker.onData('pane-1');
+    tracker.onData('pane-1');
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(tracker.getState('pane-1')).toBe('needs_me');
+  });
+
+  it('clears needs_me back to working on user input', () => {
+    const callback = vi.fn();
+    eventBus.on('activity-state-change', callback);
+
+    tracker.trackPane('pane-1');
+    tracker.onNeedsMe('pane-1');
+    callback.mockClear();
+
+    tracker.onUserInput('pane-1');
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ paneId: 'pane-1', state: 'working' })
+    );
+  });
+
   it('does not emit duplicate states', () => {
     const callback = vi.fn();
     eventBus.on('activity-state-change', callback);

--- a/src/main/__tests__/notification-detector.test.ts
+++ b/src/main/__tests__/notification-detector.test.ts
@@ -129,6 +129,49 @@ describe('NotificationDetector', () => {
     expect(callback).toHaveBeenCalledWith(expect.objectContaining({ paneId: 'pane-1' }));
   });
 
+  it('emits permission only once when the prompt redraws across many chunks', () => {
+    const callback = vi.fn();
+    eventBus.on('notification', callback);
+
+    // Claude's TUI repaints the same prompt repeatedly while waiting.
+    for (let i = 0; i < 10; i++) {
+      detector.scan('pane-1', 'Do you want to allow this action? (y/n)');
+    }
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms after the user answers, so a new prompt notifies again', async () => {
+    const callback = vi.fn();
+    eventBus.on('notification', callback);
+
+    detector.scan('pane-1', 'Do you want to allow this action? (y/n)');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // User answers the prompt; no further matching output arrives.
+    detector.onUserInput('pane-1');
+    await new Promise((r) => setTimeout(r, 450));
+
+    // A genuinely new permission request fires once more.
+    detector.scan('pane-1', 'Do you want to allow this action? (y/n)');
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays latched when input is followed by a redraw of the same prompt (nav)', async () => {
+    const callback = vi.fn();
+    eventBus.on('notification', callback);
+
+    detector.scan('pane-1', 'Do you want to allow this action? (y/n)');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Arrow-key navigation: input, then the still-pending prompt repaints.
+    detector.onUserInput('pane-1');
+    detector.scan('pane-1', 'Do you want to allow this action? (y/n)');
+    await new Promise((r) => setTimeout(r, 450));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it('does not emit notification for tmux DCS sequences', () => {
     const callback = vi.fn();
     eventBus.on('notification', callback);

--- a/src/main/activity-tracker.ts
+++ b/src/main/activity-tracker.ts
@@ -79,6 +79,10 @@ export class ActivityTracker {
     if (pane.silenceTimer) clearTimeout(pane.silenceTimer);
     pane.silenceTimer = setTimeout(() => this.onSilence(paneId), this.opts.silenceThresholdMs);
 
+    // A blocked agent keeps redrawing its permission prompt; that output must
+    // not clear needs_me. Only user input (onUserInput) or exit resolves it.
+    if (pane.state === 'needs_me') return;
+
     this.setState(paneId, 'working');
   }
 
@@ -87,6 +91,14 @@ export class ActivityTracker {
     if (!pane) return;
 
     this.setState(paneId, 'needs_me');
+  }
+
+  // The user typed into the pane — the resolution edge for a permission prompt.
+  // Clears needs_me so the pane reflects that the agent is no longer blocked.
+  onUserInput(paneId: string): void {
+    const pane = this.panes.get(paneId);
+    if (!pane || pane.exited) return;
+    if (pane.state === 'needs_me') this.setState(paneId, 'working');
   }
 
   onExit(paneId: string, exitCode: number): void {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -213,6 +213,10 @@ export function registerIpcHandlers(
   });
 
   ipcMain.on(IPC_CHANNELS.PTY_INPUT, (_event, payload: PtyInputPayload) => {
+    // User input is the resolution edge for a pending permission prompt — re-arm
+    // notifications and clear needs_me so the next prompt notifies exactly once.
+    notificationDetector.onUserInput(payload.paneId);
+    activityTracker.onUserInput(payload.paneId);
     ptyManager.write(payload.paneId, payload.data);
   });
 

--- a/src/main/notification-detector.ts
+++ b/src/main/notification-detector.ts
@@ -28,14 +28,32 @@ const OSC133D_RE = /\x1b\]133;D(?:;(\d+))?\x1b\\/;
 
 const CARRY_BUFFER_SIZE = 200;
 
+// After the user types into a pane, wait this long before deciding the
+// permission prompt was answered. If the trigger text reappears within the
+// window, it's just a redraw of the still-pending prompt (e.g. arrow-key
+// navigation), so the latch stays engaged and we don't re-notify.
+const PERMISSION_RESET_GRACE_MS = 400;
+
+type PermissionLatch = {
+  // True once we've emitted for the current prompt; suppresses redraw re-emits.
+  suppressed: boolean;
+  // True if the trigger text reappeared since the last user input.
+  matchedSinceInput: boolean;
+  resetTimer: ReturnType<typeof setTimeout> | null;
+};
+
 export class NotificationDetector {
   private eventBus: EventBus;
   private carryBuffers = new Map<string, string>();
+  private permissionLatches = new Map<string, PermissionLatch>();
 
   constructor(eventBus: EventBus) {
     this.eventBus = eventBus;
     eventBus.on('pane-closed', (event) => {
       this.carryBuffers.delete(event.paneId);
+      const latch = this.permissionLatches.get(event.paneId);
+      if (latch?.resetTimer) clearTimeout(latch.resetTimer);
+      this.permissionLatches.delete(event.paneId);
     });
   }
 
@@ -110,9 +128,38 @@ export class NotificationDetector {
   private checkPermissionPrompt(paneId: string, data: string): void {
     for (const pattern of PERMISSION_PATTERNS) {
       if (pattern.test(data)) {
+        const latch = this.permissionLatches.get(paneId);
+        if (latch) {
+          // Mark that the prompt is still on screen (used to decide whether a
+          // pending input actually answered it — see onUserInput).
+          latch.matchedSinceInput = true;
+          if (latch.suppressed) return;
+          latch.suppressed = true;
+        } else {
+          this.permissionLatches.set(paneId, {
+            suppressed: true,
+            matchedSinceInput: true,
+            resetTimer: null
+          });
+        }
         this.emitNotification(paneId, 'permission');
         return;
       }
     }
+  }
+
+  // Called when the user types into a pane. If the permission prompt text stops
+  // reappearing shortly after, the prompt was answered — re-arm the latch so the
+  // next distinct permission request notifies exactly once.
+  onUserInput(paneId: string): void {
+    const latch = this.permissionLatches.get(paneId);
+    if (!latch?.suppressed) return;
+
+    latch.matchedSinceInput = false;
+    if (latch.resetTimer) clearTimeout(latch.resetTimer);
+    latch.resetTimer = setTimeout(() => {
+      latch.resetTimer = null;
+      if (!latch.matchedSinceInput) latch.suppressed = false;
+    }, PERMISSION_RESET_GRACE_MS);
   }
 }


### PR DESCRIPTION
## Problem

When a Claude Code session shows a permission prompt, the **"An agent needs your permission"** OS notification (and the chime) re-fires roughly **every 500ms** instead of once per request — a constant ping until the prompt is answered.

## Root cause

Level-triggered detection that should be edge-triggered. `NotificationDetector.checkPermissionPrompt` runs on **every PTY data chunk** and is **stateless**. Claude's Ink TUI continuously repaints the prompt (spinner, cursor blink, countdown), so each repaint re-matches the trigger text and re-emits a `notification` event. The 500ms OS coalescer only dedups bursts *within* a window, so a sustained stream produces one popup per window.

## Fix — edge-trigger at the single source

- **`notification-detector.ts`** — per-pane latch emits `permission` **once**, suppresses redraw re-emits, and re-arms only after user input **and** the trigger text stops reappearing within a 400ms grace window. The grace + "matched since input" flag distinguishes a genuine answer (prompt gone → re-arm) from arrow-key navigation (prompt repaints → stay latched). Cleaned up on `pane-closed`.
- **`activity-tracker.ts`** — `onData` no longer demotes `needs_me` (a blocked agent's own redraws must not clear its blocked state); new `onUserInput` resolves `needs_me → working`.
- **`ipc-handlers.ts`** — `PTY_INPUT` routes user input to both `onUserInput` hooks before writing.

Renderer is untouched — both the popup and chime derive from the single main-process event, so fixing the source fixes both.

### Reset-signal decision
User input (with grace debounce). Rejected **time-decay** (suppresses Claude's common rapid tool-after-tool prompts) and **Enter-only** (misses number-key `1`/`2`/`3` selections that submit without a carriage return).

## Testing
- `npx tsc --noEmit` clean
- Full suite: **1106 tests pass** (104 files)
- Added **5 regression tests**: redraw storm → one emit; re-arm after answer → re-notifies; nav repaint → stays latched; blocked-agent output keeps `needs_me`; input clears `needs_me`
- Learnings doc added (`docs/learnings/2026-06-12-permission-notification-spam.md`)

### Known minor tradeoff
Arrow-navigating a prompt briefly drops the activity badge to "working" until you submit — no extra ping/sound, purely cosmetic, self-corrects on the next state change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)