### PR TITLE
fix(env-editor): follow renamed cwd and handle missing dir on save

### DIFF
--- a/docs/learnings/2026-06-16-env-editor-stale-cwd-after-rename.md
+++ b/docs/learnings/2026-06-16-env-editor-stale-cwd-after-rename.md
@@ -1,0 +1,58 @@
+# Env Editor: stale cwd after folder rename → cryptic ENOENT on save
+
+## Symptom
+
+Editing a `.env` via the Env Editor failed with:
+
+```
+Error invoking remote method 'env-editor:write':
+Error: ENOENT: no such file or directory, open
+'/Users/.../rune-v2/.env.fleet-tmp-40629-1781649467771-10'
+```
+
+Trigger: the user renamed the folder they were `cd`'d into, then tried to save.
+
+## Root cause
+
+Fleet caches each pane's cwd in `cwd-store` (renderer), populated two ways by
+`src/main/cwd-poller.ts`:
+
+1. OSC 7 escape sequences the shell emits on `cd`.
+2. A PID poller (`pidCwd` / `/proc/<pid>/cwd`).
+
+**The poller permanently stops once an OSC 7 is seen** (`osc7Seen` set), and OSC 7
+only fires on `cd`. Renaming the *current* folder runs no `cd`, so neither path
+updates → the store keeps the **old** path.
+
+The Env Editor used that stale path as its `root`. On save, `writeEnvFile`
+(`env-editor-fs.ts`) writes a temp file `${absPath}.fleet-tmp-...` next to the
+target. When the parent directory no longer exists, `writeFileSync` throws a raw
+`ENOENT` naming the temp file — confusing, and with no recovery.
+
+Key insight: `pidCwd(pid)` resolves the process's **live** path via inode on
+macOS, so it returns the *new* folder name on demand — the data was recoverable;
+the poller just wasn't running anymore.
+
+## Fix
+
+Two layers (commit on branch `fleet-rare-cove-dune`):
+
+1. **Resolve live cwd on demand.** Added `CwdPoller.resolveNow(paneId,
+   pathContext)` which re-reads the live cwd, emits `cwd-changed` if it differs
+   (so the whole app re-syncs), and returns it (null for WSL / no-pid). Exposed
+   via `pty:resolve-cwd` IPC + `window.fleet.pty.resolveCwd`. The Env Editor
+   calls it on open and uses the result as `root`, so it follows the renamed
+   folder.
+2. **Graceful backstop.** `writeEnvFile` now returns `{ ok: false, missingDir:
+   true }` when the parent dir is gone instead of throwing; the modal shows a
+   clear toast ("This folder no longer exists — run `cd` to refresh") and stays
+   open.
+
+## Takeaways
+
+- A "current dir" cached from OSC 7 goes stale on rename/move because no `cd`
+  fires. When you need an authoritative cwd, resolve it on demand from the pid
+  rather than trusting the cached value.
+- Atomic temp+rename writes surface ENOENT against the *temp* path, which hides
+  that the real problem is a missing parent directory. Check the dir explicitly
+  and return a meaningful result.

--- a/src/main/__tests__/cwd-poller.test.ts
+++ b/src/main/__tests__/cwd-poller.test.ts
@@ -66,6 +66,52 @@ describe('CwdPoller', () => {
     expect(changes).toContain('/tmp/test-cwd');
   });
 
+  it('resolveNow returns the live cwd and emits cwd-changed when it differs', async () => {
+    const ptyManager = makeMockPtyManager('/old-cwd');
+    poller = new CwdPoller(eventBus, ptyManager);
+
+    const changes: string[] = [];
+    eventBus.on('cwd-changed', (e) => changes.push(e.cwd));
+
+    const live = await poller.resolveNow('pane-1');
+
+    expect(live).toBe('/tmp/test-cwd');
+    expect(changes).toContain('/tmp/test-cwd');
+  });
+
+  it('resolveNow does not emit when the cwd is unchanged', async () => {
+    const ptyManager = makeMockPtyManager('/tmp/test-cwd');
+    poller = new CwdPoller(eventBus, ptyManager);
+
+    const changes: string[] = [];
+    eventBus.on('cwd-changed', (e) => changes.push(e.cwd));
+
+    const live = await poller.resolveNow('pane-1');
+
+    expect(live).toBe('/tmp/test-cwd');
+    expect(changes).toHaveLength(0);
+  });
+
+  it('resolveNow returns null for WSL panes (pidCwd is unreliable there)', async () => {
+    const ptyManager = makeMockPtyManager('/old-cwd');
+    poller = new CwdPoller(eventBus, ptyManager);
+
+    const live = await poller.resolveNow('pane-wsl', { kind: 'wsl', distro: 'Ubuntu' });
+
+    expect(live).toBeNull();
+    expect(pidCwd).not.toHaveBeenCalled();
+  });
+
+  it('resolveNow returns null when the pane has no pid', async () => {
+    const ptyManager = makeMockPtyManager('/old-cwd');
+    (ptyManager.getPid as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    poller = new CwdPoller(eventBus, ptyManager);
+
+    const live = await poller.resolveNow('pane-gone');
+
+    expect(live).toBeNull();
+  });
+
   it('stopPolling clears the timer', async () => {
     const ptyManager = makeMockPtyManager('/old-cwd');
     poller = new CwdPoller(eventBus, ptyManager);

--- a/src/main/__tests__/env-editor-fs.test.ts
+++ b/src/main/__tests__/env-editor-fs.test.ts
@@ -66,6 +66,15 @@ describe('env-editor fs ops', () => {
     expect(res.externalChange).toBe(true);
   });
 
+  it('returns missingDir instead of throwing when the parent folder is gone', () => {
+    // Simulate a folder that was renamed/deleted out from under a stale path.
+    const goneDir = join(root, 'renamed-away');
+    const p = join(goneDir, '.env');
+    const res = writeEnvFile(p, 'A=2\n');
+    expect(res.ok).toBe(false);
+    expect(res.missingDir).toBe(true);
+  });
+
   it('creates a file, rejecting non-.env names and collisions', () => {
     const { absPath } = createEnvFile(root, '.env.local');
     expect(existsSync(absPath)).toBe(true);

--- a/src/main/cwd-poller.ts
+++ b/src/main/cwd-poller.ts
@@ -42,6 +42,27 @@ export class CwdPoller {
     this.timers.set(paneId, timer);
   }
 
+  /**
+   * Resolve a pane's live cwd on demand (e.g. before opening the Env Editor, in
+   * case the folder was renamed/moved out from under the cached path). Emits a
+   * `cwd-changed` event if it differs so the rest of the app stays in sync.
+   * Returns the resolved cwd, or null if it can't be determined (no pid, or a
+   * WSL pane where pidCwd is unreliable — those only update via OSC 7).
+   */
+  async resolveNow(paneId: string, pathContext: PathContext = 'posix'): Promise<string | null> {
+    if (typeof pathContext === 'object' && pathContext.kind === 'wsl') {
+      return null;
+    }
+    const pid = this.ptyManager.getPid(paneId);
+    if (pid === undefined) return null;
+    const cwd = await readProcCwd(pid);
+    if (!cwd) return null;
+    if (cwd !== this.ptyManager.getCwd(paneId)) {
+      this.eventBus.emit('cwd-changed', { type: 'cwd-changed', paneId, cwd, source: 'poll' });
+    }
+    return cwd;
+  }
+
   markOsc7Seen(paneId: string): void {
     this.osc7Seen.add(paneId);
   }

--- a/src/main/env-editor/env-editor-fs.ts
+++ b/src/main/env-editor/env-editor-fs.ts
@@ -95,6 +95,11 @@ export function writeEnvFile(
       return { ok: false, externalChange: true, mtimeMs: current };
     }
   }
+  // The folder may have been renamed/moved out from under a stale path; report
+  // it cleanly instead of letting writeFileSync throw a cryptic temp-file ENOENT.
+  if (!existsSync(dirname(absPath))) {
+    return { ok: false, missingDir: true, mtimeMs: 0 };
+  }
   const tmp = `${absPath}.fleet-tmp-${process.pid}-${Date.now()}-${tmpCounter++}`;
   writeFileSync(tmp, text, 'utf8');
   try {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1112,6 +1112,12 @@ export function registerIpcHandlers(
     listEnvFiles(resolveCtxPath(pathContext, root))
   );
 
+  // Resolve a pane's live cwd on demand so the editor follows a renamed folder
+  // instead of using the cached (possibly stale) path.
+  ipcMain.handle(IPC_CHANNELS.PTY_RESOLVE_CWD, (_e, paneId: string, pathContext?: PathContext) =>
+    cwdPoller.resolveNow(paneId, pathContext)
+  );
+
   ipcMain.handle(IPC_CHANNELS.ENV_EDITOR_READ, (_e, absPath: string) => readEnvFile(absPath));
 
   ipcMain.handle(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -221,7 +221,9 @@ const fleetApi = {
     onExit: (callback: (payload: PtyExitPayload) => void): Unsubscribe =>
       onChannel(IPC_CHANNELS.PTY_EXIT, callback),
     onCwd: (callback: (payload: PtyCwdPayload) => void): Unsubscribe =>
-      onChannel(IPC_CHANNELS.PTY_CWD, callback)
+      onChannel(IPC_CHANNELS.PTY_CWD, callback),
+    resolveCwd: (paneId: string, pathContext?: PathContext): Promise<string | null> =>
+      typedInvoke(IPC_CHANNELS.PTY_RESOLVE_CWD, paneId, pathContext)
   },
   layout: {
     save: async (req: LayoutSaveRequest): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import {
   Terminal,
@@ -146,6 +146,9 @@ export function App(): React.JSX.Element {
   );
   const settings = useSettingsStore((s) => s.settings);
   const focusedPaneCwd = useCwdStore((s) => (activePaneId ? s.cwds.get(activePaneId) : undefined));
+  // Stable per-pane reference so consumers can safely use it in effect deps
+  // (getPaneContextById returns a fresh object for WSL panes on every call).
+  const activePathContext = useMemo(() => getPaneContextById(activePaneId), [activePaneId]);
 
   // Track serialized pane content for restored tabs (consumed once on mount)
   const restoredPanesRef = useRef<Map<string, Map<string, string>>>(new Map());
@@ -1090,7 +1093,8 @@ export function App(): React.JSX.Element {
         isOpen={envEditorOpen}
         onClose={() => setEnvEditorOpen(false)}
         cwd={focusedPaneCwd}
-        pathContext={getPaneContextById(activePaneId)}
+        paneId={activePaneId}
+        pathContext={activePathContext}
       />
       <AnnotateModal open={false} onClose={() => {}} />
       <ToolsConfigModal open={toolsConfigOpen} onClose={() => setToolsConfigOpen(false)} />

--- a/src/renderer/src/components/env-editor/EnvEditorModal.tsx
+++ b/src/renderer/src/components/env-editor/EnvEditorModal.tsx
@@ -32,11 +32,13 @@ export function EnvEditorModal({
   isOpen,
   onClose,
   cwd,
+  paneId,
   pathContext
 }: {
   isOpen: boolean;
   onClose: () => void;
   cwd: string | undefined;
+  paneId: string | null;
   pathContext?: PathContext;
 }): React.JSX.Element | null {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -57,10 +59,6 @@ export function EnvEditorModal({
   const [newFileOpen, setNewFileOpen] = useState(false);
   const [newFileError, setNewFileError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (isOpen) setRoot(cwd);
-  }, [isOpen, cwd]);
-
   const reload = useCallback(async () => {
     if (!root) {
       setFiles([]);
@@ -70,13 +68,29 @@ export function EnvEditorModal({
     setFiles(list);
   }, [root, pathContext]);
 
+  // On open, resolve the pane's live cwd (in case the folder was renamed/moved
+  // out from under the cached path), then list from it — one round-trip, no
+  // stale-root flash.
   useEffect(() => {
-    if (isOpen) {
-      setError(null);
-      setExternalChange(false);
-      void reload();
-    }
-  }, [isOpen, reload]);
+    if (!isOpen) return;
+    let cancelled = false;
+    setError(null);
+    setExternalChange(false);
+    void (async () => {
+      let activeRoot = cwd;
+      if (paneId) {
+        const live = await window.fleet.pty.resolveCwd(paneId, pathContext);
+        if (cancelled) return;
+        if (live) activeRoot = live;
+      }
+      setRoot(activeRoot);
+      const list = activeRoot ? await window.fleet.envEditor.list(activeRoot, pathContext) : [];
+      if (!cancelled) setFiles(list);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, cwd, paneId, pathContext]);
 
   useEffect(() => {
     if (isOpen) panelRef.current?.focus();
@@ -151,8 +165,10 @@ export function EnvEditorModal({
     if (dir !== null) {
       setSelected(null);
       setRoot(dir);
+      const list = await window.fleet.envEditor.list(dir, pathContext);
+      setFiles(list);
     }
-  }, []);
+  }, [pathContext]);
 
   const writeFile = useCallback(
     async (force: boolean) => {
@@ -168,6 +184,12 @@ export function EnvEditorModal({
         );
         if (!res.ok && res.externalChange) {
           setExternalChange(true);
+          return;
+        }
+        if (!res.ok && res.missingDir) {
+          showToast(
+            'This folder no longer exists — it may have been moved or deleted. Run `cd` in the terminal to refresh.'
+          );
           return;
         }
         setOriginalText(text);

--- a/src/shared/env-editor-types.ts
+++ b/src/shared/env-editor-types.ts
@@ -21,10 +21,15 @@ export const EnvReadResultSchema = z.object({
 });
 export type EnvReadResult = z.infer<typeof EnvReadResultSchema>;
 
-/** ok:false + externalChange:true means the file changed on disk since read. */
+/**
+ * ok:false + externalChange:true means the file changed on disk since read.
+ * ok:false + missingDir:true means the parent folder no longer exists (e.g. it
+ * was renamed or moved out from under a stale path).
+ */
 export const EnvWriteResultSchema = z.object({
   ok: z.boolean(),
   externalChange: z.boolean().optional(),
+  missingDir: z.boolean().optional(),
   mtimeMs: z.number()
 });
 export type EnvWriteResult = z.infer<typeof EnvWriteResultSchema>;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -8,6 +8,7 @@ export const IPC_CHANNELS = {
   PTY_EXIT: 'pty:exit',
   PTY_GC: 'pty:gc',
   PTY_CWD: 'pty:cwd',
+  PTY_RESOLVE_CWD: 'pty:resolve-cwd',
   LAYOUT_SAVE: 'layout:save',
   LAYOUT_LOAD: 'layout:load',
   LAYOUT_LIST: 'layout:list',


### PR DESCRIPTION
## Summary
- Fixes a bug where editing a `.env` failed with a cryptic `ENOENT: ... .env.fleet-tmp-...` after renaming the folder you were `cd`'d into. The Env Editor used the pane's **cached** cwd, which goes stale after a rename (no `cd` fires, so neither OSC 7 nor the already-stopped poller updates it), so the atomic temp-file write landed in a directory that no longer existed.
- **Root cause fix:** resolve the pane's *live* cwd on demand when the editor opens — new `CwdPoller.resolveNow()` + `pty:resolve-cwd` IPC + `window.fleet.pty.resolveCwd`. The modal now resolves first, then lists once (no stale-root flash / double IPC), so it follows the renamed folder. `resolveNow` also emits `cwd-changed`, re-syncing the rest of the app.
- **Backstop:** `writeEnvFile` returns `{ ok: false, missingDir: true }` when the parent folder is truly gone (deleted), and the modal shows a clear toast and stays open instead of throwing a raw ENOENT.
- Memoized the active pane's `pathContext` in `App.tsx` so the open effect doesn't churn on every re-render for WSL panes.

## Test plan
- [x] `npm run typecheck` (node + web) passes
- [x] New unit tests pass — `env-editor-fs` (missing-dir write returns `missingDir`, reproduces the original ENOENT) and `cwd-poller` (`resolveNow` resolves/emits, returns null for WSL/no-pid)
- [x] Lint clean on all changed files (0 errors)
- [ ] Manual smoke: `cd` into a folder, rename it, open the Env Editor → it lists/saves against the renamed folder; delete the folder → save shows the clear toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)