### PR TITLE
fix(rune): set RUNE_NO_ATTACH on headless rune --prompt spawns

### DIFF
--- a/src/main/kanban/pm-chat-service.ts
+++ b/src/main/kanban/pm-chat-service.ts
@@ -171,7 +171,9 @@ export class PmChatService {
     if (c.sessionId) args.push('--resume', c.sessionId);
     const child = spawn('rune', args, {
       cwd: dir,
-      env: { ...process.env, RUNE_MCP_CONFIG: mcpConfigPath },
+      // Treat the chat message as literal text — don't let rune auto-attach (and inline)
+      // files for path-like tokens the user happens to mention; the PM uses tools to read.
+      env: { ...process.env, RUNE_MCP_CONFIG: mcpConfigPath, RUNE_NO_ATTACH: '1' },
       stdio: ['ignore', 'pipe', 'pipe']
     });
 

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -259,7 +259,11 @@ export function buildWorkerInvocation(input: BuildWorkerInput): WorkerInvocation
     env: {
       RUNE_MCP_CONFIG: runeMcpConfig,
       FLEET_KANBAN_TASK: input.task.id,
-      FLEET_KANBAN_RUN: input.runToken
+      FLEET_KANBAN_RUN: input.runToken,
+      // The worker prompt is fully assembled by Fleet (task body, diffs, docs); rune
+      // must not auto-attach the path-like tokens it contains (it would silently inline
+      // the worktree's current files). Workers read files via tools instead.
+      RUNE_NO_ATTACH: '1'
     }
   };
 }

--- a/src/main/learnings/distiller.ts
+++ b/src/main/learnings/distiller.ts
@@ -120,7 +120,16 @@ async function runAgentOneShot(agent: SessionAgent, cwd: string, prompt: string)
     // `detached` on POSIX puts the child in its own process group so we can signal
     // the whole tree on timeout — rune/claude spawn their own children, and a bare
     // child.kill() hits only the direct PID, re-parenting the rest to init (PID 1).
-    const child = spawn(cmd, args, { cwd, env: process.env, detached: !isWindows });
+    // RUNE_NO_ATTACH stops rune from scanning the prompt for file references and
+    // inlining/warning on them: a serialized transcript is full of incidental path
+    // mentions, and auto-attach would inline current-cwd files (polluting the prompt)
+    // and print "(could not attach …)" onto stdout (corrupting the parsed draft).
+    // Older rune builds ignore the unknown env var, so this is backward-compatible.
+    const child = spawn(cmd, args, {
+      cwd,
+      env: { ...process.env, RUNE_NO_ATTACH: '1' },
+      detached: !isWindows
+    });
     // Decode incrementally so a multibyte codepoint split across two chunks isn't
     // mangled into U+FFFD (common with CJK/emoji in agent output).
     const outDecoder = new StringDecoder('utf8');
@@ -157,15 +166,15 @@ async function runAgentOneShot(agent: SessionAgent, cwd: string, prompt: string)
       if (stdout.length > MAX_STDOUT_CHARS) {
         killTree();
         finish(() =>
-          reject(new Error(`${cmd} produced over ${Math.floor(MAX_STDOUT_CHARS / 1000)}KB of output`))
+          reject(
+            new Error(`${cmd} produced over ${Math.floor(MAX_STDOUT_CHARS / 1000)}KB of output`)
+          )
         );
       }
     });
     child.stderr.on('data', (d: Buffer) => (stderr += errDecoder.write(d)));
     child.on('error', (err: NodeJS.ErrnoException) => {
-      finish(() =>
-        reject(err.code === 'ENOENT' ? new Error(`${cmd} ${NOT_INSTALLED}`) : err)
-      );
+      finish(() => reject(err.code === 'ENOENT' ? new Error(`${cmd} ${NOT_INSTALLED}`) : err));
     });
     child.on('close', (code) => {
       stdout += outDecoder.end();


### PR DESCRIPTION
## Summary
- `rune --prompt` auto-attaches file references it finds in the prompt text (bare path tokens, backtick spans, `@mentions`): it inlines on-disk files relative to cwd and prints `(could not attach …)` to **stdout**. Fleet feeds full, machine-built prompts to rune — a serialized transcript, a worker prompt, a chat message — all of which mention file paths, so rune inlined the cwd's current files (polluting the prompt) and, in the distiller, mixed warning lines into the captured output that `parseDraft` then baked into the saved learning.
- Sets `RUNE_NO_ATTACH=1` in the spawn env at all three headless `rune --prompt` sites: `learnings/distiller.ts`, `kanban/spawn-worker.ts`, `kanban/pm-chat-service.ts`. The prompt is treated as literal text; agents read files via tools.
- Backward-compatible — an older rune ignores the unknown env var. Left `rune-assist/rune-file-chat-service.ts` (⌘I Quick-Assist) untouched: its `[context: file <path>]` line intentionally lets rune pull in the one open file.

> Depends on rune honoring `RUNE_NO_ATTACH` (khang859/rune#42). With an older rune installed the var is simply ignored — no regression, just unfixed until rune is updated.

## Test plan
- [x] `npm run typecheck` clean
- [x] `vitest run` distiller + spawn-worker tests (41 pass)
- [x] eslint clean on changed files
- [ ] Distill a session whose transcript mentions file paths → draft has no `(could not attach …)` lines (needs updated rune on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)