### PR TITLE
fix(learnings): address deferred QA edge cases from #268

### DIFF
--- a/src/main/__tests__/learnings-search-service.test.ts
+++ b/src/main/__tests__/learnings-search-service.test.ts
@@ -28,13 +28,22 @@ describe('reciprocalRankFusion', () => {
   });
 });
 
+describe('FakeEmbedder', () => {
+  it('returns null for empty/whitespace text rather than a degenerate zero vector', () => {
+    const e = new FakeEmbedder();
+    expect(e.embed('')).toBeNull();
+    expect(e.embed('   ')).toBeNull();
+    expect(e.embed('real')).toBeInstanceOf(Float32Array);
+  });
+});
+
 describe('LearningsSearchService.hybridSearch', () => {
   let store: LearningsStore;
 
   const embedAll = async (embedder: FakeEmbedder): Promise<void> => {
     for (const l of store.search({})) {
       const v = await embedder.embed(`${l.title}\n${l.body}`);
-      store.setEmbedding(l.id, v);
+      if (v) store.setEmbedding(l.id, v);
     }
   };
 
@@ -92,6 +101,15 @@ describe('LearningsSearchService.hybridSearch', () => {
     const results = await svc.hybridSearch('caching lru', { project: 'fleet' }, 5);
     expect(results).toHaveLength(1);
     expect(results[0].sourceProject).toBe('fleet');
+  });
+
+  it('clamps a non-positive limit to one result instead of returning none', async () => {
+    const embedder = new FakeEmbedder();
+    store.create({ title: 'react hooks deps', body: 'array' });
+    await embedAll(embedder);
+
+    const svc = new LearningsSearchService(store, embedder);
+    expect(await svc.hybridSearch('react hooks', {}, 0)).toHaveLength(1);
   });
 
   it('falls back to FTS-only when the embedder is unavailable', async () => {

--- a/src/main/__tests__/learnings-store.test.ts
+++ b/src/main/__tests__/learnings-store.test.ts
@@ -179,6 +179,13 @@ describe('LearningsStore', () => {
       expect(store.hasVectorSupport()).toBe(true);
     });
 
+    it('refuses a mis-sized embedding instead of corrupting the vec table', () => {
+      const l = store.create({ title: 'sized', body: 'x' });
+      store.setEmbedding(l.id, new Float32Array(10).fill(1)); // wrong length
+      expect(store.pendingEmbeddings(10).map((p) => p.id)).toEqual([l.id]); // still pending
+      expect(store.vectorSearch(vec(1), 5)).toHaveLength(0); // nothing was written
+    });
+
     it('new learnings start pending and leave the pending set once embedded', () => {
       const a = store.create({ title: 'a', body: 'x' });
       const b = store.create({ title: 'b', body: 'y' });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1260,10 +1260,13 @@ void app.whenReady().then(async () => {
   learningsMcp
     .start(loadPreferredPort(LEARNINGS_MCP_PORT))
     .then(async (port) => {
+      // Register first, then persist: the port file is what the next launch prefers,
+      // so only record it once the configs pointing at that port are written, keeping
+      // the port file and the registered configs from diverging.
+      registerLearningsMcp(port);
       // Remember the bound port so a forced OS-fallback (default port busy) stays
       // stable next launch instead of rewriting the global configs each time.
       persistPort(port);
-      registerLearningsMcp(port);
       await runBackfill(learningsStoreRef, learningsEmbedderRef);
     })
     .catch((err: unknown) =>

--- a/src/main/learnings/embed-service.ts
+++ b/src/main/learnings/embed-service.ts
@@ -113,6 +113,9 @@ export class WorkerEmbedder implements Embedder {
   }
 
   async embed(text: string): Promise<Float32Array | null> {
+    // The model yields a degenerate embedding for empty/whitespace input; skip it so
+    // callers fall back to FTS-only rather than storing a meaningless vector.
+    if (!text.trim()) return null;
     const worker = this.ensureWorker();
     if (!worker) return null;
     const id = ++this.seq;

--- a/src/main/learnings/embedder.ts
+++ b/src/main/learnings/embedder.ts
@@ -62,7 +62,10 @@ export class NullEmbedder implements Embedder {
 export class FakeEmbedder implements Embedder {
   constructor(readonly dim: number = EMBED_DIM) {}
 
-  embed(text: string): Float32Array {
+  embed(text: string): Float32Array | null {
+    // Empty/whitespace text has no tokens → a non-unit zero vector; match the real
+    // embedder and return null so callers leave the row on the FTS-only path.
+    if (!text.trim()) return null;
     const v = new Float32Array(this.dim);
     for (const tok of text
       .toLowerCase()

--- a/src/main/learnings/ipc-handlers.ts
+++ b/src/main/learnings/ipc-handlers.ts
@@ -90,7 +90,12 @@ function dirSize(dir: string): number {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) total += dirSize(full);
-    else if (entry.isFile()) total += statSync(full).size;
+    else if (entry.isFile()) {
+      // A concurrent clear-cache (rmSync) can delete a file between readdir and stat;
+      // skip a now-missing entry rather than throwing ENOENT.
+      const st = statSync(full, { throwIfNoEntry: false });
+      if (st) total += st.size;
+    }
   }
   return total;
 }

--- a/src/main/learnings/learnings-mcp-server.ts
+++ b/src/main/learnings/learnings-mcp-server.ts
@@ -74,7 +74,7 @@ const SearchArgs = z.object({
   tag: z.string().optional(),
   project: z.string().optional()
 });
-const GetArgs = z.object({ id: z.string().min(1) });
+const GetArgs = z.object({ id: z.string().min(1).max(128) });
 
 // The JSON-RPC envelope is untrusted (loopback, but any local process can POST).
 // Parse it with zod so a malformed body is a clean 400, not a thrown cast.
@@ -219,7 +219,7 @@ export class LearningsMcpServer {
       case 'tools/call':
         return this.handleToolCall(res, rpc);
       default: {
-        this.rpcError(res, rpc.id, `unknown method: ${rpc.method}`);
+        this.rpcError(res, rpc.id, 'unknown method');
         return;
       }
     }
@@ -248,13 +248,14 @@ export class LearningsMcpServer {
         const a = GetArgs.parse(args);
         const l = this.store.get(a.id);
         if (!l) {
-          this.rpcError(res, rpc.id, `learning not found: ${a.id}`);
+          // Don't echo the (untrusted) id back in the message.
+          this.rpcError(res, rpc.id, 'learning not found');
           return;
         }
         this.text(res, rpc.id, learningToMarkdown(l));
         return;
       }
-      this.rpcError(res, rpc.id, `unknown tool: ${name}`);
+      this.rpcError(res, rpc.id, 'unknown tool');
       return;
     } catch (err) {
       this.rpcError(res, rpc.id, err instanceof Error ? err.message : String(err));

--- a/src/main/learnings/learnings-store.ts
+++ b/src/main/learnings/learnings-store.ts
@@ -367,6 +367,12 @@ export class LearningsStore {
    */
   setEmbedding(id: string, vec: Float32Array): void {
     if (!this.vec) return;
+    // A wrong-length vector would be written verbatim into the vec0 table and surface
+    // later as a corrupt/cryptic KNN failure; reject it at the source instead.
+    if (vec.length !== EMBED_DIM) {
+      log.warn('refusing to store mis-sized embedding', { id, length: vec.length });
+      return;
+    }
     const row = this.db
       .prepare<[string], { rowid: number }>('SELECT rowid FROM learnings WHERE id = ?')
       .get(id);

--- a/src/main/learnings/search-service.ts
+++ b/src/main/learnings/search-service.ts
@@ -41,24 +41,33 @@ export class LearningsSearchService {
     opts: LearningSearchFilter = {},
     limit = 10
   ): Promise<Learning[]> {
+    // A non-positive limit would otherwise yield `[]` via slice semantics; clamp it.
+    const safeLimit = Math.max(1, limit);
     const filter: LearningSearchFilter = { query, project: opts.project, tag: opts.tag };
     const fts = this.store.search(filter);
 
-    if (!query.trim() || !this.store.hasVectorSupport()) return fts.slice(0, limit);
+    if (!query.trim() || !this.store.hasVectorSupport()) return fts.slice(0, safeLimit);
 
     const vec = await this.embedder.embed(query);
-    if (!vec) return fts.slice(0, limit);
+    if (!vec) return fts.slice(0, safeLimit);
 
-    // Pull a candidate pool wider than `limit` so fusion has room to reorder.
-    const hits = this.store.vectorSearch(vec, Math.max(limit * 4, 20));
+    // Pull a candidate pool wider than `limit` so fusion has room to reorder. Vector
+    // neighbors ignore project/tag, so a selective filter discards most of them
+    // post-fusion — widen the pool when a filter is present to avoid starving results.
+    const filtered = Boolean(filter.project || filter.tag);
+    const poolSize = filtered ? Math.max(safeLimit * 20, 100) : Math.max(safeLimit * 4, 20);
+    const hits = this.store.vectorSearch(vec, poolSize);
     const fused = reciprocalRankFusion([fts.map((l) => l.id), hits.map((h) => h.id)]);
 
+    // Reuse the already-hydrated FTS rows instead of re-fetching every fused id from
+    // the store; only ids that came solely from the vector side need a `store.get`.
+    const byId = new Map(fts.map((l) => [l.id, l]));
     const out: Learning[] = [];
     for (const id of fused) {
-      const l = this.store.get(id);
+      const l = byId.get(id) ?? this.store.get(id);
       // Vector neighbors ignore project/tag — enforce the filter on the merged set.
       if (l && matchesFilter(l, filter)) out.push(l);
-      if (out.length >= limit) break;
+      if (out.length >= safeLimit) break;
     }
     return out;
   }

--- a/src/renderer/src/components/sessions/LearningsBrowser.tsx
+++ b/src/renderer/src/components/sessions/LearningsBrowser.tsx
@@ -98,7 +98,13 @@ export function LearningsBrowser({
     const q = query.trim();
     const timer = setTimeout(() => {
       void window.fleet.learnings.search(q ? { query: q } : {}).then((res) => {
-        if (!ignore) setItems(res);
+        if (ignore) return;
+        setItems(res);
+        // Re-sync the open detail to its fresh copy so an edit elsewhere (or a
+        // refreshKey bump) doesn't keep showing stale content. Keep the prior value
+        // when the item isn't in the current (possibly filtered) results rather than
+        // blanking the panel.
+        setSelected((prev) => (prev ? (res.find((l) => l.id === prev.id) ?? prev) : prev));
       });
     }, 300);
     return () => {


### PR DESCRIPTION
## Summary
Knocks out the high-value **Medium/Low** findings from the Learnings Vector KB QA sweep (#268). Surgical, low-risk hardening — no behavior change for the happy path.

**Medium**
- **Dimension guard** — `setEmbedding` rejects a wrong-length `Float32Array` instead of writing it into the vec0 table (would surface later as a corrupt/cryptic KNN failure).
- **N+1 reads in hybrid search** — reuse the already-hydrated FTS rows via a `Map<id, Learning>`; only vector-only ids fall back to `store.get`.
- **Selective filter starvation** — widen the vector candidate pool when a `tag`/`project` filter is present, so a selective filter no longer post-filters the pool down to far fewer than `limit`.
- **`dirSize` ENOENT race** — `statSync(full, { throwIfNoEntry: false })` so a file deleted by a concurrent clear-cache between `readdir` and `stat` is skipped, not thrown.
- **Stale detail panel** — `LearningsBrowser` re-syncs the open item to its fresh copy on refresh (keeps the prior value when a search filters it out, rather than blanking the panel).
- **Empty-string embeds** — `WorkerEmbedder`/`FakeEmbedder` return `null` for empty/whitespace input instead of a degenerate zero vector.

**Low / hardening**
- MCP server no longer echoes untrusted input (`unknown method`, `unknown tool`, `learning not found`) back in error messages; `GetArgs.id` capped at 128 chars.
- `hybridSearch` clamps a non-positive `limit` to 1.
- Register MCP configs **before** persisting the port file so the port file and the registered configs can't diverge.

### Deliberately deferred (noted in #268, left open)
UPDATE re-embed vs `contentChanged` divergence (harmless/wasteful), `refresh` vs debounced-search `setItems` race (low-probability), backfill termination under a hypothetical bulk-import, clear-cache vs concurrent `scheduleEmbed` (already mitigated), sync fs at startup, FTS5 repair path, and the no-auth-token design note. The migration `user_version` concern is already moot — `learnings_vec` is created on every launch independent of `user_version`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 1406 pass, 0 fail (added 3: dimension guard, limit clamp, empty-string null)
- [x] Lint introduces no new errors (identical count with/without the diff — pre-existing `no-unsafe-type-assertion` casts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)