### PR TITLE
feat(kanban): enable NAT-mode WSL autopilot agents (server dual-bind)

### DIFF
--- a/docs/learnings/2026-06-14-wsl-nat-hyperv-firewall-blocks-distro-to-host.md
+++ b/docs/learnings/2026-06-14-wsl-nat-hyperv-firewall-blocks-distro-to-host.md
@@ -1,0 +1,74 @@
+# WSL NAT mode: Hyper-V firewall drops distro→host inbound
+
+## Context
+
+Phase 3c-agent runs the kanban autopilot `rune` agent *inside* a WSL distro
+(for `\\wsl.localhost\…` worktrees). The agent must reach Fleet's kanban MCP
+server, which Fleet (a win32 process) binds on the Windows host. Whether that
+works depends on the distro's WSL networking mode:
+
+- **mirrored**: the distro shares the host loopback → `127.0.0.1:<port>` just
+  works, no exposure widening.
+- **NAT** (the default): `127.0.0.1` inside the distro is the *distro's own*
+  loopback. The host is reachable only via the distro's default-gateway IP
+  (the host's vEthernet (WSL) adapter, e.g. `192.168.32.1`).
+
+## The non-obvious blocker (confirmed empirically)
+
+Even after binding the MCP server to the host's WSL-adapter IP and pointing the
+agent at the gateway URL, **the connection still times out under NAT.** The
+cause is the **WSL Hyper-V firewall**, not classic Windows Firewall:
+
+```
+PS> Get-NetFirewallHyperVVMSetting -PolicyStore ActiveStore
+DefaultInboundAction  : Block      # <-- distro→host inbound is dropped
+DefaultOutboundAction : Allow
+```
+
+Reproduced from inside the distro (host listener bound to `192.168.32.1:<port>`):
+
+- `curl`/`nc` to the listening port → **timed out** (filtered/dropped), *not*
+  "connection refused".
+- `nc` to a *closed* host port → identical timeout ⇒ it's a blanket inbound
+  drop, not port-specific.
+- `ping 192.168.32.1` → 100% packet loss (ICMP dropped too).
+- The host-side listener logged **no connection** the whole time.
+
+A "timed out" (vs "connection refused") is the tell: the SYN is being silently
+dropped by a firewall, not rejected by a closed port.
+
+The adapter name itself is the hint — modern WSL shows
+`vEthernet (WSL (Hyper-V firewall))`. Distro↔host traffic is governed by the
+**Hyper-V firewall** layer, configured via `*-NetFirewallHyperVRule` /
+`Set-NetFirewallHyperVVMSetting` against the WSL VM-creator id
+(`{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}`). A classic `New-NetFirewallRule`
+inbound rule does **not** touch it — an easy way to "fix" it and have it still
+fail.
+
+## What this means for the code
+
+`WSL_NAT_AGENTS_ENABLED` (in `src/main/kanban/agent-context.ts`) gates NAT
+support. With it on:
+
+- `KanbanMcpServer.start()` dual-binds: `127.0.0.1` (host-side PM chat + native
+  agents) **plus** the host's WSL-adapter IP (`wslAdapterIp()` via
+  `os.networkInterfaces()`) at the same port.
+- The agent connects to `http://<gatewayIp>:<port>/mcp?run=<token>`.
+
+…but a working NAT agent **also requires a per-machine Hyper-V firewall rule**
+allowing inbound to the MCP port from the WSL VM. Without it the agent's MCP
+connection hangs. This cannot be created from a normal-privilege process (needs
+elevation), so it is a manual setup step, documented on the flag. Prefer
+recommending **mirrored mode** (set `networkingMode=mirrored` in
+`%UserProfile%\.wslconfig`, then `wsl --shutdown`) — it sidesteps all of this.
+
+## Probing tips (from inside a WSL session)
+
+- Authoritative mode check: `wslinfo --networking-mode` (don't infer from the
+  `10.255.255.254`-on-loopback artifact — that's NAT-mode DNS tunneling, *not*
+  a mirrored signature).
+- Windows interop works from the distro: `powershell.exe -NoProfile -Command …`
+  lets you drive host-side checks (adapter IPs, Hyper-V firewall settings, even
+  a throwaway `[System.Net.Sockets.TcpListener]`) without leaving the shell.
+- `zsh` has no `/dev/tcp` pseudo-device (that's a bash-ism) — use `curl`/`nc`
+  for reachability tests, or a connect timeout will read as a false negative.

--- a/src/main/__tests__/kanban-agent-context.test.ts
+++ b/src/main/__tests__/kanban-agent-context.test.ts
@@ -8,7 +8,9 @@ import {
   resolveAgentHost,
   agentHostFor,
   __clearAgentHostCache,
-  type SyncExec
+  wslAdapterIp,
+  type SyncExec,
+  type ListIfaces
 } from '../kanban/agent-context';
 
 vi.mock('../wsl-service', () => ({ wslExePath: () => 'wsl.exe' }));
@@ -178,11 +180,30 @@ describe('agentHostFor', () => {
     expect((exec as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 
-  it('surfaces the unsupported reason under NAT', () => {
+  it('resolves the gateway host under NAT (agents enabled)', () => {
     const exec = vi.fn((_file: string, args: string[]) =>
       args.includes('wslinfo') ? 'nat\n' : '192.168.32.1\n'
     ) as unknown as SyncExec;
-    const r = agentHostFor(DISTRO, exec);
-    expect('unsupported' in r).toBe(true);
+    expect(agentHostFor(DISTRO, exec)).toEqual({ host: '192.168.32.1' });
+  });
+});
+
+describe('wslAdapterIp', () => {
+  it('returns the IPv4 of the vEthernet (WSL) adapter', () => {
+    const list = () => ({
+      Ethernet: [{ family: 'IPv4', address: '10.0.0.5', internal: false }],
+      'vEthernet (WSL (Hyper-V firewall))': [
+        { family: 'IPv6', address: 'fe80::1', internal: false },
+        { family: 'IPv4', address: '192.168.32.1', internal: false }
+      ]
+    });
+    expect(wslAdapterIp(list as unknown as ListIfaces)).toBe('192.168.32.1');
+  });
+
+  it('returns null when no WSL adapter is present', () => {
+    const list = () => ({
+      Ethernet: [{ family: 'IPv4', address: '10.0.0.5', internal: false }]
+    });
+    expect(wslAdapterIp(list as unknown as ListIfaces)).toBeNull();
   });
 });

--- a/src/main/kanban/agent-context.ts
+++ b/src/main/kanban/agent-context.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process';
+import { networkInterfaces } from 'os';
 import { posix } from 'path';
 import { parseWslUncPath } from '../../shared/path-platform';
 import { wslExePath } from '../wsl-service';
@@ -95,15 +96,18 @@ export function buildAgentSpawn(spec: AgentSpawnSpec, loc: AgentWslLocation | nu
 }
 
 /**
- * NAT-mode WSL agents are NOT yet wired end-to-end: the MCP server still binds
- * `127.0.0.1` only (kanban-mcp-server.ts), which the distro can't reach across
- * the NAT boundary. Flipping this on requires the server to also bind an address
- * reachable from the WSL subnet (the vEthernet adapter IP — not 0.0.0.0) plus a
- * scoped Windows Firewall inbound rule, validated on real Windows hardware. Until
- * then NAT distros are refused with an actionable message. Mirrored mode needs
- * none of this and works today.
+ * NAT-mode WSL agents reach the host via the distro's default-gateway IP (the
+ * host's vEthernet (WSL) adapter), not loopback. With this enabled the kanban MCP
+ * server binds that adapter IP in addition to `127.0.0.1` (see
+ * KanbanMcpServer.start), and the in-distro agent connects to the gateway URL.
+ *
+ * REQUIRED per-machine setup: the WSL Hyper-V firewall blocks distro→host inbound
+ * by default (`Get-NetFirewallHyperVVMSetting` → DefaultInboundAction = Block), so
+ * a scoped Hyper-V firewall rule must allow inbound to the MCP port from the WSL
+ * VM. Without it the agent's MCP connection times out. Mirrored-mode distros need
+ * none of this (they share the host loopback) and work unconditionally.
  */
-export const WSL_NAT_AGENTS_ENABLED = false;
+export const WSL_NAT_AGENTS_ENABLED = true;
 
 export type WslNetworking = {
   mode: 'nat' | 'mirrored' | 'unknown';
@@ -126,8 +130,10 @@ const NAT_UNSUPPORTED =
  *    widening, stays loopback-only).
  *  - unknown (old WSL without `wslinfo`): assume loopback works (WSL1 / pre-NAT);
  *    a genuine failure surfaces as a clear MCP-connect error in the run log.
- *  - nat: needs the gateway IP + the deferred host bind/firewall. Until that
- *    lands (see {@link WSL_NAT_AGENTS_ENABLED}) the run is refused.
+ *  - nat: reach the host via the default-gateway IP (its vEthernet (WSL) adapter),
+ *    which the server also binds. Requires the Hyper-V firewall rule documented on
+ *    {@link WSL_NAT_AGENTS_ENABLED}; if that flag is off or no gateway resolved the
+ *    run is refused with an actionable message.
  */
 export function resolveAgentHost(
   net: WslNetworking,
@@ -200,4 +206,23 @@ export function agentHostFor(distro: string, exec: SyncExec = defaultSyncExec): 
 /** Test-only: drop the per-distro cache. */
 export function __clearAgentHostCache(): void {
   hostCache.clear();
+}
+
+/** Lists the host's network interfaces; injectable so discovery is unit-testable. */
+export type ListIfaces = () => ReturnType<typeof networkInterfaces>;
+
+/**
+ * The host's vEthernet (WSL) adapter IPv4 — the address a NAT-mode distro reaches
+ * the host on (it is the distro's default gateway). The kanban MCP server binds
+ * this in addition to loopback so the in-distro agent can connect. null when no
+ * WSL adapter exists (no distro running, or a non-Windows host).
+ */
+export function wslAdapterIp(list: ListIfaces = networkInterfaces): string | null {
+  for (const [name, addrs] of Object.entries(list())) {
+    if (!/WSL/i.test(name)) continue;
+    for (const addr of addrs ?? []) {
+      if (addr.family === 'IPv4' && !addr.internal) return addr.address;
+    }
+  }
+  return null;
 }

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -19,6 +19,7 @@ import { latestBlackboard, postBlackboardUpdate, isSwarmRoot } from './kanban-sw
 import { finalizeWorktree, reviewStat, checkMergeConflicts, headSha } from './workspace';
 import { pmDocsDir } from './pm-paths';
 import { readArtifactPreview } from './artifact-files';
+import { WSL_NAT_AGENTS_ENABLED, wslAdapterIp } from './agent-context';
 
 const log = createLogger('kanban-mcp');
 
@@ -507,6 +508,7 @@ function toolsForMode(mode: RunMode): McpTool[] {
 
 export class KanbanMcpServer {
   private server: Server | null = null;
+  private wslServer: Server | null = null;
   private runs = new Map<string, RunScope>();
   private claimLocks = new Map<string, string>(); // token -> claim lock (for heartbeat)
 
@@ -567,30 +569,72 @@ export class KanbanMcpServer {
     this.claimLocks.delete(token);
   }
 
+  private newHttpServer(): Server {
+    return createServer((req, res) => {
+      this.handle(req, res).catch((err) => {
+        log.error('handler error', { error: err instanceof Error ? err.message : String(err) });
+        this.send(res, 500, { error: 'internal' });
+      });
+    });
+  }
+
   start(port: number): Promise<number> {
     return new Promise((resolve, reject) => {
-      this.server = createServer((req, res) => {
-        this.handle(req, res).catch((err) => {
-          log.error('handler error', { error: err instanceof Error ? err.message : String(err) });
-          this.send(res, 500, { error: 'internal' });
-        });
-      });
+      this.server = this.newHttpServer();
       this.server.on('error', reject);
       // Bind to loopback only — never expose the board to the network.
       this.server.listen(port, '127.0.0.1', () => {
         const addr = this.server?.address();
         const bound = typeof addr === 'object' && addr ? addr.port : port;
         log.info('kanban mcp server listening', { port: bound });
-        resolve(bound);
+        // NAT-mode WSL distros can't reach loopback on the host, so also bind the
+        // vEthernet (WSL) adapter IP at the same port — the run-token-gated board
+        // is then reachable from inside the distro. Best-effort: a failure here
+        // never blocks the loopback server the host side depends on.
+        void this.bindWslAdapter(bound).finally(() => {
+          resolve(bound);
+        });
+      });
+    });
+  }
+
+  private bindWslAdapter(port: number): Promise<void> {
+    if (!WSL_NAT_AGENTS_ENABLED || process.platform !== 'win32') return Promise.resolve();
+    const ip = wslAdapterIp();
+    if (!ip) {
+      log.info('no wsl adapter found; skipping nat bind');
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      const srv = this.newHttpServer();
+      srv.on('error', (err) => {
+        log.warn('wsl adapter bind failed', {
+          ip,
+          port,
+          error: err instanceof Error ? err.message : String(err)
+        });
+        resolve();
+      });
+      srv.listen(port, ip, () => {
+        log.info('kanban mcp server also listening on wsl adapter', { ip, port });
+        this.wslServer = srv;
+        resolve();
       });
     });
   }
 
   stop(): Promise<void> {
     return new Promise((resolve) => {
-      if (!this.server) return resolve();
-      this.server.close(() => resolve());
+      const servers = [this.server, this.wslServer].filter((s): s is Server => s !== null);
       this.server = null;
+      this.wslServer = null;
+      if (servers.length === 0) return resolve();
+      let remaining = servers.length;
+      for (const srv of servers) {
+        srv.close(() => {
+          if (--remaining === 0) resolve();
+        });
+      }
     });
   }
 
@@ -908,7 +952,8 @@ export class KanbanMcpServer {
             .parse(args);
           let repoPath = a.repo_path ?? null;
           if (a.project !== undefined) {
-            if (repoPath) return this.rpcError(res, rpcReq.id, 'pass either project or repo_path, not both');
+            if (repoPath)
+              return this.rpcError(res, rpcReq.id, 'pass either project or repo_path, not both');
             const p = this.store.getProjectByName(scope.boardId, a.project);
             if (!p) return this.rpcError(res, rpcReq.id, `unknown project: ${a.project}`);
             repoPath = p.path;
@@ -966,7 +1011,8 @@ export class KanbanMcpServer {
         case 'kanban_project_remove': {
           const a = z.object({ name: z.string() }).parse(args);
           const p = this.store.getProjectByName(scope.boardId, a.name);
-          if (!p) return this.rpcError(res, rpcReq.id, `project not found on this board: ${a.name}`);
+          if (!p)
+            return this.rpcError(res, rpcReq.id, `project not found on this board: ${a.name}`);
           commands.removeProject(p.id);
           return this.text(res, rpcReq.id, `Project "${a.name}" removed.`);
         }
@@ -974,11 +1020,19 @@ export class KanbanMcpServer {
           const a = z.object({ artifact_id: z.string() }).parse(args);
           const art = this.store.getArtifact(a.artifact_id);
           if (!art || art.boardId !== scope.boardId) {
-            return this.rpcError(res, rpcReq.id, `artifact not found on this board: ${a.artifact_id}`);
+            return this.rpcError(
+              res,
+              rpcReq.id,
+              `artifact not found on this board: ${a.artifact_id}`
+            );
           }
           const preview = readArtifactPreview(art.storedPath, 64 * 1024);
           if (!preview.previewable) {
-            return this.rpcError(res, rpcReq.id, preview.reason ?? 'artifact is not readable as text');
+            return this.rpcError(
+              res,
+              rpcReq.id,
+              preview.reason ?? 'artifact is not readable as text'
+            );
           }
           const suffix = preview.truncated ? '\n\n…(truncated)' : '';
           return this.text(res, rpcReq.id, (preview.text ?? '') + suffix);
@@ -1257,9 +1311,7 @@ export class KanbanMcpServer {
           return this.text(res, rpcReq.id, JSON.stringify(latestBlackboard(this.store, a.root)));
         }
         case 'kanban_swarm_post': {
-          const a = z
-            .object({ root: z.string(), key: z.string(), value: z.unknown() })
-            .parse(args);
+          const a = z.object({ root: z.string(), key: z.string(), value: z.unknown() }).parse(args);
           if (!isSwarmRoot(this.store, a.root)) {
             return this.rpcError(res, rpcReq.id, `${a.root} is not a swarm root`);
           }


### PR DESCRIPTION
## What

Enables the kanban autopilot agent to run inside a **NAT-mode** WSL distro and reach Fleet's kanban MCP server on the Windows host. Follow-up to #253 (which shipped the agent-side wiring but kept NAT gated off behind `WSL_NAT_AGENTS_ENABLED = false`).

## Why this was the only piece left

The agent side already resolved the host and wrote the gateway-IP URL into `mcp.json` (`spawnRuneWorker → agentHostFor → buildWorkerInvocation`). The missing half was the **server**: a NAT distro can't reach host loopback, so it never had a reachable address to connect to.

## Changes

- **Flip `WSL_NAT_AGENTS_ENABLED → true`.**
- **`KanbanMcpServer.start()` now dual-binds:** `127.0.0.1` (host-side PM chat + native agents, unchanged) **plus** the host's vEthernet (WSL) adapter IP at the same port, so the run-token-gated board is reachable from inside the distro. Best-effort — a failure on the WSL bind never blocks the loopback listener. `stop()` tears down both.
- **`wslAdapterIp()`** discovers that adapter address via `os.networkInterfaces()` (no shelling out).
- Tests: add `wslAdapterIp` coverage; update the `agentHostFor` NAT case to expect the gateway host now that agents are enabled.

## Required per-machine setup (important)

Confirmed empirically on a NAT box (`wslinfo` = `nat`, gateway `192.168.32.1`) that distro→host inbound is **dropped by the WSL Hyper-V firewall** (`Get-NetFirewallHyperVVMSetting` → `DefaultInboundAction = Block`). So enabling the flag makes NAT work **only where a scoped Hyper-V firewall rule** permits inbound to the MCP port from the WSL VM. Without that rule the agent's MCP connection **times out** (a UX regression vs. the prior fail-fast "switch to mirrored" message). This tradeoff is documented on the `WSL_NAT_AGENTS_ENABLED` flag. **Mirrored-mode distros need none of this** and are unaffected.

## Verification

- `npm run typecheck` ✅
- agent-context + spawn-worker tests: 53 pass ✅
- full suite green before the format pass ✅
- prettier clean; no new eslint errors beyond the file's existing style ✅
- ⚠️ **Not** validated against a live NAT run — that needs the Hyper-V firewall rule on real hardware. Merges on code review + green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)