### PR TITLE
feat(diagnostics): capture errors + "Report a Problem"

### DIFF
--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -1,0 +1,86 @@
+import { app, shell } from 'electron';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir, release } from 'node:os';
+import { LOG_DIR } from './logger';
+import type { DiagnosticsInfo } from '../shared/ipc-api';
+
+/** Default amount of log content returned to the renderer for a problem report. */
+const DEFAULT_TAIL_BYTES = 64 * 1024;
+
+export function collectDiagnosticsInfo(): DiagnosticsInfo {
+  return {
+    version: app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+    osRelease: release(),
+    electron: process.versions.electron,
+    chrome: process.versions.chrome,
+    node: process.versions.node
+  };
+}
+
+/**
+ * Strip secrets and user-identifying paths so a log tail is safe to paste into a
+ * public GitHub issue. Conservative — favours leaving readable text over
+ * over-redacting, but covers the credential shapes Fleet actually handles
+ * (env-sync, fal.ai, provider API keys, bearer tokens).
+ */
+export function redact(text: string): string {
+  let out = text;
+
+  // Collapse the user's home directory to ~ (covers most identifying paths).
+  const home = homedir();
+  if (home) out = out.split(home).join('~');
+
+  // key/secret/token/password = value  →  key = [REDACTED]
+  out = out.replace(
+    /((?:api[_-]?key|secret|token|password|passphrase|auth(?:orization)?)\s*[:='"]+\s*)\S+/gi,
+    '$1[REDACTED]'
+  );
+  // Bearer tokens
+  out = out.replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]');
+  // Provider key prefixes (sk-..., pk-..., rk-...)
+  out = out.replace(/\b(sk|pk|rk)-[A-Za-z0-9_-]{8,}/g, '$1-[REDACTED]');
+  // AWS access key IDs
+  out = out.replace(/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_AWS_KEY]');
+
+  return out;
+}
+
+/**
+ * Read the tail of the most recent daily log file and return it redacted.
+ * Returns an empty string if no log files exist yet.
+ */
+export async function readRedactedLogTail(maxBytes = DEFAULT_TAIL_BYTES): Promise<string> {
+  let entries: string[];
+  try {
+    entries = await readdir(LOG_DIR);
+  } catch {
+    return '';
+  }
+
+  // Filenames are fleet-YYYY-MM-DD.log, so lexical sort == chronological.
+  const latest = entries
+    .filter((name) => name.startsWith('fleet-') && name.endsWith('.log'))
+    .sort()
+    .pop();
+  if (!latest) return '';
+
+  let buf: Buffer;
+  try {
+    buf = await readFile(join(LOG_DIR, latest));
+  } catch {
+    return '';
+  }
+
+  // Slice by bytes (honouring maxBytes) before decoding. A multibyte char may be
+  // clipped at the cut point — harmless for ASCII-dominant logs.
+  const tail = buf.length > maxBytes ? buf.subarray(buf.length - maxBytes) : buf;
+  return redact(tail.toString('utf8'));
+}
+
+/** Reveal the log directory so the user can attach the full log to a report. */
+export async function openLogsFolder(): Promise<void> {
+  await shell.openPath(LOG_DIR);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1339,3 +1339,20 @@ process.on('SIGINT', () => {
   shutdownAll();
   process.exit(0);
 });
+
+// Last-resort capture for errors that escape every try/catch so they land in
+// ~/.fleet/logs/ instead of only an OS crash dump. Registering this handler
+// overrides Electron's default (print stack + exit) — we deliberately log and
+// keep running rather than tearing down the user's running terminals/agents.
+process.on('uncaughtException', (err) => {
+  log.error('uncaughtException', {
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined
+  });
+});
+process.on('unhandledRejection', (reason) => {
+  log.error('unhandledRejection', {
+    error: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined
+  });
+});

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain, BrowserWindow, Menu, dialog, safeStorage } from 'electron';
 import type { MenuItemConstructorOptions } from 'electron';
 import { safeOpenExternal } from './safe-external';
+import { collectDiagnosticsInfo, readRedactedLogTail, openLogsFolder } from './diagnostics';
 import { createLogger, logger } from './logger';
 
 const log = createLogger('ipc');
@@ -462,6 +463,13 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC_CHANNELS.SHELL_OPEN_EXTERNAL, async (_event, url: string) => {
     await safeOpenExternal(url);
   });
+
+  // Diagnostics — "Report a Problem" gathers redacted logs + environment info
+  ipcMain.handle(IPC_CHANNELS.DIAGNOSTICS_GET_INFO, () => collectDiagnosticsInfo());
+  ipcMain.handle(IPC_CHANNELS.DIAGNOSTICS_GET_LOG_TAIL, async (_event, maxBytes?: number) =>
+    readRedactedLogTail(maxBytes)
+  );
+  ipcMain.handle(IPC_CHANNELS.DIAGNOSTICS_OPEN_LOGS, async () => openLogsFolder());
 
   // Native right-click context menu for terminal panes.
   // Renderer passes { hasSelection } so Copy is disabled when nothing is selected;

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -66,6 +66,10 @@ const fileFormat = winston.format.combine(
 
 const logDir = join(electronApp ? electronApp.home : homedir(), '.fleet', 'logs');
 
+/** Absolute path to the daily log directory. Single source of truth for any
+ * module (e.g. diagnostics) that needs to read these logs back. */
+export const LOG_DIR = logDir;
+
 const transports: winston.transport[] = [
   new winston.transports.Console({
     format: isDev

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,7 @@ import type {
   RecentImagesResponse,
   ClipboardHistoryResponse,
   LogEntry,
+  DiagnosticsInfo,
   ActivityStatePayload,
   RemoteStatePayload,
   WorktreeCreateRequest,
@@ -407,6 +408,12 @@ const fleetApi = {
   shell: {
     openExternal: async (url: string): Promise<void> =>
       typedInvoke(IPC_CHANNELS.SHELL_OPEN_EXTERNAL, url)
+  },
+  diagnostics: {
+    getInfo: async (): Promise<DiagnosticsInfo> => typedInvoke(IPC_CHANNELS.DIAGNOSTICS_GET_INFO),
+    getLogTail: async (maxBytes?: number): Promise<string> =>
+      typedInvoke(IPC_CHANNELS.DIAGNOSTICS_GET_LOG_TAIL, maxBytes),
+    openLogsFolder: async (): Promise<void> => typedInvoke(IPC_CHANNELS.DIAGNOSTICS_OPEN_LOGS)
   },
   terminal: {
     showContextMenu: async (params: {

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { createLogger } from '../logger';
+
+const log = createLogger('renderer:error-boundary');
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches render-time errors so a crashing component shows a recoverable
+ * fallback instead of a blank window, and logs the error + component stack to
+ * ~/.fleet/logs/ for debugging.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    log.error('react render error', {
+      message: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack ?? undefined
+    });
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-neutral-950 p-8">
+        <div className="max-w-md space-y-4 text-center">
+          <div className="text-lg font-medium text-neutral-100">Something went wrong</div>
+          <p className="text-sm text-neutral-400">
+            Fleet hit an unexpected error and this view crashed. The details were saved to your
+            local logs. You can reload, or send them to us via Settings → Diagnostics → Report a
+            Problem.
+          </p>
+          <pre className="max-h-32 overflow-auto rounded-md border border-neutral-800 bg-neutral-900 p-3 text-left text-xs text-red-400">
+            {error.message}
+          </pre>
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-md bg-neutral-700 px-3 py-1.5 text-sm text-white transition-colors hover:bg-neutral-600 active:scale-[0.97]"
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/src/components/settings/DiagnosticsSection.tsx
+++ b/src/renderer/src/components/settings/DiagnosticsSection.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import type { DiagnosticsInfo } from '../../../../shared/ipc-api';
+
+const REPO = 'khang859/fleet';
+// Keep the prefilled issue URL comfortably under browser/GitHub limits.
+const MAX_URL_LENGTH = 7000;
+
+function buildIssueUrl(info: DiagnosticsInfo, logSnippet: string): string {
+  const title = `Bug: <short summary> (v${info.version})`;
+
+  const build = (snippet: string): string => {
+    const body = [
+      '## Describe the problem',
+      '',
+      '<!-- What happened? What did you expect to happen? -->',
+      '',
+      '## Environment',
+      `- Fleet: v${info.version}`,
+      `- OS: ${info.platform} ${info.arch} (${info.osRelease})`,
+      `- Electron ${info.electron} · Chrome ${info.chrome} · Node ${info.node}`,
+      '',
+      '## Recent logs',
+      'Secrets and paths are redacted, but please review before posting. For the full logs,',
+      'click "Open Logs Folder" in Settings → Diagnostics and attach the latest `fleet-*.log`.',
+      '',
+      '```',
+      snippet.trim() || '(no recent log entries)',
+      '```'
+    ].join('\n');
+    return `https://github.com/${REPO}/issues/new?labels=bug&title=${encodeURIComponent(
+      title
+    )}&body=${encodeURIComponent(body)}`;
+  };
+
+  // Shrink the embedded log snippet until the URL fits. encodeURIComponent can
+  // expand each char up to ~3x, so check the encoded URL length (not the raw
+  // snippet length) and halve the snippet to 0 if needed; the snippet-less URL
+  // is always well under the limit.
+  let snippet = logSnippet.slice(-3000);
+  let url = build(snippet);
+  while (url.length > MAX_URL_LENGTH && snippet.length > 0) {
+    // ceil so a length-1 snippet drops to 0 (floor would stay at 1 forever).
+    snippet = snippet.slice(Math.ceil(snippet.length / 2));
+    url = build(snippet);
+  }
+  return url;
+}
+
+export function DiagnosticsSection(): React.JSX.Element {
+  const [info, setInfo] = useState<DiagnosticsInfo | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void window.fleet.diagnostics.getInfo().then(setInfo);
+  }, []);
+
+  const reportProblem = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const current = info ?? (await window.fleet.diagnostics.getInfo());
+      const logTail = await window.fleet.diagnostics.getLogTail();
+      await window.fleet.shell.openExternal(buildIssueUrl(current, logTail));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open report');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <div className="text-sm text-neutral-300">{info ? `Fleet v${info.version}` : 'Fleet'}</div>
+        {info && (
+          <div className="text-xs text-neutral-500">
+            {info.platform} {info.arch} · Electron {info.electron} · Chrome {info.chrome}
+          </div>
+        )}
+      </div>
+
+      <p className="text-sm text-neutral-400">
+        Hit a bug? Report a Problem opens a prefilled GitHub issue with your version, OS, and a
+        redacted snippet of recent logs. For the full logs, open the logs folder and attach the
+        latest <code className="text-neutral-300">fleet-*.log</code> file. Nothing is sent anywhere
+        until you submit the issue.
+      </p>
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            void reportProblem();
+          }}
+          disabled={busy}
+          className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.97] disabled:active:scale-100"
+        >
+          {busy ? 'Opening…' : 'Report a Problem'}
+        </button>
+        <button
+          onClick={() => {
+            void window.fleet.diagnostics.openLogsFolder();
+          }}
+          className="px-3 py-1.5 text-sm bg-neutral-700 hover:bg-neutral-600 text-white rounded-md transition-colors active:scale-[0.97]"
+        >
+          Open Logs Folder
+        </button>
+      </div>
+
+      {error && <div className="text-sm text-red-400">{error}</div>}
+    </div>
+  );
+}

--- a/src/renderer/src/components/settings/SettingsNav.tsx
+++ b/src/renderer/src/components/settings/SettingsNav.tsx
@@ -10,7 +10,8 @@ export type SettingsSection =
   | 'pi'
   | 'kanban'
   | 'envSync'
-  | 'learnings';
+  | 'learnings'
+  | 'diagnostics';
 
 const ALL_SECTIONS: Array<{ id: SettingsSection; label: string; darwinOnly?: boolean }> = [
   { id: 'general', label: 'General' },
@@ -24,6 +25,7 @@ const ALL_SECTIONS: Array<{ id: SettingsSection; label: string; darwinOnly?: boo
   { id: 'learnings', label: 'Learnings' },
   { id: 'envSync', label: 'Env Sync' },
   { id: 'annotate', label: 'Annotate' },
+  { id: 'diagnostics', label: 'Diagnostics' },
   { id: 'updates', label: 'Updates' } // Always keep at bottom
 ];
 

--- a/src/renderer/src/components/settings/SettingsTab.tsx
+++ b/src/renderer/src/components/settings/SettingsTab.tsx
@@ -13,6 +13,7 @@ import { RuneSection } from './rune/RuneSection';
 import { KanbanSection } from './kanban/KanbanSection';
 import { EnvSyncSection } from './EnvSyncSection';
 import { LearningsSection } from './LearningsSection';
+import { DiagnosticsSection } from './DiagnosticsSection';
 
 const SECTION_COMPONENTS: Record<SettingsSection, React.ComponentType> = {
   general: GeneralSection,
@@ -26,7 +27,8 @@ const SECTION_COMPONENTS: Record<SettingsSection, React.ComponentType> = {
   pi: PiSection,
   kanban: KanbanSection,
   envSync: EnvSyncSection,
-  learnings: LearningsSection
+  learnings: LearningsSection,
+  diagnostics: DiagnosticsSection
 };
 
 export function SettingsTab(): React.JSX.Element {

--- a/src/renderer/src/logger.ts
+++ b/src/renderer/src/logger.ts
@@ -62,14 +62,26 @@ function resolveMeta(meta?: MetaArg): Record<string, unknown> | undefined {
   return { ...meta };
 }
 
-// --- No-op logger for production ---
+// --- Production logger ---
+// debug/info stay no-ops for performance, but warn/error are forwarded through
+// the batch bridge so they land in ~/.fleet/logs/ — without this, production
+// renderer crashes (React errors, unhandled rejections) would be invisible.
 const noop = (): void => {};
-const noopLogger: RendererLogger = {
-  debug: noop,
-  info: noop,
-  warn: noop,
-  error: noop
-};
+
+function createProdLogger(tag: string): RendererLogger {
+  ensureFlushTimer();
+
+  function log(level: 'warn' | 'error', message: string, meta?: MetaArg): void {
+    enqueue({ tag, level, message, meta: resolveMeta(meta), timestamp: new Date().toISOString() });
+  }
+
+  return {
+    debug: noop,
+    info: noop,
+    warn: (message, meta?) => log('warn', message, meta),
+    error: (message, meta?) => log('error', message, meta)
+  };
+}
 
 function createDevLogger(tag: string): RendererLogger {
   ensureFlushTimer();
@@ -105,5 +117,5 @@ function createDevLogger(tag: string): RendererLogger {
 }
 
 export function createLogger(tag: string): RendererLogger {
-  return isDev ? createDevLogger(tag) : noopLogger;
+  return isDev ? createDevLogger(tag) : createProdLogger(tag);
 }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,9 +1,13 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { createLogger } from './logger';
 import './index.css';
 
+const log = createLogger('renderer');
+
 window.addEventListener('error', (event) => {
-  console.error('[renderer:error]', {
+  log.error('uncaught error', {
     message: event.message,
     filename: event.filename,
     lineno: event.lineno,
@@ -14,7 +18,7 @@ window.addEventListener('error', (event) => {
 
 window.addEventListener('unhandledrejection', (event) => {
   const reason: unknown = event.reason;
-  console.error('[renderer:unhandledrejection]', {
+  log.error('unhandled rejection', {
     message: reason instanceof Error ? reason.message : String(reason),
     stack: reason instanceof Error ? reason.stack : undefined
   });
@@ -67,6 +71,10 @@ const fontTimeout = new Promise<void>((resolve) => setTimeout(resolve, 3000));
 void Promise.race([Promise.allSettled(fontLoads), fontTimeout]).then(() => {
   const root = document.getElementById('root');
   if (root) {
-    createRoot(root).render(<App />);
+    createRoot(root).render(
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    );
   }
 });

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -239,6 +239,17 @@ export interface LogEntry {
   timestamp: string;
 }
 
+/** Environment snapshot included in a "Report a Problem" bundle. */
+export interface DiagnosticsInfo {
+  version: string;
+  platform: string;
+  arch: string;
+  osRelease: string;
+  electron: string;
+  chrome: string;
+  node: string;
+}
+
 export type WorktreeCreateRequest = {
   repoPath: string;
   /** Pane context; for a WSL pane the worktree is created inside the distro. */

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -250,5 +250,9 @@ export const IPC_CHANNELS = {
   ENV_EDITOR_CREATE: 'env-editor:create',
   ENV_EDITOR_RENAME: 'env-editor:rename',
   ENV_EDITOR_DELETE: 'env-editor:delete',
-  ENV_EDITOR_RESTORE: 'env-editor:restore'
+  ENV_EDITOR_RESTORE: 'env-editor:restore',
+  // Diagnostics ("Report a Problem")
+  DIAGNOSTICS_GET_INFO: 'diagnostics:get-info',
+  DIAGNOSTICS_GET_LOG_TAIL: 'diagnostics:get-log-tail',
+  DIAGNOSTICS_OPEN_LOGS: 'diagnostics:open-logs'
 } as const;


### PR DESCRIPTION
## Summary
- **Closes the capture gaps** that made user errors invisible: main-process `uncaughtException`/`unhandledRejection` now log to `~/.fleet/logs/`; the renderer logger forwards `warn`/`error` to disk in production (was a no-op); `window.onerror`/`unhandledrejection` route through the logger; and a React `ErrorBoundary` shows a recoverable fallback instead of a white screen.
- **Adds a user-initiated "Report a Problem"** (Settings → Diagnostics): collects version/OS + a redacted tail of recent logs and opens a prefilled GitHub issue (snippet auto-trimmed to fit the URL), plus an "Open Logs Folder" button to attach the full log.
- **Privacy:** redaction (home dir → `~`, API keys/tokens/bearer/AWS keys) runs in the main process, so the renderer only ever sees safe text. Nothing leaves the machine until the user submits the issue.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run` logger tests (6/6)
- [x] Lint clean on all touched files
- [ ] Manual: trigger a render crash → ErrorBoundary fallback appears + entry lands in `~/.fleet/logs/`
- [ ] Manual: click **Report a Problem** → prefilled GitHub issue opens in browser
- [ ] Manual: eyeball redaction on a log containing a key/token

🤖 Generated with [Claude Code](https://claude.com/claude-code)