### PR TITLE
refactor(kanban): hoist reviewer profile lookup before fallback

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1032,9 +1032,10 @@ void app.whenReady().then(async () => {
       } else if (mode === 'review') {
         // Singleton reviewer selected BY MODE; fall back to an in-memory default persona when
         // no saved reviewer profile exists (existing users have none). NEVER write task.assignee.
-        profile = profiles.find(
+        const reviewerProfile = profiles.find(
           (p) => p.name === REVIEWER_PROFILE_NAME && p.role === 'reviewer'
-        ) ?? {
+        );
+        profile = reviewerProfile ?? {
           name: REVIEWER_PROFILE_NAME,
           role: 'reviewer',
           model: '',


### PR DESCRIPTION
## What

Behavior-neutral readability tweak in review-mode profile selection (`src/main/index.ts`): extract the `profiles.find(...)` result into a named `reviewerProfile` local before applying the `?? {default}` fallback, instead of inlining the `.find()` directly in front of `??`.

## Why

Makes the "find a saved reviewer profile, else fall back to the in-memory default persona" intent read more clearly. No logic change — same lookup, same fallback, same `task.assignee` handling.

## Notes

This change predates the WSL NAT work and is unrelated to PR #255; split out into its own PR to keep that feature PR clean.

## Verification

- `npm run typecheck` passes (full suite already green on this base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)