### PR TITLE
fix(kanban): stop PM chat latching on "Thinking" forever

### DIFF
--- a/docs/learnings/2026-06-15-pm-chat-stuck-thinking.md
+++ b/docs/learnings/2026-06-15-pm-chat-stuck-thinking.md
@@ -1,0 +1,64 @@
+# Learnings: Board PM stuck on "Thinking" (2026-06-15)
+
+## Symptom
+
+The kanban Board PM chat panel showed "Thinking…" indefinitely and never recovered. No
+`rune` process was running, so the LLM turn was long over — yet the UI stayed stuck and
+the input stayed disabled. `reset()` also refused to help (it throws while in-flight).
+
+## Root cause
+
+`PmChatService.sendMessage` (`src/main/kanban/pm-chat-service.ts`) set `c.inFlight = true`
+and emitted `status: 'thinking'`, then ran ~30 lines of **unguarded synchronous setup**
+(`mcp.registerRun`, `mkdirSync`, `writeFileSync`, `spawn`) **before** wiring the child
+`'error'`/`'exit'` handlers. There was no `try`/`finally`.
+
+`inFlight` was only ever reset to `false` inside `finish()`, and `finish()` is reachable
+**only** from the child's `'error'`/`'exit'` events (or the timeout's `kill`, which needs a
+child). So if any setup step threw (FS error like EACCES/ENOSPC, or `spawn` throwing
+synchronously on EMFILE / bad options), `inFlight` latched `true` forever with no child to
+ever fire `finish()`. The renderer faithfully renders `inFlight` as "Thinking" and only
+re-reads the authoritative flag on panel mount / board switch, so the phantom persisted
+until app restart (restart rehydrates `inFlight: false`).
+
+A red herring to avoid: an earlier theory blamed the un-`.catch()`'d
+`readMessages().then()` in `finish()`. That's **not** it — `readRuneSession`
+(`src/main/sessions/rune-source.ts`) catches everything internally and returns `null`, so
+`readMessages` can never reject. Verified by reading the code + 3 adversarial sub-reviews.
+
+Secondary latent gap: the per-turn timeout sent a single `SIGTERM` with **no SIGKILL
+escalation**, so a rune that traps SIGTERM would also hang `inFlight` forever (different
+trigger, same latch).
+
+## Fix
+
+Restructured `sendMessage` so **every** exit path funnels through a single null-safe
+`finish()`:
+
+- Hoisted `finish` (and `token`/`child`/`timeout`/`killTimer`/`sessionId`) above the setup,
+  guarding `clearTimeout`/`inFlightChildren.delete` for the case where the child was never
+  created.
+- Wrapped the setup + spawn + handler wiring in `try { … } catch (err) { finish(msg); throw err }`
+  so a synchronous setup failure clears `inFlight`, emits a terminal `error` status, and
+  still surfaces the error to the caller.
+- Added SIGKILL escalation: after the timeout's SIGTERM, a `PM_TURN_SIGKILL_GRACE_MS` (5s)
+  timer sends SIGKILL if the child hasn't exited.
+- Defensive `.catch()` on the transcript read-back, with the status transition moved to
+  `.finally()` so a future throw there can't strand the turn on "Thinking" either.
+
+## Takeaways
+
+- Any flag set to a "busy" value must have a `try`/`finally` (or single funnel) guaranteeing
+  it is reset on **every** path, including synchronous setup throws — not just the happy
+  async completion.
+- `spawn` can throw **synchronously**; handlers attached after `spawn` won't catch that. Set
+  up your reset path before/around `spawn`, not only on its events.
+- A process-killing timeout needs SIGKILL escalation; SIGTERM alone is a request, not a
+  guarantee.
+- The renderer trusted live push events with re-sync only on mount/board-switch; the durable
+  fix lives in main (guaranteed terminal status), but a periodic/self-healing re-sync in the
+  renderer would add defense in depth (not done here — kept the change surgical).
+
+Tests: `src/main/kanban/__tests__/pm-chat-service.test.ts` — reproduces the latched-flag case
+(setup throw → `inFlight` returns to `false`, terminal `error` emitted) and the
+SIGTERM→SIGKILL escalation.

--- a/src/main/kanban/__tests__/pm-chat-service.test.ts
+++ b/src/main/kanban/__tests__/pm-chat-service.test.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from 'events';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PmChatService } from '../pm-chat-service';
+import type { KanbanMcpServer } from '../kanban-mcp-server';
+import type { PmChatStatusPayload } from '../../../shared/ipc-api';
+
+// The service imports { spawn } from 'child_process'; intercept it so we can drive
+// the child lifecycle deterministically (no real `rune` binary needed).
+const spawnMock = vi.fn();
+vi.mock('child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }));
+
+function makeService(overrides: {
+  mcp?: Partial<KanbanMcpServer>;
+  emitStatus?: (p: PmChatStatusPayload) => void;
+}): PmChatService {
+  const home = mkdtempSync(join(tmpdir(), 'fleet-pm-test-'));
+  const mcp = {
+    registerRun: vi.fn(),
+    unregisterRun: vi.fn(),
+    ...overrides.mcp
+  } as unknown as KanbanMcpServer;
+  return new PmChatService({
+    mcp,
+    mcpPort: 1234,
+    kanbanHome: home,
+    emitStatus: overrides.emitStatus ?? vi.fn(),
+    emitTranscript: vi.fn(),
+    getProjects: () => []
+  });
+}
+
+function fakeChild(): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+  pid: number;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.pid = 4242;
+  return child;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  spawnMock.mockReset();
+});
+
+describe('PmChatService turn lifecycle', () => {
+  it('resets inFlight and emits a terminal status when turn setup throws (no latched Thinking)', async () => {
+    const emitStatus = vi.fn();
+    const svc = makeService({
+      // A failure during turn setup, before the child is spawned.
+      mcp: {
+        registerRun: vi.fn(() => {
+          throw new Error('registry boom');
+        })
+      },
+      emitStatus
+    });
+
+    expect(() => svc.sendMessage('default', 'hello')).toThrow('registry boom');
+
+    // inFlight is cleared synchronously by finish(), so the board never latches.
+    expect((await svc.getState('default')).inFlight).toBe(false);
+
+    const statuses = (): string[] =>
+      emitStatus.mock.calls.map((c) => (c[0] as PmChatStatusPayload).status);
+    expect(statuses()[0]).toBe('thinking');
+    // The terminal status is emitted after the (async) transcript read-back.
+    await vi.waitFor(() => expect(statuses().at(-1)).toBe('error'));
+  });
+
+  it('escalates a hung turn from SIGTERM to SIGKILL when the child ignores SIGTERM', () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const svc = makeService({});
+
+    svc.sendMessage('default', 'hi');
+
+    // Per-turn timeout fires -> graceful SIGTERM first.
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+
+    // Child ignores SIGTERM (never emits 'exit') -> escalate to SIGKILL after the grace period.
+    vi.advanceTimersByTime(10 * 1000);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+});

--- a/src/main/kanban/pm-chat-service.ts
+++ b/src/main/kanban/pm-chat-service.ts
@@ -23,6 +23,8 @@ const log = createLogger('kanban-pm');
 
 /** A PM turn that runs longer than this is assumed hung and killed. */
 const PM_TURN_TIMEOUT_MS = 5 * 60 * 1000;
+/** After SIGTERM on a timed-out turn, wait this long for a clean exit before SIGKILL. */
+const PM_TURN_SIGKILL_GRACE_MS = 5 * 1000;
 /** Keep only this much of the child's output in memory (see docs/learnings on stdout OOM). */
 const OUTPUT_CAP = 64 * 1024;
 /** Defensive cap on MEMORY.md injection (persona asks for ~200 lines). */
@@ -141,63 +143,22 @@ export class PmChatService {
     this.opts.emitStatus({ boardId, status: 'thinking' });
 
     const token = randomUUID();
-    this.opts.mcp.registerRun(token, { kind: 'board', boardId });
-
-    const dir = pmBoardDir(this.opts.kanbanHome, boardId);
-    const runeDir = join(dir, '.rune');
-    mkdirSync(runeDir, { recursive: true });
-    mkdirSync(pmDocsDir(this.opts.kanbanHome, boardId), { recursive: true });
-    let memory: string | null = null;
-    try {
-      memory = readFileSync(join(dir, 'MEMORY.md'), 'utf-8').slice(0, MEMORY_INJECT_CAP);
-    } catch {
-      // no memory yet — first turn or never written
-    }
-    let projects: Project[] = [];
-    try {
-      projects = this.opts.getProjects(boardId);
-    } catch {
-      // registry unavailable must never block the chat turn
-    }
-    writeFileSync(join(dir, 'AGENTS.md'), buildPmAgentsMd({ projects, memory }));
-    const mcpConfigPath = join(runeDir, 'mcp.json');
-    const url = `http://127.0.0.1:${this.opts.mcpPort}/mcp?run=${token}`;
-    writeFileSync(
-      mcpConfigPath,
-      JSON.stringify({ servers: { kanban: { type: 'http', url } } }, null, 2)
-    );
-
-    const args = ['--prompt', body];
-    if (c.sessionId) args.push('--resume', c.sessionId);
-    const child = spawn('rune', args, {
-      cwd: dir,
-      // Treat the chat message as literal text — don't let rune auto-attach (and inline)
-      // files for path-like tokens the user happens to mention; the PM uses tools to read.
-      env: { ...process.env, RUNE_MCP_CONFIG: mcpConfigPath, RUNE_NO_ATTACH: '1' },
-      stdio: ['ignore', 'pipe', 'pipe']
-    });
-
-    this.inFlightChildren.add(child);
-
-    let output = ''; // merged stdout+stderr tail, for error classification
+    let child: ChildProcess | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
     let sessionId: string | null = c.sessionId;
-    const collect = (chunk: Buffer): void => {
-      output = (output + chunk.toString('utf-8')).slice(-OUTPUT_CAP);
-      if (!sessionId) {
-        sessionId = /^session-id: ([A-Za-z0-9_-]+)$/m.exec(output)?.[1] ?? null;
-      }
-    };
-    child.stdout.on('data', collect);
-    child.stderr.on('data', collect);
 
-    // One-shot: a failed spawn fires 'error' AND 'exit', and the second call
-    // would clobber the specific error with the generic exit fallback.
+    // The single funnel that guarantees inFlight is cleared. Every exit path routes
+    // here: synchronous setup failure, child 'error'/'exit', and the turn timeout.
+    // One-shot: a failed spawn fires 'error' AND 'exit', and the second call would
+    // clobber the specific error with the generic exit fallback.
     let finished = false;
     const finish = (error: string | null): void => {
       if (finished) return;
       finished = true;
-      this.inFlightChildren.delete(child);
-      clearTimeout(timeout);
+      if (timeout) clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      if (child) this.inFlightChildren.delete(child);
       this.opts.mcp.unregisterRun(token);
       c.inFlight = false;
       c.error = error;
@@ -205,45 +166,113 @@ export class PmChatService {
         c.sessionId = sessionId;
         this.persistSessions();
       }
-      void this.readMessages(c.sessionId).then((messages) => {
-        if (messages.length > 0) this.opts.emitTranscript({ boardId, messages });
-        this.opts.emitStatus(
-          error ? { boardId, status: 'error', error } : { boardId, status: 'idle' }
-        );
-      });
+      void this.readMessages(c.sessionId)
+        .then((messages) => {
+          if (messages.length > 0) this.opts.emitTranscript({ boardId, messages });
+        })
+        .catch(() => {
+          // reading the transcript back is best-effort; never block the status transition
+        })
+        .finally(() => {
+          this.opts.emitStatus(
+            error ? { boardId, status: 'error', error } : { boardId, status: 'idle' }
+          );
+        });
     };
 
-    const timeout = setTimeout(() => {
-      log.warn('pm turn timed out; killing rune', { boardId, pid: child.pid });
-      child.kill('SIGTERM');
-    }, PM_TURN_TIMEOUT_MS);
+    try {
+      this.opts.mcp.registerRun(token, { kind: 'board', boardId });
 
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      log.error('pm rune failed to spawn', { boardId, error: err.message });
-      finish(err.code === 'ENOENT' ? RUNE_NOT_INSTALLED_MESSAGE : err.message);
-    });
-    child.on('exit', (code, signal) => {
-      if (code === 0) {
-        finish(null);
-        return;
+      const dir = pmBoardDir(this.opts.kanbanHome, boardId);
+      const runeDir = join(dir, '.rune');
+      mkdirSync(runeDir, { recursive: true });
+      mkdirSync(pmDocsDir(this.opts.kanbanHome, boardId), { recursive: true });
+      let memory: string | null = null;
+      try {
+        memory = readFileSync(join(dir, 'MEMORY.md'), 'utf-8').slice(0, MEMORY_INJECT_CAP);
+      } catch {
+        // no memory yet — first turn or never written
       }
-      if (signal) {
-        finish('the PM run was interrupted; try again');
-        return;
+      let projects: Project[] = [];
+      try {
+        projects = this.opts.getProjects(boardId);
+      } catch {
+        // registry unavailable must never block the chat turn
       }
-      if (isAuthFailureText(output)) {
-        finish(
-          'rune authentication failed — fix the provider credentials (e.g. `rune login`) and retry'
-        );
-        return;
-      }
-      const lastLine = output
-        .split('\n')
-        .map((l) => l.trim())
-        .filter(Boolean)
-        .pop();
-      finish(lastLine ? lastLine.slice(0, 300) : `the PM run failed (exit ${code ?? '?'})`);
-    });
+      writeFileSync(join(dir, 'AGENTS.md'), buildPmAgentsMd({ projects, memory }));
+      const mcpConfigPath = join(runeDir, 'mcp.json');
+      const url = `http://127.0.0.1:${this.opts.mcpPort}/mcp?run=${token}`;
+      writeFileSync(
+        mcpConfigPath,
+        JSON.stringify({ servers: { kanban: { type: 'http', url } } }, null, 2)
+      );
+
+      const args = ['--prompt', body];
+      if (c.sessionId) args.push('--resume', c.sessionId);
+      const spawned = spawn('rune', args, {
+        cwd: dir,
+        // Treat the chat message as literal text — don't let rune auto-attach (and inline)
+        // files for path-like tokens the user happens to mention; the PM uses tools to read.
+        env: { ...process.env, RUNE_MCP_CONFIG: mcpConfigPath, RUNE_NO_ATTACH: '1' },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      child = spawned;
+      this.inFlightChildren.add(spawned);
+
+      let output = ''; // merged stdout+stderr tail, for error classification
+      const collect = (chunk: Buffer): void => {
+        output = (output + chunk.toString('utf-8')).slice(-OUTPUT_CAP);
+        if (!sessionId) {
+          sessionId = /^session-id: ([A-Za-z0-9_-]+)$/m.exec(output)?.[1] ?? null;
+        }
+      };
+      spawned.stdout.on('data', collect);
+      spawned.stderr.on('data', collect);
+
+      timeout = setTimeout(() => {
+        log.warn('pm turn timed out; killing rune', { boardId, pid: spawned.pid });
+        spawned.kill('SIGTERM');
+        // Escalate if rune traps/ignores SIGTERM, so the turn can't hang inFlight forever.
+        killTimer = setTimeout(() => {
+          if (finished) return;
+          log.warn('pm turn ignored SIGTERM; sending SIGKILL', { boardId, pid: spawned.pid });
+          spawned.kill('SIGKILL');
+        }, PM_TURN_SIGKILL_GRACE_MS);
+      }, PM_TURN_TIMEOUT_MS);
+
+      spawned.on('error', (err: NodeJS.ErrnoException) => {
+        log.error('pm rune failed to spawn', { boardId, error: err.message });
+        finish(err.code === 'ENOENT' ? RUNE_NOT_INSTALLED_MESSAGE : err.message);
+      });
+      spawned.on('exit', (code, signal) => {
+        if (code === 0) {
+          finish(null);
+          return;
+        }
+        if (signal) {
+          finish('the PM run was interrupted; try again');
+          return;
+        }
+        if (isAuthFailureText(output)) {
+          finish(
+            'rune authentication failed — fix the provider credentials (e.g. `rune login`) and retry'
+          );
+          return;
+        }
+        const lastLine = output
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean)
+          .pop();
+        finish(lastLine ? lastLine.slice(0, 300) : `the PM run failed (exit ${code ?? '?'})`);
+      });
+    } catch (err) {
+      // Synchronous setup failure (fs error, spawn throw, registry). Route through
+      // finish() so inFlight is cleared and the renderer leaves 'thinking', then
+      // surface the error to the caller as before.
+      finish(err instanceof Error ? err.message : String(err));
+      throw err;
+    }
   }
 
   private async readMessages(sessionId: string | null): Promise<TranscriptMessage[]> {


### PR DESCRIPTION
## Summary
- **Root cause:** `PmChatService.sendMessage` set `inFlight = true`, then ran unguarded synchronous setup (`registerRun`/`mkdirSync`/`writeFileSync`/`spawn`) *before* wiring the child `error`/`exit` handlers. `inFlight` was only ever reset inside `finish()`, reachable solely via those child events — so any setup throw (FS error, synchronous `spawn` throw) or a rune that ignores `SIGTERM` latched the flag `true` forever, which the renderer renders as a permanent "Thinking".
- **Fix:** funnel every exit path through one null-safe `finish()`. Setup is wrapped in `try/catch` that calls `finish()` and re-throws; the turn timeout now escalates `SIGTERM` → `SIGKILL` after a grace period; the transcript read-back is guarded with `.catch()`/`.finally()` so the status transition always fires.
- Debunked an earlier theory (un-`.catch()`'d `readMessages().then()`): `readRuneSession` swallows all errors and returns `null`, so it can never reject — verified by reading the code and 3 adversarial sub-reviews.

## Test plan
- [x] New `src/main/kanban/__tests__/pm-chat-service.test.ts`: setup-throw → `inFlight` returns to `false` + terminal `error` status emitted; timeout escalates `SIGTERM` → `SIGKILL`. (RED first, now GREEN.)
- [x] `npm run typecheck` — clean
- [x] `eslint` on changed files — no issues
- [x] `vitest run src/main/kanban src/renderer` — 214 passed
- [ ] Manual smoke: trigger a PM turn that fails setup (or kill the rune child) and confirm the panel leaves "Thinking" instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)