### PR TITLE
feat(wsl): phase 3a — run query tools inside the distro for WSL panes

### DIFF
--- a/docs/wsl-path-handling-plan.md
+++ b/docs/wsl-path-handling-plan.md
@@ -1,6 +1,6 @@
 # WSL ↔ Windows Path Handling — Implementation Plan
 
-> Status: **Phase 0 + 1 + the Phase 2 paste/quote slice are implemented** (this PR). Phases 2 (remainder), 3 and 4 remain. Covers all three tiers; pick the next cut line from here.
+> Status: **Phase 0 + 1 + the Phase 2 paste/quote slice + Phase 3a (read-only query tools)** are implemented. Phase 3a = `runInPathContext` foundation + git (Git Changes), file-list/check-ignore, file-grep, file-search, plus the FILE_READDIR UNC bridge that browse-mode needs — all run *inside* the distro for WSL panes and return POSIX paths. Remaining: Phase 2 (remainder), **Phase 3b** (env-editor/env-sync, worktrees/kanban — the write/workflow tools, which depend on the `GIT_REPO_ROOT`-stays-POSIX semantics change §13.4) and Phase 4. Known follow-up: opening a WSL grep/files/search *result* in the in-app editor still needs FILE_READ/STAT/READ_BINARY routed through the UNC bridge + the editor pane carrying the file's `pathContext` (a separate viewing slice); the Telescope **paste** action already works via Phase 2.
 
 ## 1. Runtime model (confirmed)
 

--- a/src/main/__tests__/file-readdir.test.ts
+++ b/src/main/__tests__/file-readdir.test.ts
@@ -49,4 +49,16 @@ describe('sortAndMapDirEntries', () => {
   it('returns empty array for empty input', () => {
     expect(sortAndMapDirEntries([], '/any/path')).toEqual([]);
   });
+
+  it('joins with posix separators for a WSL context (OS-independent)', () => {
+    const entries = [makeDirent('src', true)];
+    const wsl = { kind: 'wsl', distro: 'Ubuntu-24.04' } as const;
+    const result = sortAndMapDirEntries(entries, '/home/khang/repo', wsl);
+    // posix join is platform-independent, so this holds on Windows CI too.
+    expect(result[0]).toEqual({
+      name: 'src',
+      path: '/home/khang/repo/src',
+      isDirectory: true
+    });
+  });
 });

--- a/src/main/__tests__/git-service.test.ts
+++ b/src/main/__tests__/git-service.test.ts
@@ -14,6 +14,22 @@ vi.mock('simple-git', () => ({
   simpleGit: vi.fn(() => mockGit)
 }));
 
+// Mock the WSL spawn boundary so we can drive git output without a real distro.
+const mockExecInContext = vi.fn();
+vi.mock('../run-in-context', () => ({
+  execInContext: (...args: unknown[]) => mockExecInContext(...args)
+}));
+
+const wsl = { kind: 'wsl', distro: 'Ubuntu-24.04' } as const;
+const ok = (
+  stdout: string
+): { stdout: string; stderr: string; code: number; timedOut: boolean } => ({
+  stdout,
+  stderr: '',
+  code: 0,
+  timedOut: false
+});
+
 describe('GitService', () => {
   let service: GitService;
 
@@ -100,6 +116,104 @@ describe('GitService', () => {
 
       expect(result.isRepo).toBe(true);
       expect(result.error).toBe('fatal: corrupted repo');
+    });
+  });
+
+  describe('WSL context (runs git inside the distro)', () => {
+    // Resolve based on the git subcommand so a single mock covers a full status.
+    function routeGit(gitArgs: string[]): {
+      stdout: string;
+      stderr: string;
+      code: number;
+      timedOut: boolean;
+    } {
+      const a = gitArgs.join(' ');
+      if (a.includes('rev-parse --is-inside-work-tree')) return ok('true\n');
+      if (a.includes('rev-parse --show-toplevel')) return ok('/home/khang/repo\n');
+      if (a.includes('branch --show-current')) return ok('main\n');
+      if (a.includes('status --porcelain=v1')) {
+        return ok(' M src/app.ts\n?? new-file.ts\n');
+      }
+      if (a.includes('diff HEAD --numstat')) return ok('3\t1\tsrc/app.ts\n');
+      if (a.includes('diff --no-index')) {
+        return {
+          stdout:
+            'diff --git a/new-file.ts b/new-file.ts\nnew file\n--- /dev/null\n+++ b/new-file.ts\n@@ -0,0 +1 @@\n+content\n',
+          stderr: '',
+          code: 1, // --no-index always exits 1 when files differ
+          timedOut: false
+        };
+      }
+      if (a.includes('diff HEAD')) {
+        return ok(
+          'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n'
+        );
+      }
+      return ok('');
+    }
+
+    beforeEach(() => {
+      mockExecInContext.mockImplementation(async (_ctx, _cmd, args: string[]) => routeGit(args));
+    });
+
+    it('checkIsRepo runs rev-parse inside the distro', async () => {
+      const result = await service.checkIsRepo('/home/khang/repo', wsl);
+      expect(result).toEqual({ isRepo: true });
+      // never falls back to simple-git for a WSL pane
+      expect(mockGit.checkIsRepo).not.toHaveBeenCalled();
+      const [ctx, cmd, args] = mockExecInContext.mock.calls[0];
+      expect(ctx).toEqual(wsl);
+      expect(cmd).toBe('git');
+      expect(args).toEqual(['rev-parse', '--is-inside-work-tree']);
+    });
+
+    it('checkIsRepo returns false when not a work tree', async () => {
+      mockExecInContext.mockResolvedValueOnce({
+        stdout: '',
+        stderr: 'fatal: not a git repository',
+        code: 128,
+        timedOut: false
+      });
+      expect(await service.checkIsRepo('/tmp', wsl)).toEqual({ isRepo: false });
+    });
+
+    it('repoRoot returns the posix toplevel', async () => {
+      expect(await service.repoRoot('/home/khang/repo', wsl)).toEqual({
+        root: '/home/khang/repo'
+      });
+    });
+
+    it('getFullStatus builds the same payload shape as native', async () => {
+      const result = await service.getFullStatus('/home/khang/repo', undefined, wsl);
+      expect(result.isRepo).toBe(true);
+      expect(result.branch).toBe('main');
+      expect(result.files).toHaveLength(2);
+      expect(result.files[0]).toMatchObject({
+        path: 'src/app.ts',
+        status: 'modified',
+        insertions: 3,
+        deletions: 1
+      });
+      expect(result.files[1]).toMatchObject({ path: 'new-file.ts', status: 'untracked' });
+      expect(result.diff).toContain('diff --git a/src/app.ts');
+      expect(result.diff).toContain('diff --git a/new-file.ts');
+      expect(result.error).toBeUndefined();
+      expect(mockGit.status).not.toHaveBeenCalled();
+    });
+
+    it('getFullStatus handles a rename in porcelain output', async () => {
+      mockExecInContext.mockImplementation(async (_ctx, _cmd, args: string[]) => {
+        const a = args.join(' ');
+        if (a.includes('rev-parse --is-inside-work-tree')) return ok('true\n');
+        if (a.includes('branch --show-current')) return ok('main\n');
+        if (a.includes('status --porcelain=v1')) return ok('R  old.ts -> new.ts\n');
+        if (a.includes('--numstat')) return ok('1\t1\tnew.ts\n');
+        if (a.includes('diff HEAD')) return ok('diff --git a/new.ts b/new.ts\n');
+        return ok('');
+      });
+      const result = await service.getFullStatus('/home/khang/repo', undefined, wsl);
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]).toMatchObject({ path: 'new.ts', status: 'renamed' });
     });
   });
 });

--- a/src/main/__tests__/run-in-context.test.ts
+++ b/src/main/__tests__/run-in-context.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildContextArgv } from '../run-in-context';
+
+const wsl = { kind: 'wsl', distro: 'Ubuntu-24.04' } as const;
+
+describe('buildContextArgv', () => {
+  describe('native contexts', () => {
+    it('passes the command and args through unchanged for win32', () => {
+      expect(buildContextArgv('win32', 'git', ['status'], 'C:\\repo')).toEqual({
+        file: 'git',
+        argv: ['status']
+      });
+    });
+
+    it('passes through for posix and ignores cwd (applied via spawn options)', () => {
+      expect(buildContextArgv('posix', 'rg', ['-n', 'foo', '/home/k'], '/home/k')).toEqual({
+        file: 'rg',
+        argv: ['-n', 'foo', '/home/k']
+      });
+    });
+  });
+
+  describe('wsl context', () => {
+    it('wraps the command in wsl.exe with --cd and --exec', () => {
+      const { file, argv } = buildContextArgv(wsl, 'git', ['status'], '/home/khang/repo');
+      // wslExePath resolves to System32\wsl.exe; assert the basename, not the prefix.
+      expect(file.replace(/\\/g, '/').endsWith('System32/wsl.exe')).toBe(true);
+      expect(argv).toEqual([
+        '-d',
+        'Ubuntu-24.04',
+        '--cd',
+        '/home/khang/repo',
+        '--exec',
+        'git',
+        'status'
+      ]);
+    });
+
+    it('omits --cd when no cwd is given', () => {
+      const { argv } = buildContextArgv(wsl, 'rg', ['-n', 'foo']);
+      expect(argv).toEqual(['-d', 'Ubuntu-24.04', '--exec', 'rg', '-n', 'foo']);
+    });
+
+    it('preserves argv verbatim (no shell interpolation)', () => {
+      const { argv } = buildContextArgv(wsl, 'git', ['diff', '--no-index', '/dev/null', 'a b.txt']);
+      expect(argv).toEqual([
+        '-d',
+        'Ubuntu-24.04',
+        '--exec',
+        'git',
+        'diff',
+        '--no-index',
+        '/dev/null',
+        'a b.txt'
+      ]);
+    });
+  });
+});

--- a/src/main/file-grep.ts
+++ b/src/main/file-grep.ts
@@ -1,9 +1,16 @@
-import { spawn, type ChildProcess } from 'child_process';
-import { relative } from 'path';
+import type { ChildProcess } from 'child_process';
+import { relative, posix as posixPath } from 'path';
 import type { FileGrepRequest, FileGrepResponse, FileGrepResult } from '../shared/ipc-api';
+import type { PathContext } from '../shared/shell-profiles';
 import { captureBoundedStdout } from './bounded-stdout';
+import { spawnInContext } from './run-in-context';
 
 let activeProcess: ChildProcess | null = null;
+
+// The only object variant of PathContext is the WSL one.
+function isWslContext(ctx: PathContext | undefined): ctx is { kind: 'wsl'; distro: string } {
+  return typeof ctx === 'object';
+}
 
 function killActive(): void {
   if (activeProcess && !activeProcess.killed) {
@@ -40,9 +47,11 @@ function buildRgCommand(
 function buildFallbackCommand(
   query: string,
   cwd: string,
-  limit: number
+  limit: number,
+  ctx?: PathContext
 ): { cmd: string; args: string[] } {
-  if (process.platform === 'win32') {
+  // A WSL pane always falls back to the distro's grep, never Windows findstr.
+  if (!isWslContext(ctx) && process.platform === 'win32') {
     return {
       cmd: 'findstr',
       args: ['/s', '/n', '/i', `/c:${query}`, `${cwd}\\*`]
@@ -61,7 +70,12 @@ function buildFallbackCommand(
  * Context lines: file-line-text
  * Block separators: --
  */
-function parseRgOutput(stdout: string, cwd: string, limit: number): FileGrepResult[] {
+function parseRgOutput(
+  stdout: string,
+  cwd: string,
+  limit: number,
+  rel: (from: string, to: string) => string
+): FileGrepResult[] {
   const results: FileGrepResult[] = [];
   const lines = stdout.split('\n');
 
@@ -149,7 +163,7 @@ function parseRgOutput(stdout: string, cwd: string, limit: number): FileGrepResu
     if (results.length >= limit) break;
     results.push({
       file: block.file,
-      relativePath: relative(cwd, block.file),
+      relativePath: rel(cwd, block.file),
       line: block.matchLine,
       text: block.matchText,
       contextBefore: block.before.length > 0 ? block.before : undefined,
@@ -164,7 +178,12 @@ function parseRgOutput(stdout: string, cwd: string, limit: number): FileGrepResu
  * Parse fallback grep/findstr output.
  * Format: file:line:text (no context lines)
  */
-function parseFallbackOutput(stdout: string, cwd: string, limit: number): FileGrepResult[] {
+function parseFallbackOutput(
+  stdout: string,
+  cwd: string,
+  limit: number,
+  rel: (from: string, to: string) => string
+): FileGrepResult[] {
   const results: FileGrepResult[] = [];
   const lines = stdout.split('\n');
 
@@ -179,7 +198,7 @@ function parseFallbackOutput(stdout: string, cwd: string, limit: number): FileGr
     const [, file, lineNumStr, text] = match;
     results.push({
       file,
-      relativePath: relative(cwd, file),
+      relativePath: rel(cwd, file),
       line: parseInt(lineNumStr, 10),
       text
     });
@@ -191,19 +210,24 @@ function parseFallbackOutput(stdout: string, cwd: string, limit: number): FileGr
 export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse> {
   killActive();
 
-  const { requestId, query, cwd } = req;
+  const { requestId, query, cwd, pathContext } = req;
   const limit = req.limit ?? 50;
 
   if (!query.trim()) {
     return { success: true, requestId, results: [] };
   }
 
+  // For a WSL pane the file paths returned by rg/grep are posix; relativize
+  // them with posix semantics (win32 `relative` would mangle them).
+  const rel = isWslContext(pathContext)
+    ? (from: string, to: string): string => posixPath.relative(from, to)
+    : (from: string, to: string): string => relative(from, to);
   const { cmd, args } = buildRgCommand(query, cwd, limit);
 
   return new Promise((resolve) => {
     let timedOut = false;
 
-    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const proc = spawnInContext(pathContext ?? 'posix', cmd, args, { cwd });
     activeProcess = proc;
 
     const timer = setTimeout(() => {
@@ -220,8 +244,8 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
       const errCode = (err as NodeJS.ErrnoException).code;
       if (errCode === 'ENOENT') {
         // rg not found — fall back to grep/findstr
-        const { cmd: fbCmd, args: fbArgs } = buildFallbackCommand(query, cwd, limit);
-        const fbProc = spawn(fbCmd, fbArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
+        const { cmd: fbCmd, args: fbArgs } = buildFallbackCommand(query, cwd, limit, pathContext);
+        const fbProc = spawnInContext(pathContext ?? 'posix', fbCmd, fbArgs, { cwd });
         activeProcess = fbProc;
 
         const fbTimer = setTimeout(() => {
@@ -233,7 +257,7 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
         fbProc.on('close', () => {
           clearTimeout(fbTimer);
           activeProcess = null;
-          const results = parseFallbackOutput(fbOut.text, cwd, limit);
+          const results = parseFallbackOutput(fbOut.text, cwd, limit, rel);
           resolve({ success: true, requestId, results });
         });
 
@@ -257,7 +281,7 @@ export async function grepFiles(req: FileGrepRequest): Promise<FileGrepResponse>
         return;
       }
 
-      const results = parseRgOutput(out.text, cwd, limit);
+      const results = parseRgOutput(out.text, cwd, limit, rel);
       resolve({ success: true, requestId, results });
     });
   });

--- a/src/main/file-search.ts
+++ b/src/main/file-search.ts
@@ -1,11 +1,19 @@
-import { spawn, type ChildProcess } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import { stat, realpath } from 'fs/promises';
-import { basename, dirname } from 'path';
+import { basename, dirname, posix as posixPath } from 'path';
 import { homedir } from 'os';
 import type { FileSearchRequest, FileSearchResponse, FileSearchResult } from '../shared/ipc-api';
+import type { PathContext } from '../shared/shell-profiles';
 import { captureBoundedStdout } from './bounded-stdout';
+import { spawnInContext } from './run-in-context';
+import { toWslUncPath } from '../shared/path-platform';
 
 let activeProcess: ChildProcess | null = null;
+
+// The only object variant of PathContext is the WSL one.
+function isWslContext(ctx: PathContext | undefined): ctx is { kind: 'wsl'; distro: string } {
+  return typeof ctx === 'object';
+}
 
 function killActive(): void {
   if (activeProcess && !activeProcess.killed) {
@@ -17,11 +25,21 @@ function killActive(): void {
 function buildCommand(
   query: string,
   scope: string | undefined,
-  limit: number
+  limit: number,
+  ctx: PathContext
 ): { cmd: string; args: string[] } {
+  const escapedQuery = query.replace(/'/g, "\\'");
+
+  // A WSL pane uses the distro's own indexer (locate), like native linux.
+  if (isWslContext(ctx)) {
+    return {
+      cmd: 'locate',
+      args: ['-i', '-l', String(limit), '--', `*${query}*`]
+    };
+  }
+
   const platform = process.platform;
   const searchScope = scope ?? homedir();
-  const escapedQuery = query.replace(/'/g, "\\'");
 
   if (platform === 'darwin') {
     return {
@@ -43,8 +61,22 @@ function buildCommand(
   };
 }
 
-async function statResult(filePath: string): Promise<FileSearchResult | null> {
+async function statResult(filePath: string, ctx: PathContext): Promise<FileSearchResult | null> {
   try {
+    if (isWslContext(ctx)) {
+      // The path is posix; stat it over the UNC bridge but keep posix coords in
+      // the result (realpath would rewrite it to a UNC path). Distro temp paths
+      // and symlinks are left unresolved — acceptable for a picker.
+      const s = await stat(toWslUncPath(ctx.distro, filePath));
+      if (!s.isFile()) return null;
+      return {
+        path: filePath,
+        name: posixPath.basename(filePath),
+        parentDir: posixPath.dirname(filePath),
+        modifiedAt: s.mtimeMs,
+        size: s.size
+      };
+    }
     const resolved = await realpath(filePath);
     const s = await stat(resolved);
     if (!s.isFile()) return null;
@@ -63,14 +95,16 @@ async function statResult(filePath: string): Promise<FileSearchResult | null> {
 export async function searchFiles(req: FileSearchRequest): Promise<FileSearchResponse> {
   killActive();
 
-  const { requestId, query, scope } = req;
+  const { requestId, query, scope, pathContext } = req;
   const limit = req.limit ?? 20;
+  const ctx: PathContext = pathContext ?? 'posix';
+  const wsl = isWslContext(ctx);
 
   if (!query.trim()) {
     return { success: true, requestId, results: [] };
   }
 
-  const { cmd, args } = buildCommand(query, scope, limit);
+  const { cmd, args } = buildCommand(query, scope, limit, ctx);
 
   return new Promise((resolve) => {
     const isNonIndexed = cmd === 'powershell' || cmd === 'find';
@@ -78,7 +112,7 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
 
     let timedOut = false;
 
-    const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const proc = spawnInContext(ctx, cmd, args, {});
     activeProcess = proc;
 
     const timer = setTimeout(() => {
@@ -95,19 +129,18 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
       const errCode = (err as NodeJS.ErrnoException).code;
       const canFallback = cmd === 'locate' || cmd === 'es.exe';
       if (errCode === 'ENOENT' && canFallback) {
-        const fallbackScope = scope ?? homedir();
-        const isWin = process.platform === 'win32';
-        const fallbackCmd = isWin ? 'powershell' : 'find';
-        const fallbackArgs = isWin
-          ? [
+        // WSL and native-linux fall back to `find`; native-Windows to PowerShell.
+        const useFind = wsl || process.platform !== 'win32';
+        const fallbackScope = scope ?? (wsl ? '.' : homedir());
+        const fallbackCmd = useFind ? 'find' : 'powershell';
+        const fallbackArgs = useFind
+          ? [fallbackScope, '-maxdepth', '5', '-iname', `*${query}*`, '-type', 'f']
+          : [
               '-NoProfile',
               '-Command',
               `Get-ChildItem -Path '${fallbackScope}' -Recurse -Filter '*${query}*' -File -ErrorAction SilentlyContinue | Select-Object -First ${limit} -ExpandProperty FullName`
-            ]
-          : [fallbackScope, '-maxdepth', '5', '-iname', `*${query}*`, '-type', 'f'];
-        const findProc = spawn(fallbackCmd, fallbackArgs, {
-          stdio: ['ignore', 'pipe', 'pipe']
-        });
+            ];
+        const findProc = spawnInContext(ctx, fallbackCmd, fallbackArgs, {});
         activeProcess = findProc;
 
         const findTimer = setTimeout(() => {
@@ -119,7 +152,7 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
         findProc.on('close', () => {
           clearTimeout(findTimer);
           activeProcess = null;
-          void processResults(findOut.text, limit, requestId).then(resolve);
+          void processResults(findOut.text, limit, requestId, ctx).then(resolve);
         });
 
         findProc.on('error', () => {
@@ -142,7 +175,7 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
         return;
       }
 
-      void processResults(out.text, limit, requestId).then(resolve);
+      void processResults(out.text, limit, requestId, ctx).then(resolve);
     });
   });
 }
@@ -150,7 +183,8 @@ export async function searchFiles(req: FileSearchRequest): Promise<FileSearchRes
 async function processResults(
   stdout: string,
   limit: number,
-  requestId: number
+  requestId: number,
+  ctx: PathContext
 ): Promise<FileSearchResponse> {
   const paths = stdout
     .split('\n')
@@ -163,7 +197,7 @@ async function processResults(
 
   for (const p of paths) {
     if (results.length >= limit) break;
-    const result = await statResult(p);
+    const result = await statResult(p, ctx);
     if (result && !seen.has(result.path)) {
       seen.add(result.path);
       results.push(result);

--- a/src/main/git-service.ts
+++ b/src/main/git-service.ts
@@ -5,13 +5,32 @@ import type {
   GitRepoRootPayload,
   GitFileStatus
 } from '../shared/ipc-api';
+import type { PathContext } from '../shared/shell-profiles';
+import { execInContext, type ExecResult } from './run-in-context';
+
+const GIT_TIMEOUT_MS = 20_000;
+
+// The only object variant of PathContext is the WSL one.
+function isWslCtx(ctx: PathContext | undefined): ctx is { kind: 'wsl'; distro: string } {
+  return typeof ctx === 'object';
+}
 
 export class GitService {
   private getGit(cwd: string): SimpleGit {
     return simpleGit({ baseDir: cwd });
   }
 
-  async checkIsRepo(cwd: string): Promise<GitIsRepoPayload> {
+  /** Run `git args...` inside the WSL distro at the (posix) repo cwd. */
+  private async runWslGit(
+    ctx: { kind: 'wsl'; distro: string },
+    cwd: string,
+    args: string[]
+  ): Promise<ExecResult> {
+    return execInContext(ctx, 'git', args, { cwd, timeoutMs: GIT_TIMEOUT_MS });
+  }
+
+  async checkIsRepo(cwd: string, ctx?: PathContext): Promise<GitIsRepoPayload> {
+    if (isWslCtx(ctx)) return this.checkIsRepoWsl(ctx, cwd);
     try {
       const isRepo = await this.getGit(cwd).checkIsRepo();
       return { isRepo };
@@ -20,7 +39,8 @@ export class GitService {
     }
   }
 
-  async repoRoot(cwd: string): Promise<GitRepoRootPayload> {
+  async repoRoot(cwd: string, ctx?: PathContext): Promise<GitRepoRootPayload> {
+    if (isWslCtx(ctx)) return this.repoRootWsl(ctx, cwd);
     try {
       const root = (await this.getGit(cwd).revparse(['--show-toplevel'])).trim();
       return { root: root || null };
@@ -29,7 +49,8 @@ export class GitService {
     }
   }
 
-  async getFullStatus(cwd: string, baseRef?: string): Promise<GitStatusPayload> {
+  async getFullStatus(cwd: string, baseRef?: string, ctx?: PathContext): Promise<GitStatusPayload> {
+    if (isWslCtx(ctx)) return this.getFullStatusWsl(ctx, cwd, baseRef);
     const git = this.getGit(cwd);
 
     // Check if it's a repo first
@@ -173,6 +194,236 @@ export class GitService {
       return { isRepo: true, branch: '', files: [], diff: '', error: message };
     }
   }
+
+  // ── WSL variants ────────────────────────────────────────────────────────
+  // Run git inside the distro (see run-in-context.ts) rather than spawning the
+  // Windows git.exe against a posix/UNC cwd. Returns posix paths.
+
+  private async checkIsRepoWsl(
+    ctx: { kind: 'wsl'; distro: string },
+    cwd: string
+  ): Promise<GitIsRepoPayload> {
+    try {
+      const { stdout, code } = await this.runWslGit(ctx, cwd, [
+        'rev-parse',
+        '--is-inside-work-tree'
+      ]);
+      return { isRepo: code === 0 && stdout.trim() === 'true' };
+    } catch {
+      return { isRepo: false };
+    }
+  }
+
+  private async repoRootWsl(
+    ctx: { kind: 'wsl'; distro: string },
+    cwd: string
+  ): Promise<GitRepoRootPayload> {
+    try {
+      const { stdout, code } = await this.runWslGit(ctx, cwd, ['rev-parse', '--show-toplevel']);
+      return { root: code === 0 ? stdout.trim() || null : null };
+    } catch {
+      return { root: null };
+    }
+  }
+
+  private async getFullStatusWsl(
+    ctx: { kind: 'wsl'; distro: string },
+    cwd: string,
+    baseRef?: string
+  ): Promise<GitStatusPayload> {
+    const repo = await this.checkIsRepoWsl(ctx, cwd);
+    if (!repo.isRepo) {
+      return { isRepo: false, branch: '', files: [], diff: '' };
+    }
+
+    if (baseRef) {
+      return this.getRefDiffWsl(ctx, cwd, baseRef);
+    }
+
+    try {
+      const branch = (await this.runWslGit(ctx, cwd, ['branch', '--show-current'])).stdout.trim();
+      const statusRaw = (
+        await this.runWslGit(ctx, cwd, [
+          '-c',
+          'core.quotepath=false',
+          'status',
+          '--porcelain=v1',
+          '--untracked-files=all'
+        ])
+      ).stdout;
+      const { files: statusFiles, untracked } = parsePorcelainV1(statusRaw);
+
+      const hasTrackedChanges = statusFiles.some((f) => !untracked.has(f.path));
+      let numstatRaw = '';
+      if (hasTrackedChanges) {
+        numstatRaw = (
+          await this.runWslGit(ctx, cwd, [
+            '-c',
+            'core.quotepath=false',
+            'diff',
+            'HEAD',
+            '--numstat'
+          ])
+        ).stdout;
+      }
+      const numstatMap = parseNumstat(numstatRaw);
+
+      const files: GitFileStatus[] = statusFiles.map((f) => {
+        const isUntracked = untracked.has(f.path);
+        const stats = numstatMap.get(f.path) ?? { insertions: 0, deletions: 0 };
+        return {
+          path: f.path,
+          status: resolveStatus(f, isUntracked),
+          insertions: stats.insertions,
+          deletions: stats.deletions
+        };
+      });
+
+      let diff = '';
+      if (hasTrackedChanges) {
+        diff = (await this.runWslGit(ctx, cwd, ['diff', 'HEAD'])).stdout;
+      }
+
+      // Untracked files: `git diff --no-index /dev/null <path>` exits 1 but
+      // still prints the diff on stdout (no shell, so no exit-code throw here).
+      for (const path of untracked) {
+        const { stdout } = await this.runWslGit(ctx, cwd, [
+          'diff',
+          '--no-index',
+          '/dev/null',
+          path
+        ]);
+        diff += stdout;
+      }
+
+      return { isRepo: true, branch, files, diff };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { isRepo: true, branch: '', files: [], diff: '', error: message };
+    }
+  }
+
+  private async getRefDiffWsl(
+    ctx: { kind: 'wsl'; distro: string },
+    cwd: string,
+    baseRef: string
+  ): Promise<GitStatusPayload> {
+    const range = `${baseRef}...HEAD`;
+    try {
+      const branch = (await this.runWslGit(ctx, cwd, ['branch', '--show-current'])).stdout.trim();
+      const numstatRaw = (
+        await this.runWslGit(ctx, cwd, ['-c', 'core.quotepath=false', 'diff', range, '--numstat'])
+      ).stdout;
+      const nameStatusRaw = (
+        await this.runWslGit(ctx, cwd, [
+          '-c',
+          'core.quotepath=false',
+          'diff',
+          range,
+          '--name-status'
+        ])
+      ).stdout;
+
+      const numstatMap = parseNumstatWithRename(numstatRaw);
+
+      const files: GitFileStatus[] = [];
+      for (const line of nameStatusRaw.split('\n')) {
+        if (!line.trim()) continue;
+        const parts = line.split('\t');
+        const code = parts[0]?.[0] ?? 'M';
+        const path = parts[parts.length - 1];
+        const stats = numstatMap.get(path) ?? { insertions: 0, deletions: 0 };
+        files.push({
+          path,
+          status:
+            code === 'A'
+              ? 'added'
+              : code === 'D'
+                ? 'deleted'
+                : code === 'R'
+                  ? 'renamed'
+                  : 'modified',
+          insertions: stats.insertions,
+          deletions: stats.deletions
+        });
+      }
+
+      const diff = (await this.runWslGit(ctx, cwd, ['diff', range])).stdout;
+      return { isRepo: true, branch, files, diff };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { isRepo: true, branch: '', files: [], diff: '', error: message };
+    }
+  }
+}
+
+/** Parse `git diff --numstat` text → path → {insertions, deletions}. */
+function parseNumstat(raw: string): Map<string, { insertions: number; deletions: number }> {
+  const map = new Map<string, { insertions: number; deletions: number }>();
+  for (const line of raw.split('\n')) {
+    const parts = line.split('\t');
+    if (parts.length === 3) {
+      map.set(parts[2], {
+        insertions: parseInt(parts[0]) || 0,
+        deletions: parseInt(parts[1]) || 0
+      });
+    }
+  }
+  return map;
+}
+
+/**
+ * Like {@link parseNumstat} but collapses rename path columns
+ * (`dir/{old => new}/file` or `old => new`) to the new path so name-status
+ * lookups match — used for ref-diffs where renames are detected.
+ */
+function parseNumstatWithRename(
+  raw: string
+): Map<string, { insertions: number; deletions: number }> {
+  const map = new Map<string, { insertions: number; deletions: number }>();
+  for (const line of raw.split('\n')) {
+    const parts = line.split('\t');
+    if (parts.length === 3) {
+      let path = parts[2];
+      const brace = path.match(/^(.*)\{.* => (.*?)\}(.*)$/);
+      if (brace) path = brace[1] + brace[2] + brace[3];
+      else if (path.includes(' => ')) path = path.split(' => ')[1];
+      map.set(path, {
+        insertions: parseInt(parts[0]) || 0,
+        deletions: parseInt(parts[1]) || 0
+      });
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse `git status --porcelain=v1` (with core.quotepath=false). Each line is
+ * `XY <path>`, or `XY <orig> -> <path>` for renames/copies. Mirrors the shape
+ * simple-git's `status()` returns (files + untracked set) so the WSL and native
+ * code paths build identical payloads.
+ */
+function parsePorcelainV1(raw: string): {
+  files: FileStatusResult[];
+  untracked: Set<string>;
+} {
+  const files: FileStatusResult[] = [];
+  const untracked = new Set<string>();
+  for (const line of raw.split('\n')) {
+    if (line.length < 4) continue;
+    const index = line[0];
+    const working_dir = line[1];
+    let path = line.slice(3);
+    if (index === '?' && working_dir === '?') {
+      untracked.add(path);
+      files.push({ path, index, working_dir });
+      continue;
+    }
+    const arrow = path.indexOf(' -> ');
+    if (arrow !== -1) path = path.slice(arrow + 4);
+    files.push({ path, index, working_dir });
+  }
+  return { files, untracked };
 }
 
 function resolveStatus(file: FileStatusResult, isUntracked: boolean): GitFileStatus['status'] {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -6,11 +6,96 @@ import { createLogger, logger } from './logger';
 const log = createLogger('ipc');
 import { readFile, writeFile, stat, readdir } from 'fs/promises';
 import type { Dirent } from 'fs';
-import { extname, join, relative } from 'path';
+import { extname, join, relative, posix as posixPath } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { execInContext } from './run-in-context';
 
 const execAsync = promisify(exec);
+
+/** Common directories pruned when walking a non-git tree for FILE_LIST. */
+const FILE_LIST_IGNORE_DIRS = [
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  '.nuxt',
+  'coverage',
+  '__pycache__',
+  '.cache',
+  '.parcel-cache',
+  'out',
+  '.svelte-kit'
+];
+
+// The only object variant of PathContext is the WSL one.
+function isWslContext(ctx: PathContext | undefined): ctx is { kind: 'wsl'; distro: string } {
+  return typeof ctx === 'object';
+}
+
+/** Native (non-WSL) host coordinate system for the running process. */
+function hostContext(): PathContext {
+  return process.platform === 'win32' ? 'win32' : 'posix';
+}
+
+type FileListEntry = { path: string; relativePath: string; name: string };
+
+/**
+ * FILE_LIST for a WSL pane — run git/find *inside* the distro so we get clean
+ * POSIX paths (the win32 `path.join` over a posix dir would mangle separators).
+ */
+async function listFilesWsl(
+  ctx: { kind: 'wsl'; distro: string },
+  dirPath: string
+): Promise<{ success: true; files: FileListEntry[] }> {
+  try {
+    const { stdout, code } = await execInContext(
+      ctx,
+      'git',
+      ['ls-files', '--cached', '--others', '--exclude-standard'],
+      { cwd: dirPath, maxBuffer: 10 * 1024 * 1024 }
+    );
+    if (code === 0) {
+      const files = stdout
+        .split('\n')
+        .filter(Boolean)
+        .map((f) => ({
+          path: posixPath.join(dirPath, f),
+          relativePath: f,
+          name: f.split('/').pop() ?? f
+        }));
+      return { success: true, files };
+    }
+  } catch {
+    // fall through to find
+  }
+
+  // Not a git repo (or git unavailable) — prune common dirs and list files.
+  try {
+    const findArgs: string[] = [dirPath, '('];
+    FILE_LIST_IGNORE_DIRS.forEach((n, i) => {
+      if (i > 0) findArgs.push('-o');
+      findArgs.push('-name', n);
+    });
+    findArgs.push(')', '-prune', '-o', '-type', 'f', '-print');
+    const { stdout } = await execInContext(ctx, 'find', findArgs, {
+      cwd: dirPath,
+      maxBuffer: 10 * 1024 * 1024
+    });
+    const files = stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((abs) => ({
+        path: abs,
+        relativePath: posixPath.relative(dirPath, abs),
+        name: abs.split('/').pop() ?? abs
+      }));
+    return { success: true, files };
+  } catch {
+    return { success: true, files: [] };
+  }
+}
 import { IPC_CHANNELS } from '../shared/constants';
 import type {
   PtyCreateRequest,
@@ -64,6 +149,7 @@ import type { PiEnvInjectionManager } from './pi-env-injection-manager';
 import type { ShellProfileRegistry } from './shell-profiles';
 import type { WslService } from './wsl-service';
 import type { PathContext } from '../shared/shell-profiles';
+import { toWslUncPath, toWindowsAccessiblePath } from '../shared/path-platform';
 import type { BedrockWritePatch, BedrockSecretField } from '../shared/pi-env-injection-types';
 import type { PiProvider, PiSettings } from '../shared/pi-config-types';
 import type { FleetSettingsPatch } from '../shared/types';
@@ -324,17 +410,20 @@ export function registerIpcHandlers(
   });
 
   // Git handlers
-  ipcMain.handle(IPC_CHANNELS.GIT_IS_REPO, async (_event, cwd: string) => {
-    return gitService.checkIsRepo(cwd);
+  ipcMain.handle(IPC_CHANNELS.GIT_IS_REPO, async (_event, cwd: string, ctx?: PathContext) => {
+    return gitService.checkIsRepo(cwd, ctx);
   });
 
-  ipcMain.handle(IPC_CHANNELS.GIT_REPO_ROOT, async (_event, cwd: string) => {
-    return gitService.repoRoot(cwd);
+  ipcMain.handle(IPC_CHANNELS.GIT_REPO_ROOT, async (_event, cwd: string, ctx?: PathContext) => {
+    return gitService.repoRoot(cwd, ctx);
   });
 
-  ipcMain.handle(IPC_CHANNELS.GIT_STATUS, async (_event, cwd: string, baseRef?: string) => {
-    return gitService.getFullStatus(cwd, baseRef);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.GIT_STATUS,
+    async (_event, cwd: string, baseRef?: string, ctx?: PathContext) => {
+      return gitService.getFullStatus(cwd, baseRef, ctx);
+    }
+  );
 
   // System-level dependency check (app-wide pre-checks screen)
   ipcMain.handle(IPC_CHANNELS.SYSTEM_CHECK, async () => {
@@ -417,64 +506,68 @@ export function registerIpcHandlers(
   );
 
   // List files recursively in a directory, respecting .gitignore when in a git repo
-  ipcMain.handle(IPC_CHANNELS.FILE_LIST, async (_event, { dirPath }: { dirPath: string }) => {
-    try {
-      // Try git ls-files first (respects .gitignore)
-      const { stdout } = await execAsync('git ls-files --cached --others --exclude-standard', {
-        cwd: dirPath,
-        maxBuffer: 10 * 1024 * 1024
-      });
-      const files = stdout
-        .split('\n')
-        .filter(Boolean)
-        .map((f) => ({
-          path: join(dirPath, f),
-          relativePath: f,
-          name: f.split('/').pop() ?? f
-        }));
-      return { success: true, files };
-    } catch {
-      // Fallback: manual recursive walk with common ignore patterns
-      const IGNORE_DIRS = new Set([
-        'node_modules',
-        '.git',
-        'dist',
-        'build',
-        '.next',
-        '.nuxt',
-        'coverage',
-        '__pycache__',
-        '.cache',
-        '.parcel-cache',
-        'out',
-        '.svelte-kit'
-      ]);
-      const files: Array<{ path: string; relativePath: string; name: string }> = [];
+  ipcMain.handle(
+    IPC_CHANNELS.FILE_LIST,
+    async (_event, { dirPath, pathContext }: { dirPath: string; pathContext?: PathContext }) => {
+      if (isWslContext(pathContext)) return listFilesWsl(pathContext, dirPath);
+      try {
+        // Try git ls-files first (respects .gitignore)
+        const { stdout } = await execAsync('git ls-files --cached --others --exclude-standard', {
+          cwd: dirPath,
+          maxBuffer: 10 * 1024 * 1024
+        });
+        const files = stdout
+          .split('\n')
+          .filter(Boolean)
+          .map((f) => ({
+            path: join(dirPath, f),
+            relativePath: f,
+            name: f.split('/').pop() ?? f
+          }));
+        return { success: true, files };
+      } catch {
+        // Fallback: manual recursive walk with common ignore patterns
+        const IGNORE_DIRS = new Set([
+          'node_modules',
+          '.git',
+          'dist',
+          'build',
+          '.next',
+          '.nuxt',
+          'coverage',
+          '__pycache__',
+          '.cache',
+          '.parcel-cache',
+          'out',
+          '.svelte-kit'
+        ]);
+        const files: Array<{ path: string; relativePath: string; name: string }> = [];
 
-      async function walk(dir: string, base: string): Promise<void> {
-        let entries: Dirent[];
-        try {
-          entries = await readdir(dir, { withFileTypes: true });
-        } catch {
-          return;
-        }
-        for (const entry of entries) {
-          if (entry.isDirectory()) {
-            if (!IGNORE_DIRS.has(entry.name) && !entry.name.startsWith('.')) {
-              await walk(join(dir, entry.name), base);
+        async function walk(dir: string, base: string): Promise<void> {
+          let entries: Dirent[];
+          try {
+            entries = await readdir(dir, { withFileTypes: true });
+          } catch {
+            return;
+          }
+          for (const entry of entries) {
+            if (entry.isDirectory()) {
+              if (!IGNORE_DIRS.has(entry.name) && !entry.name.startsWith('.')) {
+                await walk(join(dir, entry.name), base);
+              }
+            } else if (entry.isFile()) {
+              const abs = join(dir, entry.name);
+              const rel = relative(base, abs);
+              files.push({ path: abs, relativePath: rel, name: entry.name });
             }
-          } else if (entry.isFile()) {
-            const abs = join(dir, entry.name);
-            const rel = relative(base, abs);
-            files.push({ path: abs, relativePath: rel, name: entry.name });
           }
         }
-      }
 
-      await walk(dirPath, dirPath);
-      return { success: true, files };
+        await walk(dirPath, dirPath);
+        return { success: true, files };
+      }
     }
-  });
+  );
 
   // File operations
   ipcMain.handle(IPC_CHANNELS.FILE_READ, async (_event, filePath: string) => {
@@ -521,14 +614,20 @@ export function registerIpcHandlers(
   });
 
   // List immediate children of a directory (single level, no recursion)
-  ipcMain.handle(IPC_CHANNELS.FILE_READDIR, async (_event, { dirPath }: { dirPath: string }) => {
-    try {
-      const entries = await readdir(dirPath, { withFileTypes: true });
-      return { success: true, entries: sortAndMapDirEntries(entries, dirPath) };
-    } catch (err) {
-      return { success: false, error: toError(err).message, entries: [] };
+  ipcMain.handle(
+    IPC_CHANNELS.FILE_READDIR,
+    async (_event, { dirPath, pathContext }: { dirPath: string; pathContext?: PathContext }) => {
+      try {
+        // For a WSL pane the dir is posix; read it over the UNC bridge but keep
+        // the returned entry paths in the pane's (posix) coordinate system.
+        const readDir = pathContext ? toWindowsAccessiblePath(dirPath, pathContext) : dirPath;
+        const entries = await readdir(readDir, { withFileTypes: true });
+        return { success: true, entries: sortAndMapDirEntries(entries, dirPath, pathContext) };
+      } catch (err) {
+        return { success: false, error: toError(err).message, entries: [] };
+      }
     }
-  });
+  );
 
   // List image files in a folder for the terminal background slideshow
   ipcMain.handle(
@@ -540,20 +639,32 @@ export function registerIpcHandlers(
   // Check which entries in a directory are gitignored (returns ignored names)
   ipcMain.handle(
     IPC_CHANNELS.FILE_CHECK_IGNORED,
-    async (_event, { dirPath }: { dirPath: string }): Promise<string[]> => {
+    async (
+      _event,
+      { dirPath, pathContext }: { dirPath: string; pathContext?: PathContext }
+    ): Promise<string[]> => {
       try {
-        const entries = await readdir(dirPath, { withFileTypes: true });
+        // For a WSL pane the dir is a posix path; read its entries over the UNC
+        // bridge, then run git check-ignore inside the distro.
+        const wsl = isWslContext(pathContext);
+        const listDir = wsl ? toWslUncPath(pathContext.distro, dirPath) : dirPath;
+        const entries = await readdir(listDir, { withFileTypes: true });
         const names = entries.filter((e) => e.isFile() || e.isDirectory()).map((e) => e.name);
         if (names.length === 0) return [];
 
-        const { stdout } = await execAsync(
-          `git check-ignore -- ${names.map((n) => `'${n.replace(/'/g, "'\\''")}'`).join(' ')}`,
+        // argv form (no shell) — removes the quoting/injection-prone glob string
+        // and works identically inside WSL via --exec.
+        const { stdout } = await execInContext(
+          pathContext ?? hostContext(),
+          'git',
+          ['check-ignore', '--', ...names],
           { cwd: dirPath, maxBuffer: 1024 * 1024 }
         );
         return stdout.split('\n').filter(Boolean);
       } catch {
-        // git check-ignore exits with code 1 when no files are ignored,
-        // or fails if not a git repo — both cases mean "nothing ignored"
+        // git check-ignore exits 1 when no files are ignored, or fails if not a
+        // git repo — both mean "nothing ignored". (execInContext only rejects on
+        // spawn failure, which also lands here.)
         return [];
       }
     }
@@ -581,9 +692,19 @@ export function registerIpcHandlers(
     }
   });
 
-  ipcMain.handle(IPC_CHANNELS.FILE_SEARCH, async (_event, req: FileSearchRequest) =>
-    searchFiles(req)
-  );
+  ipcMain.handle(IPC_CHANNELS.FILE_SEARCH, async (_event, req: FileSearchRequest) => {
+    // For a WSL pane with no explicit scope, root the `find` fallback at the
+    // distro's posix home (homedir() would be the Windows home — unreachable).
+    if (isWslContext(req.pathContext) && !req.scope) {
+      try {
+        const home = await wslService.homeDir(req.pathContext.distro);
+        return await searchFiles({ ...req, scope: home });
+      } catch {
+        // distro stopped/cold — fall through; locate may still answer
+      }
+    }
+    return searchFiles(req);
+  });
 
   ipcMain.handle(IPC_CHANNELS.FILE_GREP, async (_event, req: FileGrepRequest) => grepFiles(req));
 
@@ -981,7 +1102,16 @@ export function registerIpcHandlers(
 }
 
 // Exported for testing
-export function sortAndMapDirEntries(entries: Dirent[], dirPath: string): DirEntry[] {
+export function sortAndMapDirEntries(
+  entries: Dirent[],
+  dirPath: string,
+  ctx?: PathContext
+): DirEntry[] {
+  // A WSL pane's dirPath is posix; join children with posix separators so the
+  // entry paths stay in the pane's coordinate system (win32 join would mangle).
+  const joinPath = isWslContext(ctx)
+    ? (...parts: string[]): string => posixPath.join(...parts)
+    : (...parts: string[]): string => join(...parts);
   return entries
     .filter((e) => e.isFile() || e.isDirectory())
     .sort((a, b) => {
@@ -992,7 +1122,7 @@ export function sortAndMapDirEntries(entries: Dirent[], dirPath: string): DirEnt
     })
     .map((e) => ({
       name: e.name,
-      path: join(dirPath, e.name),
+      path: joinPath(dirPath, e.name),
       isDirectory: e.isDirectory()
     }));
 }

--- a/src/main/run-in-context.ts
+++ b/src/main/run-in-context.ts
@@ -1,0 +1,144 @@
+import { spawn, type ChildProcess, type StdioOptions } from 'child_process';
+import type { PathContext } from '../shared/shell-profiles';
+import { wslExePath } from './wsl-service';
+
+/**
+ * Tier-3 spawn boundary (see docs/wsl-path-handling-plan.md §8). Runs a Windows
+ * CLI tool either natively or *inside* a WSL distro, keyed on the pane's
+ * {@link PathContext}. For a WSL pane the tool runs in the distro via
+ *
+ *     wsl.exe -d <distro> [--cd <posixCwd>] --exec <cmd> <args...>
+ *
+ * so it sees the distro's own `git`/`rg`/`find` config and the repo's true
+ * POSIX path — Windows `git.exe` against a UNC cwd is unreliable. `--exec`
+ * passes argv verbatim with **no shell**: no pipes, globs or quoting. Anything
+ * that needs a shell must invoke `sh -c` explicitly as the command.
+ */
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+// The only object variant of PathContext is the WSL one.
+function isWslContext(ctx: PathContext): ctx is { kind: 'wsl'; distro: string } {
+  return typeof ctx === 'object';
+}
+
+/**
+ * Resolve the executable + argv to run `cmd args...` in the given context.
+ * Pure — no spawning — so the WSL prefixing is unit-testable. For native
+ * contexts the cwd is applied by the spawn options; for WSL it travels in the
+ * `--cd` flag instead (the wsl.exe process itself can't chdir to a posix path).
+ */
+export function buildContextArgv(
+  ctx: PathContext,
+  cmd: string,
+  args: string[],
+  cwd?: string
+): { file: string; argv: string[] } {
+  if (isWslContext(ctx)) {
+    const argv = ['-d', ctx.distro];
+    if (cwd) argv.push('--cd', cwd);
+    argv.push('--exec', cmd, ...args);
+    return { file: wslExePath(), argv };
+  }
+  return { file: cmd, argv: args };
+}
+
+export interface SpawnInContextOptions {
+  /** Working directory — a posix path for WSL, a native path otherwise. */
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdio?: StdioOptions;
+}
+
+/** Spawn `cmd args...` in the given context, returning the live ChildProcess. */
+export function spawnInContext(
+  ctx: PathContext,
+  cmd: string,
+  args: string[],
+  opts: SpawnInContextOptions = {}
+): ChildProcess {
+  const { file, argv } = buildContextArgv(ctx, cmd, args, opts.cwd);
+  // For WSL the cwd is carried by `--cd`; the wsl.exe process must not inherit
+  // the posix cwd (it isn't a valid win32 directory and would fail to spawn).
+  const spawnCwd = isWslContext(ctx) ? undefined : opts.cwd;
+  return spawn(file, argv, {
+    cwd: spawnCwd,
+    env: opts.env,
+    stdio: opts.stdio ?? ['ignore', 'pipe', 'pipe']
+  });
+}
+
+export interface ExecInContextOptions extends SpawnInContextOptions {
+  /** Kill the process after this many ms (a stopped distro can cold-boot). */
+  timeoutMs?: number;
+  /** Cap on buffered stdout bytes; excess is dropped. */
+  maxBuffer?: number;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+}
+
+/**
+ * Run `cmd args...` to completion in the given context, buffering stdout/stderr.
+ * Resolves with the exit code for any clean exit (never rejects on a non-zero
+ * code — callers like `git diff --no-index` rely on that); rejects only when the
+ * process fails to spawn.
+ */
+export async function execInContext(
+  ctx: PathContext,
+  cmd: string,
+  args: string[],
+  opts: ExecInContextOptions = {}
+): Promise<ExecResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+
+  return new Promise((resolve, reject) => {
+    const proc = spawnInContext(ctx, cmd, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const outChunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    let outLen = 0;
+    let timedOut = false;
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill('SIGTERM');
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (c: Buffer) => {
+      outLen += c.length;
+      if (outLen <= maxBuffer) outChunks.push(c);
+    });
+    proc.stderr?.on('data', (c: Buffer) => errChunks.push(c));
+
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        stdout: Buffer.concat(outChunks).toString('utf-8'),
+        stderr: Buffer.concat(errChunks).toString('utf-8'),
+        code,
+        timedOut
+      });
+    });
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -244,12 +244,15 @@ const fleetApi = {
       typedInvoke(IPC_CHANNELS.SETTINGS_SET, settings)
   },
   git: {
-    isRepo: async (cwd: string): Promise<GitIsRepoPayload> =>
-      typedInvoke(IPC_CHANNELS.GIT_IS_REPO, cwd),
-    repoRoot: async (cwd: string): Promise<GitRepoRootPayload> =>
-      typedInvoke(IPC_CHANNELS.GIT_REPO_ROOT, cwd),
-    getStatus: async (cwd: string, baseRef?: string): Promise<GitStatusPayload> =>
-      typedInvoke(IPC_CHANNELS.GIT_STATUS, cwd, baseRef)
+    isRepo: async (cwd: string, pathContext?: PathContext): Promise<GitIsRepoPayload> =>
+      typedInvoke(IPC_CHANNELS.GIT_IS_REPO, cwd, pathContext),
+    repoRoot: async (cwd: string, pathContext?: PathContext): Promise<GitRepoRootPayload> =>
+      typedInvoke(IPC_CHANNELS.GIT_REPO_ROOT, cwd, pathContext),
+    getStatus: async (
+      cwd: string,
+      baseRef?: string,
+      pathContext?: PathContext
+    ): Promise<GitStatusPayload> => typedInvoke(IPC_CHANNELS.GIT_STATUS, cwd, baseRef, pathContext)
   },
   worktree: {
     create: async (req: WorktreeCreateRequest): Promise<WorktreeCreateResponse> =>
@@ -285,13 +288,14 @@ const fleetApi = {
       } = {}
     ): Promise<string[]> => typedInvoke(IPC_CHANNELS.FILE_OPEN_DIALOG, opts),
     list: async (
-      dirPath: string
+      dirPath: string,
+      pathContext?: PathContext
     ): Promise<{
       success: true;
       files: Array<{ path: string; relativePath: string; name: string }>;
-    }> => typedInvoke(IPC_CHANNELS.FILE_LIST, { dirPath }),
-    readdir: async (dirPath: string): Promise<ReaddirResponse> =>
-      typedInvoke(IPC_CHANNELS.FILE_READDIR, { dirPath }),
+    }> => typedInvoke(IPC_CHANNELS.FILE_LIST, { dirPath, pathContext }),
+    readdir: async (dirPath: string, pathContext?: PathContext): Promise<ReaddirResponse> =>
+      typedInvoke(IPC_CHANNELS.FILE_READDIR, { dirPath, pathContext }),
     onOpenInTab: (callback: (payload: FileOpenInTabPayload) => void): Unsubscribe =>
       onChannel(IPC_CHANNELS.FILE_OPEN_IN_TAB, callback),
     readBinary: async (
@@ -313,8 +317,8 @@ const fleetApi = {
       typedInvoke(IPC_CHANNELS.FILE_RECENT_IMAGES, { pathContext }),
     scanImageFolder: async (folderPath: string): Promise<string[]> =>
       typedInvoke(IPC_CHANNELS.FILE_SCAN_IMAGE_FOLDER, { folderPath }),
-    checkIgnored: async (dirPath: string): Promise<string[]> =>
-      typedInvoke(IPC_CHANNELS.FILE_CHECK_IGNORED, { dirPath })
+    checkIgnored: async (dirPath: string, pathContext?: PathContext): Promise<string[]> =>
+      typedInvoke(IPC_CHANNELS.FILE_CHECK_IGNORED, { dirPath, pathContext })
   },
   clipboard: {
     getHistory: async (): Promise<ClipboardHistoryResponse> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,7 +15,12 @@ import { getFileIcon } from './lib/file-icons';
 import { Sidebar } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { PaneGrid } from './components/PaneGrid';
-import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from './store/workspace-store';
+import {
+  useWorkspaceStore,
+  collectPaneIds,
+  collectPaneLeafs,
+  getPaneContextById
+} from './store/workspace-store';
 import { usePaneNavigation } from './hooks/use-pane-navigation';
 import { useNotifications } from './hooks/use-notifications';
 import { useNotificationStore } from './store/notification-store';
@@ -1054,6 +1059,7 @@ export function App(): React.JSX.Element {
         isOpen={gitChangesOpen}
         onClose={() => setGitChangesOpen(false)}
         cwd={focusedPaneCwd}
+        pathContext={getPaneContextById(activePaneId)}
       />
       <QuickOpenOverlay
         isOpen={quickOpenOpen}

--- a/src/renderer/src/components/FileSearchOverlay.tsx
+++ b/src/renderer/src/components/FileSearchOverlay.tsx
@@ -361,7 +361,8 @@ export function FileSearchOverlay({
           requestId: id,
           query: query.trim(),
           scope: undefined,
-          limit: 20
+          limit: 20,
+          pathContext: getActivePaneContext().pathContext
         })
         .then((res) => {
           // Discard stale responses

--- a/src/renderer/src/components/GitChangesModal.tsx
+++ b/src/renderer/src/components/GitChangesModal.tsx
@@ -4,6 +4,7 @@ import { X, Loader2, GitBranch, AlertCircle } from 'lucide-react';
 import { DiffView, DiffModeEnum, DiffFile, type DiffHighlighter } from '@git-diff-view/react';
 import '@git-diff-view/react/styles/diff-view.css';
 import type { GitStatusPayload, GitFileStatus } from '../../../shared/ipc-api';
+import type { PathContext } from '../../../shared/shell-profiles';
 import { getLanguageForPath } from '../../../shared/languages';
 import { Overlay } from './Overlay';
 
@@ -29,13 +30,16 @@ type GitChangesModalProps = {
   cwd: string | undefined;
   /** When set, show committed changes against this ref (base...HEAD) instead of the working tree. */
   compareRef?: string | null;
+  /** Pane coordinate system for `cwd`; WSL panes run git inside the distro. */
+  pathContext?: PathContext;
 };
 
 export function GitChangesModal({
   isOpen,
   onClose,
   cwd,
-  compareRef
+  compareRef,
+  pathContext
 }: GitChangesModalProps): React.JSX.Element | null {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<GitStatusPayload | null>(null);
@@ -63,7 +67,7 @@ export function GitChangesModal({
     setFilterText('');
     setActiveFileIndex(0);
     window.fleet.git
-      .getStatus(cwd, compareRef ?? undefined)
+      .getStatus(cwd, compareRef ?? undefined, pathContext)
       .then((result) => {
         setData(result);
         setLoading(false);
@@ -73,7 +77,7 @@ export function GitChangesModal({
         setData({ isRepo: true, branch: '', files: [], diff: '', error: String(err) });
         setLoading(false);
       });
-  }, [isOpen, cwd, compareRef]);
+  }, [isOpen, cwd, compareRef, pathContext]);
 
   // Filter files
   const filteredFiles = useMemo(() => {

--- a/src/renderer/src/components/PiTab.tsx
+++ b/src/renderer/src/components/PiTab.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 import { z } from 'zod';
 import { useTerminal } from '../hooks/use-terminal';
-import { useWorkspaceStore } from '../store/workspace-store';
+import { useWorkspaceStore, getPaneContextById } from '../store/workspace-store';
 import { PaneToolbar } from './PaneToolbar';
 import { SearchBar } from './SearchBar';
 import { openAnnotateModal } from '../lib/annotate-modal-bridge';
@@ -139,14 +139,14 @@ function PiTerminal({
     }
     if (gitCheckTimerRef.current) clearTimeout(gitCheckTimerRef.current);
     gitCheckTimerRef.current = setTimeout(() => {
-      void window.fleet.git.isRepo(cwd).then((result) => {
+      void window.fleet.git.isRepo(cwd, getPaneContextById(paneId)).then((result) => {
         setIsGitRepo(result.isRepo);
       });
     }, 500);
     return () => {
       if (gitCheckTimerRef.current) clearTimeout(gitCheckTimerRef.current);
     };
-  }, [cwd]);
+  }, [cwd, paneId]);
 
   useEffect(() => {
     const handler = (e: Event): void => {

--- a/src/renderer/src/components/QuickOpenOverlay.tsx
+++ b/src/renderer/src/components/QuickOpenOverlay.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Overlay } from './Overlay';
-import { useWorkspaceStore } from '../store/workspace-store';
+import { useWorkspaceStore, getActivePaneContext } from '../store/workspace-store';
 import { fuzzyMatch } from '../lib/commands';
 import { getFileIcon } from '../lib/file-icons';
 
@@ -61,7 +61,7 @@ export function QuickOpenOverlay({
     if (!isOpen || !rootDir) return;
     setIsLoading(true);
     setAllFiles([]);
-    void window.fleet.file.list(rootDir).then((result) => {
+    void window.fleet.file.list(rootDir, getActivePaneContext().pathContext).then((result) => {
       if (result.success) {
         setAllFiles(result.files);
       }

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -16,7 +16,12 @@ import { TabItem } from './TabItem';
 import { createLogger } from '../logger';
 
 const logDnd = createLogger('sidebar:dnd');
-import { useWorkspaceStore, collectPaneIds, collectPaneLeafs } from '../store/workspace-store';
+import {
+  useWorkspaceStore,
+  collectPaneIds,
+  collectPaneLeafs,
+  getPaneContextById
+} from '../store/workspace-store';
 import { useNotificationStore } from '../store/notification-store';
 import { useCwdStore } from '../store/cwd-store';
 import { useKanbanStore } from '../store/kanban-store';
@@ -711,7 +716,7 @@ export function Sidebar({
         const firstPaneId = collectPaneIds(tab.splitRoot)[0];
         const cwd = (firstPaneId ? liveCwds.get(firstPaneId) : undefined) ?? tab.cwd;
         try {
-          const result = await window.fleet.git.isRepo(cwd);
+          const result = await window.fleet.git.isRepo(cwd, getPaneContextById(firstPaneId));
           if (result.isRepo) newSet.add(tab.id);
         } catch {
           // ignore

--- a/src/renderer/src/components/Telescope/modes/browse-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/browse-mode.ts
@@ -24,6 +24,7 @@ export function createBrowseMode(
   activePaneId: string | null,
   onStateChange: () => void
 ): TelescopeMode & { getState: () => BrowseState } {
+  const ctx = getPaneContextById(activePaneId);
   const state: BrowseState = {
     currentDir: cwd,
     entries: [],
@@ -36,7 +37,7 @@ export function createBrowseMode(
     state.loading = true;
     onStateChange();
 
-    const result = await window.fleet.file.readdir(dir);
+    const result = await window.fleet.file.readdir(dir, ctx);
     if (result.success) {
       // Sort: directories first, then alphabetical within each group
       state.entries = [...result.entries].sort((a, b) => {
@@ -48,7 +49,7 @@ export function createBrowseMode(
 
       // Fetch gitignore status (use cache if available)
       if (!ignoreCache.has(dir)) {
-        const ignored = await window.fleet.file.checkIgnored(dir);
+        const ignored = await window.fleet.file.checkIgnored(dir, ctx);
         ignoreCache.set(dir, new Set(ignored));
       }
       state.ignoredNames = ignoreCache.get(dir) ?? new Set();
@@ -125,7 +126,6 @@ export function createBrowseMode(
     onAltSelect: (item) => {
       const filePath = item.data?.filePath;
       if (typeof filePath !== 'string' || !activePaneId) return;
-      const ctx = getPaneContextById(activePaneId);
       const quoted = quotePathForShell(pathForPaneContext(filePath, ctx), ctx);
       window.fleet.pty.input({
         paneId: activePaneId,

--- a/src/renderer/src/components/Telescope/modes/files-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/files-mode.ts
@@ -27,9 +27,10 @@ function makeItem(file: FileEntry): TelescopeItem {
 }
 
 export function createFilesMode(cwd: string, activePaneId: string | null): TelescopeMode {
+  const ctx = getPaneContextById(activePaneId);
   // Pre-load file listing in the background
   if (!fileCache.has(cwd)) {
-    void window.fleet.file.list(cwd).then((result) => {
+    void window.fleet.file.list(cwd, ctx).then((result) => {
       fileCache.set(cwd, result.files);
     });
   }
@@ -71,7 +72,7 @@ export function createFilesMode(cwd: string, activePaneId: string | null): Teles
       // Ensure cache is populated (may have been set by pre-load)
       let files = fileCache.get(cwd);
       if (!files) {
-        const result = await window.fleet.file.list(cwd);
+        const result = await window.fleet.file.list(cwd, ctx);
         fileCache.set(cwd, result.files);
         files = result.files;
       }
@@ -91,7 +92,6 @@ export function createFilesMode(cwd: string, activePaneId: string | null): Teles
     onAltSelect: (item) => {
       const filePath = item.data?.filePath;
       if (typeof filePath !== 'string' || !activePaneId) return;
-      const ctx = getPaneContextById(activePaneId);
       const quoted = quotePathForShell(pathForPaneContext(filePath, ctx), ctx);
       window.fleet.pty.input({
         paneId: activePaneId,

--- a/src/renderer/src/components/Telescope/modes/grep-mode.ts
+++ b/src/renderer/src/components/Telescope/modes/grep-mode.ts
@@ -2,11 +2,12 @@
 import { createElement } from 'react';
 import { TextSearch } from 'lucide-react';
 import { bracketedPaste } from '../../../lib/shell-utils';
-import { useWorkspaceStore } from '../../../store/workspace-store';
+import { useWorkspaceStore, getPaneContextById } from '../../../store/workspace-store';
 import type { TelescopeMode, TelescopeItem } from '../types';
 
 export function createGrepMode(cwd: string, activePaneId: string | null): TelescopeMode {
   let requestCounter = 0;
+  const pathContext = getPaneContextById(activePaneId);
 
   return {
     id: 'grep',
@@ -20,7 +21,13 @@ export function createGrepMode(cwd: string, activePaneId: string | null): Telesc
       const myRequest = ++requestCounter;
       const requestId = myRequest;
 
-      const response = await window.fleet.file.grep({ requestId, query, cwd, limit: 50 });
+      const response = await window.fleet.file.grep({
+        requestId,
+        query,
+        cwd,
+        limit: 50,
+        pathContext
+      });
 
       // Discard stale responses
       if (myRequest !== requestCounter) return [];

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -7,7 +7,7 @@ import { PaneToolbar } from './PaneToolbar';
 import { SearchBar } from './SearchBar';
 import { openAnnotateModal } from '../lib/annotate-modal-bridge';
 import { useCwdStore } from '../store/cwd-store';
-import { useWorkspaceStore } from '../store/workspace-store';
+import { useWorkspaceStore, getPaneContextById } from '../store/workspace-store';
 import { getFleetSkillContentInput } from '../lib/fleet-skill-prompt';
 import type { TerminalThemeId } from '../../../shared/theme-presets';
 import type { TerminalBackground } from '../../../shared/types';
@@ -94,7 +94,7 @@ export function TerminalPane({
 
     if (gitCheckTimerRef.current) clearTimeout(gitCheckTimerRef.current);
     gitCheckTimerRef.current = setTimeout(() => {
-      void window.fleet.git.isRepo(currentCwd).then((result) => {
+      void window.fleet.git.isRepo(currentCwd, getPaneContextById(paneId)).then((result) => {
         setIsGitRepo(result.isRepo);
       });
     }, 500);
@@ -102,7 +102,7 @@ export function TerminalPane({
     return () => {
       if (gitCheckTimerRef.current) clearTimeout(gitCheckTimerRef.current);
     };
-  }, [currentCwd]);
+  }, [currentCwd, paneId]);
   // Listen for search toggle events targeted at this pane
   useEffect(() => {
     const handler = (e: Event): void => {

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -1,5 +1,5 @@
 import type { Workspace, NotificationEvent, ActivityState } from './types';
-import type { ShellProfile, WslDistroState } from './shell-profiles';
+import type { ShellProfile, WslDistroState, PathContext } from './shell-profiles';
 import type { TranscriptMessage } from './sessions';
 import type {
   UpdateTaskFields,
@@ -166,6 +166,8 @@ export type FileSearchRequest = {
   query: string;
   scope?: string;
   limit?: number;
+  /** Pane coordinate system; WSL panes run locate/find inside the distro. */
+  pathContext?: PathContext;
 };
 
 export type FileSearchResult = {
@@ -185,6 +187,8 @@ export type FileGrepRequest = {
   query: string;
   cwd: string;
   limit?: number;
+  /** Pane coordinate system; WSL panes run rg/grep inside the distro. */
+  pathContext?: PathContext;
 };
 
 export type FileGrepResult = {


### PR DESCRIPTION
Stacked on #248 (Phase 0/1/2). **Base = `fix/wsl-windows-path-handling`** — retarget to `main` once #248 merges.

## What

Tier-3a of `docs/wsl-path-handling-plan.md` §8 — the **read-only query tools**. For a WSL pane these now run *inside* the distro (`wsl.exe -d <distro> --cd <posix> --exec <tool>`) instead of spawning the Windows binary against a posix/UNC cwd, and return POSIX paths. Native (non-WSL) paths are byte-for-byte unchanged.

- **`run-in-context.ts`** — `spawnInContext` / `execInContext` / `buildContextArgv` foundation (`--exec` is argv-only, no shell). Unit-tested.
- **git** — `checkIsRepo`/`repoRoot`/`getFullStatus`/`getRefDiff` take a `pathContext`; WSL shells out to git and parses porcelain v1 into the same payload `simple-git` produces. **Fixes the Git Changes toolbar for repos opened in a WSL pane.**
- **`FILE_LIST`** — `git ls-files` / `find` inside the distro → clean POSIX paths (no more mangled `\home\khang\…`).
- **`FILE_CHECK_IGNORED`** — migrated to argv-form `git check-ignore` (no shell; drops the quoting/injection-prone glob string), runs inside WSL.
- **`FILE_READDIR`** — reads over the UNC bridge, returns POSIX entry paths so Telescope **browse** mode works in WSL panes.
- **file-grep / file-search** — `rg`/`grep` and `locate`/`find` run in the distro; results stay POSIX (stat via the UNC bridge).
- Threaded `pathContext` through the git/file IPC + preload + renderer call sites (Git Changes, TerminalPane/Sidebar/PiTab repo checks, Telescope grep/files/browse, QuickOpen, FileSearchOverlay).

## Scope / deferred

- **3b** (separate PR): env-editor/env-sync, worktrees/kanban — the write/workflow tools (depend on the `GIT_REPO_ROOT`-stays-POSIX semantics change, §13.4).
- **Known follow-up:** opening a WSL grep/files/search *result* in the in-app editor still needs `FILE_READ`/`STAT`/`READ_BINARY` routed through the UNC bridge **and** the editor pane carrying the file's `pathContext` (a distinct viewing slice). The Telescope **paste** action (alt-select) already works via Phase 2.

## Verification

- `npx tsc --noEmit` (root) ✓ · `npm run typecheck` (node+web) ✓
- `npm test` → **1151/1151** ✓ (added: `run-in-context` argv builder, WSL git-service status/rename/repo, posix `sortAndMapDirEntries`)
- ESLint clean on all touched files.
- WSL behaviour (Git Changes, grep/search/list inside a distro) needs manual verification on a real Windows+WSL box — see plan §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)