### PR TITLE
fix(env-editor): stop WSL pane crash by discovering env files in-distro

### DIFF
--- a/docs/learnings/2026-06-15-env-editor-wsl-unc-walk-crash.md
+++ b/docs/learnings/2026-06-15-env-editor-wsl-unc-walk-crash.md
@@ -1,0 +1,49 @@
+# Learnings: Env Editor crashed Fleet when opened from a WSL pane (2026-06-15)
+
+## A synchronous directory walk over the `\\wsl.localhost` 9P share froze/killed the main process
+
+**Problem:** On Windows, opening the Env Editor from a **WSL pane** took the
+whole app down (and restoring a WSL pane was already hanging). The Env Editor's
+`ENV_EDITOR_LIST` handler ran:
+
+```ts
+listEnvFiles(resolveCtxPath(pathContext, root))
+```
+
+For a WSL pane, `resolveCtxPath` rewrites the pane's posix cwd into a
+`\\wsl.localhost\<distro>\…` UNC path (Strategy 1, the UNC bridge from #250).
+`listEnvFiles` then walks it **synchronously** with `readdirSync` + `statSync`,
+recursing to depth 4. A synchronous recursive walk over the WSL 9P network
+share blocks the main process event loop — and can hard-fault it — so the app
+froze/crashed. Native (macOS/Linux/Windows-non-WSL) never hit this: there's no
+UNC bridge, so the walk is local and fast.
+
+The tell was the sibling handler: #250 gave **FILE_LIST** a WSL branch
+(`listFilesWsl`) that runs `git`/`find` *inside* the distro via
+`execInContext`, explicitly to avoid walking posix paths from the win32 side.
+`ENV_EDITOR_LIST` was the one discovery path left on the synchronous UNC walk —
+an architectural inconsistency, not a typo, which is why it only repro'd on
+Windows + WSL.
+
+**Fix:** Mirror `listFilesWsl`. New `src/main/env-editor/env-editor-wsl.ts`
+(`listEnvFilesWsl`) discovers `.env*` files *inside* the distro via
+`find … -prune … -name '.env*'` over `execInContext` (which has a 15s timeout,
+so a stopped distro returns instead of hanging). Per-file reads for the
+var-count badge use **async** `fs/promises` over the UNC bridge — a slow distro
+yields a slow promise, never a frozen event loop. Returned `absPath`s are UNC,
+so READ/WRITE/RENAME/DELETE (which take an `absPath` with no context) keep
+working unchanged. The handler branches on `isWslContext(pathContext)`; the
+native path is byte-for-byte the old `listEnvFiles(root)`.
+
+Entry-shaping (group/name/template/varCount) was extracted into
+`buildEnvEntry()` in `env-editor-fs.ts` and shared by both walkers so their
+output stays identical.
+
+**Rule of thumb:** Anywhere the main process touches a WSL pane's filesystem,
+do it *inside the distro* (`execInContext`) or with **async** fs over the UNC
+bridge — never a synchronous `readdirSync`/`statSync` walk across
+`\\wsl.localhost`. When adding a per-pane feature, check every sibling handler
+got the WSL branch, not just the obvious one.
+
+**Note / still open:** WSL pane *restore* hanging is a separate issue (not
+fixed here) — worth its own look.

--- a/src/main/__tests__/env-editor-wsl.test.ts
+++ b/src/main/__tests__/env-editor-wsl.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { listEnvFilesWsl, buildFindArgs } from '../env-editor/env-editor-wsl';
+import { toWslUncPath } from '../../shared/path-platform';
+import type { ExecResult } from '../run-in-context';
+
+const ctx = { kind: 'wsl' as const, distro: 'Ubuntu' };
+const root = '/home/k/proj';
+
+// Async thunks (with a real await) so lint's promise-function-async / require-await
+// stay happy while the returned function is still injectable as a Dep.
+function resolves<T>(value: T): () => Promise<T> {
+  return async () => {
+    await Promise.resolve();
+    return value;
+  };
+}
+function rejects(err: Error): () => Promise<never> {
+  return async () => {
+    await Promise.resolve();
+    throw err;
+  };
+}
+function execStdout(stdout: string): () => Promise<ExecResult> {
+  return resolves<ExecResult>({ stdout, stderr: '', code: 0, timedOut: false });
+}
+
+describe('listEnvFilesWsl', () => {
+  it('discovers env files in-distro and returns UNC-accessible entries', async () => {
+    const files = [`${root}/.env`, `${root}/apps/web/.env`, `${root}/.env.example`];
+    const entries = await listEnvFilesWsl(ctx, root, {
+      exec: execStdout(files.join('\n') + '\n'),
+      read: resolves('A=1\nB=2\n')
+    });
+
+    const byRel = new Map(entries.map((e) => [e.relPath, e]));
+    expect(byRel.get('.env')!.absPath).toBe(toWslUncPath(ctx.distro, `${root}/.env`));
+    expect(byRel.get('.env')!.group).toBe('·root');
+    expect(byRel.get('.env')!.varCount).toBe(2);
+    expect(byRel.get('.env')!.isTemplate).toBe(false);
+    expect(byRel.get('.env')!.readable).toBe(true);
+    expect(byRel.get('apps/web/.env')!.absPath).toBe(
+      toWslUncPath(ctx.distro, `${root}/apps/web/.env`)
+    );
+    expect(byRel.get('apps/web/.env')!.group).toBe('apps/web');
+    expect(byRel.get('.env.example')!.isTemplate).toBe(true);
+  });
+
+  it('sorts ·root group first', async () => {
+    const files = [`${root}/pkg/.env`, `${root}/.env`];
+    const entries = await listEnvFilesWsl(ctx, root, {
+      exec: execStdout(files.join('\n') + '\n'),
+      read: resolves('')
+    });
+    expect(entries[0].group).toBe('·root');
+  });
+
+  it('marks a file unreadable when its read fails, without throwing', async () => {
+    const entries = await listEnvFilesWsl(ctx, root, {
+      exec: execStdout(`${root}/.env\n`),
+      read: rejects(new Error('EIO'))
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].readable).toBe(false);
+    expect(entries[0].varCount).toBe(0);
+  });
+
+  it('returns an empty list when the in-distro find fails (e.g. stopped distro)', async () => {
+    const entries = await listEnvFilesWsl(ctx, root, {
+      exec: rejects(new Error('spawn wsl.exe ENOENT')),
+      read: resolves('')
+    });
+    expect(entries).toEqual([]);
+  });
+});
+
+describe('buildFindArgs', () => {
+  it('prunes excluded dirs, bounds depth, and matches .env*', () => {
+    const args = buildFindArgs(root);
+    expect(args[0]).toBe(root);
+    expect(args).toContain('-maxdepth');
+    expect(args).toContain('node_modules');
+    expect(args).toContain('-prune');
+    expect(args.slice(-5)).toEqual(['-type', 'f', '-name', '.env*', '-print']);
+  });
+});

--- a/src/main/env-editor/env-editor-fs.ts
+++ b/src/main/env-editor/env-editor-fs.ts
@@ -20,7 +20,9 @@ import type {
   EnvTrashResult
 } from '../../shared/env-editor-types';
 
-const EXCLUDE_DIRS = new Set([
+/** Directory names skipped when discovering .env files. Shared with the WSL
+ *  in-distro `find` path (env-editor-wsl.ts) so both walkers prune identically. */
+export const ENV_EXCLUDE_DIRS = [
   'node_modules',
   '.git',
   'dist',
@@ -29,7 +31,11 @@ const EXCLUDE_DIRS = new Set([
   '.turbo',
   'out',
   'coverage'
-]);
+];
+/** Max directory depth (root = 0) descended when discovering .env files. */
+export const ENV_MAX_DEPTH = 4;
+
+const EXCLUDE_DIRS = new Set(ENV_EXCLUDE_DIRS);
 const TEMPLATE_SUFFIXES = ['.example', '.sample', '.template', '.dist', '.defaults'];
 
 function isEnvName(name: string): boolean {
@@ -39,23 +45,27 @@ function isTemplateName(name: string): boolean {
   return TEMPLATE_SUFFIXES.some((s) => name.endsWith(s));
 }
 
-function toEntry(root: string, full: string): EnvFileEntry {
-  const name = basename(full);
-  const rel = relative(root, full).split(sep).join('/');
-  const slash = rel.lastIndexOf('/');
-  const dir = slash === -1 ? '' : rel.slice(0, slash);
+/**
+ * Build an entry from a forward-slash relative path, an OS-accessible absolute
+ * path, and the file's text (or null if it could not be read). Shared by the
+ * native walker and the WSL in-distro path so entry shaping stays identical.
+ */
+export function buildEnvEntry(relPath: string, absPath: string, text: string | null): EnvFileEntry {
+  const slash = relPath.lastIndexOf('/');
+  const name = slash === -1 ? relPath : relPath.slice(slash + 1);
+  const dir = slash === -1 ? '' : relPath.slice(0, slash);
   let varCount = 0;
-  let readable = true;
-  try {
-    varCount = parseEnvFile(readFileSync(full, 'utf8')).lines.filter(
-      (l) => l.kind === 'var'
-    ).length;
-  } catch {
-    readable = false;
+  let readable = text !== null;
+  if (text !== null) {
+    try {
+      varCount = parseEnvFile(text).lines.filter((l) => l.kind === 'var').length;
+    } catch {
+      readable = false;
+    }
   }
   return {
-    absPath: full,
-    relPath: rel,
+    absPath,
+    relPath,
     group: dir === '' ? '·root' : dir,
     name,
     isTemplate: isTemplateName(name),
@@ -64,7 +74,18 @@ function toEntry(root: string, full: string): EnvFileEntry {
   };
 }
 
-function sortEntries(entries: EnvFileEntry[]): EnvFileEntry[] {
+function toEntry(root: string, full: string): EnvFileEntry {
+  const rel = relative(root, full).split(sep).join('/');
+  let text: string | null;
+  try {
+    text = readFileSync(full, 'utf8');
+  } catch {
+    text = null;
+  }
+  return buildEnvEntry(rel, full, text);
+}
+
+export function sortEntries(entries: EnvFileEntry[]): EnvFileEntry[] {
   return [...entries].sort((a, b) => {
     if (a.group !== b.group) {
       if (a.group === '·root') return -1;
@@ -159,7 +180,7 @@ export function restoreEnvFile(trashPath: string, absPath: string): { ok: true }
 }
 
 /** Recursively find all .env* files under root (templates included). */
-export function listEnvFiles(root: string, maxDepth = 4): EnvFileEntry[] {
+export function listEnvFiles(root: string, maxDepth = ENV_MAX_DEPTH): EnvFileEntry[] {
   const out: EnvFileEntry[] = [];
   const walk = (dir: string, depth: number): void => {
     if (depth > maxDepth) return;

--- a/src/main/env-editor/env-editor-wsl.ts
+++ b/src/main/env-editor/env-editor-wsl.ts
@@ -1,0 +1,82 @@
+import { readFile } from 'node:fs/promises';
+import { posix as posixPath } from 'node:path';
+import { toWslUncPath } from '../../shared/path-platform';
+import { execInContext, type ExecResult } from '../run-in-context';
+import { buildEnvEntry, sortEntries, ENV_EXCLUDE_DIRS, ENV_MAX_DEPTH } from './env-editor-fs';
+import type { EnvFileEntry } from '../../shared/env-editor-types';
+
+type Deps = {
+  /** Run a command inside the distro. Injected in tests. */
+  exec?: (
+    ctx: { kind: 'wsl'; distro: string },
+    cmd: string,
+    args: string[],
+    opts?: { cwd?: string; maxBuffer?: number }
+  ) => Promise<ExecResult>;
+  /** Read a file's UTF-8 text by its Windows-accessible (UNC) path. */
+  read?: (absPath: string) => Promise<string>;
+};
+
+/**
+ * `find` argv that discovers `.env*` files under `rootPosix`, pruning the same
+ * directories as the native walker and bounding depth. find counts the root's
+ * own files at depth 1, so a file in a dir at our depth-N sits at find depth
+ * N+1 — hence `ENV_MAX_DEPTH + 1`.
+ */
+export function buildFindArgs(rootPosix: string): string[] {
+  const args: string[] = [rootPosix, '-maxdepth', String(ENV_MAX_DEPTH + 1), '('];
+  ENV_EXCLUDE_DIRS.forEach((name, i) => {
+    if (i > 0) args.push('-o');
+    args.push('-name', name);
+  });
+  args.push(')', '-prune', '-o', '-type', 'f', '-name', '.env*', '-print');
+  return args;
+}
+
+/**
+ * ENV_EDITOR_LIST for a WSL pane. A synchronous win32 walk over the
+ * `\\wsl.localhost\<distro>` 9P share blocks (and can crash) the main process,
+ * so discovery runs *inside* the distro via `find` — mirroring FILE_LIST's
+ * `listFilesWsl`. Per-file reads (for the var-count badge) use async fs over the
+ * UNC bridge, so a slow/stopped distro yields a slow promise, never a frozen
+ * event loop. Returned `absPath`s are UNC so READ/WRITE/RENAME/DELETE work as-is.
+ */
+export async function listEnvFilesWsl(
+  ctx: { kind: 'wsl'; distro: string },
+  rootPosix: string,
+  deps: Deps = {}
+): Promise<EnvFileEntry[]> {
+  const exec = deps.exec ?? execInContext;
+  const read = deps.read;
+
+  let stdout: string;
+  try {
+    ({ stdout } = await exec(ctx, 'find', buildFindArgs(rootPosix), {
+      cwd: rootPosix,
+      maxBuffer: 10 * 1024 * 1024
+    }));
+  } catch {
+    return [];
+  }
+
+  const posixPaths = stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const entries = await Promise.all(
+    posixPaths.map(async (filePosix) => {
+      const absPath = toWslUncPath(ctx.distro, filePosix);
+      const relPath = posixPath.relative(rootPosix, filePosix);
+      let text: string | null;
+      try {
+        text = read ? await read(absPath) : await readFile(absPath, 'utf8');
+      } catch {
+        text = null;
+      }
+      return buildEnvEntry(relPath, absPath, text);
+    })
+  );
+
+  return sortEntries(entries);
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -199,6 +199,8 @@ import {
   softDeleteEnvFile,
   restoreEnvFile
 } from './env-editor/env-editor-fs';
+import { listEnvFilesWsl } from './env-editor/env-editor-wsl';
+import type { EnvFileEntry } from '../shared/env-editor-types';
 import type {
   EnvSyncSetPassphraseRequest,
   EnvSyncClearPassphraseRequest,
@@ -1108,8 +1110,10 @@ export function registerIpcHandlers(
   // LIST/CREATE receive a pane cwd/dir (posix for a WSL pane) so they translate;
   // READ/WRITE/RENAME/DELETE/RESTORE only ever get an absPath that LIST/CREATE
   // already returned in Windows-accessible form, so they need no context.
-  ipcMain.handle(IPC_CHANNELS.ENV_EDITOR_LIST, (_e, root: string, pathContext?: PathContext) =>
-    listEnvFiles(resolveCtxPath(pathContext, root))
+  ipcMain.handle(
+    IPC_CHANNELS.ENV_EDITOR_LIST,
+    (_e, root: string, pathContext?: PathContext): EnvFileEntry[] | Promise<EnvFileEntry[]> =>
+      isWslContext(pathContext) ? listEnvFilesWsl(pathContext, root) : listEnvFiles(root)
   );
 
   ipcMain.handle(IPC_CHANNELS.ENV_EDITOR_READ, (_e, absPath: string) => readEnvFile(absPath));


### PR DESCRIPTION
## Summary
- Opening the Env Editor from a **WSL pane** on Windows crashed the whole app: `ENV_EDITOR_LIST` walked the `\\wsl.localhost\<distro>` 9P share with a **synchronous** `readdirSync`/`statSync` recursion (depth 4), blocking/hard-faulting the main process. Native platforms were unaffected (no UNC bridge → local walk).
- Root cause is an inconsistency from #250: its sibling `FILE_LIST` already runs discovery *inside* the distro (`listFilesWsl`), but env-editor LIST was left on the synchronous UNC walk.
- New `listEnvFilesWsl` mirrors that pattern — discovers `.env*` via `find` over `execInContext` (15s timeout, so a stopped distro returns `[]` instead of hanging), reads per-file contents **async** over UNC for the var-count badge, and returns UNC `absPath`s so read/write/rename/delete are unchanged. The handler branches on `isWslContext`; the native path is byte-for-byte the old `listEnvFiles(root)`.
- Entry-shaping extracted into shared `buildEnvEntry()` so both walkers produce identical entries.

## Test plan
- [x] `npm run typecheck` (node + web)
- [x] `npm run lint` (changed files clean; pre-existing menu-code lint untouched)
- [x] `vitest` — 5 new `env-editor-wsl` tests + existing `env-editor-fs` tests (13 passing)
- [ ] **Manual (Windows + WSL):** open Env Editor from a WSL pane → file list loads, no crash; read/save/create/rename/delete a `.env` works
- [ ] Regression: Env Editor on macOS/Linux/native-Windows behaves as before

## Out of scope
- WSL pane **restore** hanging is a separate, still-open issue (noted in the learnings doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)