### PR TITLE
feat(slideshow): add/append, clear-all, and reorder for files mode

### DIFF
--- a/src/renderer/src/components/settings/BackgroundThumbnails.tsx
+++ b/src/renderer/src/components/settings/BackgroundThumbnails.tsx
@@ -4,9 +4,10 @@ import type { TerminalBackgroundSlideshow } from '../../../../shared/types';
 export function BackgroundThumbnails(props: {
   slideshow: TerminalBackgroundSlideshow;
   onRemoveFile?: (path: string) => void;
+  onReorderFile?: (from: number, to: number) => void;
   maxVisible?: number;
 }): React.JSX.Element | null {
-  const { slideshow, onRemoveFile, maxVisible = 8 } = props;
+  const { slideshow, onRemoveFile, onReorderFile, maxVisible = 8 } = props;
 
   const [folderImages, setFolderImages] = useState<string[]>([]);
   const [scanning, setScanning] = useState(false);
@@ -46,12 +47,110 @@ export function BackgroundThumbnails(props: {
   // source === 'files'
   if (slideshow.filePaths.length === 0) return null;
 
+  // The file list is the user's editable, ordered slideshow — show every image
+  // (not the capped preview) so each can be removed and reordered.
+  if (onRemoveFile && onReorderFile) {
+    return (
+      <EditableFileGrid
+        paths={slideshow.filePaths}
+        onRemoveFile={onRemoveFile}
+        onReorderFile={onReorderFile}
+      />
+    );
+  }
+
   return (
     <ThumbnailGrid
       paths={slideshow.filePaths}
       maxVisible={maxVisible}
       onRemoveFile={onRemoveFile}
     />
+  );
+}
+
+function EditableFileGrid(props: {
+  paths: string[];
+  onRemoveFile: (path: string) => void;
+  onReorderFile: (from: number, to: number) => void;
+}): React.JSX.Element {
+  const { paths, onRemoveFile, onReorderFile } = props;
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const clearDrag = (): void => {
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  const drop = (to: number): void => {
+    if (dragIndex !== null && dragIndex !== to) onReorderFile(dragIndex, to);
+    clearDrag();
+  };
+
+  return (
+    <div className="grid grid-cols-4 gap-1.5 max-h-[260px] overflow-y-auto pr-0.5">
+      {paths.map((path, index) => {
+        const filename = path.split('/').pop() ?? path;
+        const isDragging = dragIndex === index;
+        const isOver = overIndex === index && dragIndex !== index;
+        return (
+          <div
+            key={path}
+            draggable
+            onDragStart={(e) => {
+              e.dataTransfer.effectAllowed = 'move';
+              setDragIndex(index);
+            }}
+            onDragEnter={() => setOverIndex(index)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => drop(index)}
+            onDragEnd={clearDrag}
+            title={filename}
+            className={`group relative aspect-[16/10] rounded overflow-hidden border cursor-grab active:cursor-grabbing transition ${
+              isOver
+                ? 'border-fleet-text-subtle ring-1 ring-fleet-text-subtle'
+                : 'border-fleet-border-strong'
+            } ${isDragging ? 'opacity-40' : ''}`}
+          >
+            <img
+              src={encodeURI(`fleet-image://${path}`)}
+              className="w-full h-full object-cover pointer-events-none"
+              loading="lazy"
+              draggable={false}
+              alt=""
+            />
+            <button
+              type="button"
+              onClick={() => onRemoveFile(path)}
+              aria-label={`Remove ${filename}`}
+              className="absolute top-0.5 right-0.5 bg-black/60 text-white rounded-full w-4 h-4 text-[10px] leading-none flex items-center justify-center hover:bg-black/80"
+            >
+              ×
+            </button>
+            <div className="absolute bottom-0.5 left-0.5 flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+              <button
+                type="button"
+                disabled={index === 0}
+                onClick={() => onReorderFile(index, index - 1)}
+                aria-label={`Move ${filename} earlier`}
+                className="bg-black/60 text-white rounded w-4 h-4 text-[11px] leading-none flex items-center justify-center hover:bg-black/80 disabled:opacity-30 disabled:cursor-default"
+              >
+                ‹
+              </button>
+              <button
+                type="button"
+                disabled={index === paths.length - 1}
+                onClick={() => onReorderFile(index, index + 1)}
+                aria-label={`Move ${filename} later`}
+                className="bg-black/60 text-white rounded w-4 h-4 text-[11px] leading-none flex items-center justify-center hover:bg-black/80 disabled:opacity-30 disabled:cursor-default"
+              >
+                ›
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/renderer/src/components/settings/TerminalBackgroundSettings.tsx
+++ b/src/renderer/src/components/settings/TerminalBackgroundSettings.tsx
@@ -145,9 +145,18 @@ export function TerminalBackgroundSettings(): React.JSX.Element | null {
     if (folder) saveSlideshow({ source: 'folder', folderPath: folder });
   };
 
-  const pickSlideshowFiles = async (): Promise<void> => {
+  const addSlideshowFiles = async (): Promise<void> => {
     const paths = await window.fleet.file.openDialog({ multi: true, filters: IMAGE_FILTERS });
-    if (paths.length > 0) saveSlideshow({ source: 'files', filePaths: paths });
+    if (paths.length === 0) return;
+    const current = useSettingsStore.getState().settings;
+    if (!current) return;
+    const merged = [...current.general.terminalBackground.slideshow.filePaths];
+    for (const p of paths) if (!merged.includes(p)) merged.push(p);
+    saveSlideshow({ source: 'files', filePaths: merged });
+  };
+
+  const clearSlideshowFiles = (): void => {
+    saveSlideshow({ filePaths: [] });
   };
 
   const removeSlideshowFile = (path: string): void => {
@@ -155,6 +164,16 @@ export function TerminalBackgroundSettings(): React.JSX.Element | null {
     if (!current) return;
     const next = current.general.terminalBackground.slideshow.filePaths.filter((p) => p !== path);
     saveSlideshow({ filePaths: next });
+  };
+
+  const reorderSlideshowFile = (from: number, to: number): void => {
+    const current = useSettingsStore.getState().settings;
+    if (!current) return;
+    const arr = [...current.general.terminalBackground.slideshow.filePaths];
+    if (from < 0 || from >= arr.length || to < 0 || to >= arr.length || from === to) return;
+    const [moved] = arr.splice(from, 1);
+    arr.splice(to, 0, moved);
+    saveSlideshow({ filePaths: arr });
   };
 
   if (!bg) return null;
@@ -294,17 +313,27 @@ export function TerminalBackgroundSettings(): React.JSX.Element | null {
                 </span>
                 <button
                   type="button"
-                  onClick={() => void pickSlideshowFiles()}
+                  onClick={() => void addSlideshowFiles()}
                   className={BUTTON_CLASS}
                 >
-                  {ss.filePaths.length > 0 ? 'Change…' : 'Select Files…'}
+                  {ss.filePaths.length > 0 ? 'Add…' : 'Select Files…'}
                 </button>
+                {ss.filePaths.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={clearSlideshowFiles}
+                    className={SUBTLE_BUTTON_CLASS}
+                  >
+                    Clear All
+                  </button>
+                )}
               </div>
             </SettingRow>
           )}
           <BackgroundThumbnails
             slideshow={ss}
             onRemoveFile={ss.source === 'files' ? removeSlideshowFile : undefined}
+            onReorderFile={ss.source === 'files' ? reorderSlideshowFile : undefined}
           />
           <SettingRow label="Order">
             <SegmentedControl


### PR DESCRIPTION
## What

The Files-mode terminal background slideshow previously had a single **Change…** button that *replaced* the entire image list — forcing a full reselect and silently discarding prior curation. This adds proper list management.

- **Add…** (primary): appends to the existing list and **dedupes** by path
- **Clear All** (de-emphasized): empties the list (Replace = Clear All + Add)
- **Per-image ×**: retained
- **Drag-to-reorder** thumbnails, plus hover/keyboard-focus-revealed **‹ ›** move-earlier/later buttons as the accessible non-drag fallback
- The files grid now shows the **full list** (scrolls past ~3 rows) since it's the management surface; folder mode keeps the read-only capped preview

## Why

The single "Change" button was a textbook *User Control & Freedom* (NN/g heuristic #3) violation — one action silently destroyed curated work with no undo. UX choices are backed by Baymard / Nielsen Norman Group guidance:

- Append-by-default with the destructive path **separated and de-emphasized** — NN/g *Dangerous UX: Consequential Options*
- Verb+noun labels ("Add…") over ambiguous "Change…" — NN/g *Command Names*
- Per-item remove without confirmation (low-stakes/reversible); reorder ships with a non-drag fallback — NN/g *Confirmation Dialogs* & *Drag-and-Drop*

## Scope

No IPC / schema / store / render changes — `useSlideshow` already reacts to `filePaths`. Confined to:
- `TerminalBackgroundSettings.tsx` — `addSlideshowFiles` (append+dedupe), `clearSlideshowFiles`, `reorderSlideshowFile`, updated buttons
- `BackgroundThumbnails.tsx` — new `EditableFileGrid`; folder path unchanged

Typecheck passes; both files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)