### PR TITLE
feat(kanban): SDLC pipeline templates (#234)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-sdlc-pipeline-templates.md
+++ b/docs/superpowers/plans/2026-06-16-sdlc-pipeline-templates.md
@@ -1,0 +1,1851 @@
+# SDLC Pipeline Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add selectable pipeline templates so a `full_feature` ticket flows automatically through explore → spec → (human approval gate) → implement → review → QA while `quick_fix`/NULL keeps today's lightweight work → review flow unchanged.
+
+**Architecture:** A pipeline template is a code-defined ordered list of stages. `template-expander.ts` (mirroring `kanban-swarm.ts`'s `createSwarm`) deterministically lays down explore/spec/gate/qa tasks plus `task_links`; only the implement-children fan-out is LLM-decided by the architect at the spec stage. The approval gate is a `blocked` task released by an `approve_spec` proposal (PM-agent-independent, built on #233). Stage identity lives in `tasks.pipeline_stage`; QA gates the feature PR via `features.qa_verdict`. No new tables, no new process — the existing dispatcher tick drives everything.
+
+**Tech Stack:** Electron + electron-vite + React + TypeScript, better-sqlite3, zod, vitest.
+
+---
+
+## Conventions every task must follow
+
+- Verify with `npm run typecheck` (node + web), `npm run lint` (only NEW issues matter — repo lint is pre-existing-red), and `npx vitest run <file>` for the touched test. Vitest does NOT run typecheck.
+- **No unsafe type assertions in `src/`**: use zod for runtime validation, never `as` casts or `eslint-disable`. Casts are allowed ONLY in `*.test.ts` files.
+- Main/preload output ESM; never use `__dirname`.
+- `SCHEMA_SQL` runs BEFORE migrations: add new columns to the `CREATE TABLE` in `schema.ts` (columns only) AND via `addColumnIfMissing` in the migration block. Never put an index on a migration-added column in `SCHEMA_SQL`.
+- Surgical changes; match existing style; do not refactor unrelated code.
+- Commit each task with a conventional-commit message and this EXACT footer (use a HEREDOC commit):
+
+```
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Task 1 — Schema + migration + store accessors (SCHEMA_VERSION 17 → 18)
+
+**Files**
+- Modify: `src/main/kanban/schema.ts` (`SCHEMA_VERSION` line 1; `tasks` CREATE TABLE ~line 54 after `system_kind`; `features` CREATE TABLE ~line 137 after `pr_skip_notified`)
+- Modify: `src/main/kanban/kanban-store.ts` (`migrate()` ~line 255 after the `current < 17` block; `rowToTask` ~line 336; `rowToFeature` ~line 1450; new `setQaVerdict` near `setReviewVerdict` ~line 1915)
+- Modify: `src/main/__tests__/kanban-store.test.ts` (10 `toBe(17)` assertions), `src/main/__tests__/kanban-review-store.test.ts` (1 `toBe(17)`)
+- Test: `src/main/__tests__/kanban-store.test.ts`
+
+Steps:
+
+- [ ] In `src/main/kanban/schema.ts` bump the version:
+
+```ts
+export const SCHEMA_VERSION = 18;
+```
+
+- [ ] In `schema.ts`, add the two task columns to the `tasks` CREATE TABLE, immediately after the `system_kind TEXT,` line (columns only, NO index):
+
+```ts
+  system_kind TEXT,
+  pipeline_template TEXT,
+  pipeline_stage TEXT,
+  created_at INTEGER NOT NULL,
+```
+
+- [ ] In `schema.ts`, add the feature column to the `features` CREATE TABLE, immediately after `pr_skip_notified INTEGER NOT NULL DEFAULT 0,`:
+
+```ts
+  pr_skip_notified INTEGER NOT NULL DEFAULT 0,
+  qa_verdict TEXT,
+  created_at INTEGER NOT NULL,
+```
+
+- [ ] In `kanban-store.ts` `migrate()`, add a new migration block immediately after the `if (current < 17) { ... }` block and before the `// Seed the permanent default board` comment:
+
+```ts
+    if (current < 18) {
+      // SDLC pipeline templates (#234): stage identity on tasks + a QA verdict on
+      // features. Additive, idempotent. The columns are in SCHEMA_SQL for fresh
+      // installs; add them here for existing DBs. No new indexes.
+      this.addColumnIfMissing('tasks', 'pipeline_template', 'TEXT');
+      this.addColumnIfMissing('tasks', 'pipeline_stage', 'TEXT');
+      this.addColumnIfMissing('features', 'qa_verdict', 'TEXT');
+    }
+```
+
+- [ ] In `kanban-store.ts` `rowToTask`, add the two fields right after the `systemKind: ...` line:
+
+```ts
+      systemKind: (r.system_kind as string | null) ?? null,
+      pipelineTemplate: (r.pipeline_template as Task['pipelineTemplate']) ?? null,
+      pipelineStage: (r.pipeline_stage as Task['pipelineStage']) ?? null,
+      createdAt: Number(r.created_at),
+```
+
+- [ ] In `kanban-store.ts` `createTask`, add the two columns to the INSERT. Update the column list and VALUES list to include `pipeline_template, pipeline_stage` (after `system_kind`), and add to the `.run({...})` object after `system_kind`:
+
+```ts
+        system_kind: input.systemKind ?? null,
+        pipeline_template: input.pipelineTemplate ?? null,
+        pipeline_stage: input.pipelineStage ?? null,
+        max_runtime_seconds: input.maxRuntimeSeconds ?? null,
+```
+
+(Also add `pipeline_template, pipeline_stage` to the SQL column names list and `@pipeline_template, @pipeline_stage` to the VALUES list, both right after `system_kind`/`@system_kind`.)
+
+- [ ] In `kanban-store.ts` `rowToFeature`, add the field right after `prSkipNotified`:
+
+```ts
+      prSkipNotified: Number(r.pr_skip_notified ?? 0) === 1,
+      qaVerdict: (r.qa_verdict as Feature['qaVerdict']) ?? null,
+      createdAt: Number(r.created_at),
+```
+
+- [ ] In `kanban-store.ts`, add a `setQaVerdict` accessor immediately after `setReviewVerdict` (~line 1915):
+
+```ts
+  /** Record the feature-level QA verdict (pipeline §8). null clears it. */
+  setQaVerdict(featureId: string, verdict: 'pass' | 'request_changes' | null): void {
+    this.db
+      .prepare('UPDATE features SET qa_verdict=@v, updated_at=@ts WHERE id=@id')
+      .run({ id: featureId, v: verdict, ts: this.now() });
+  }
+```
+
+- [ ] Bump every `toBe(17)` to `toBe(18)`. In `src/main/__tests__/kanban-store.test.ts` these are at lines 28, 37, 44, 75, 100, 121, 144, 166, 593, 1017 (10 total). In `src/main/__tests__/kanban-review-store.test.ts` line 11 (1 total). Use search-and-replace `toBe(17)` → `toBe(18)` in those two files only. (Note: the spec said "12" / "10+1"; the real repo has exactly 11 — 10 + 1.)
+
+- [ ] Add a migration test for the new columns. Append to `src/main/__tests__/kanban-store.test.ts` inside the top-level describe (near the existing schema-version tests):
+
+```ts
+  it('persists pipeline columns and qa verdict at schema v18', () => {
+    const store = makeStore();
+    expect(store.schemaVersion()).toBe(18);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const t = store.createTask({
+      title: 'root',
+      pipelineTemplate: 'full_feature',
+      pipelineStage: 'explore',
+      featureId: f.id
+    });
+    const got = store.getTask(t.id);
+    expect(got?.pipelineTemplate).toBe('full_feature');
+    expect(got?.pipelineStage).toBe('explore');
+    store.setQaVerdict(f.id, 'pass');
+    expect(store.getFeature(f.id)?.qaVerdict).toBe('pass');
+    store.close();
+  });
+```
+
+(Use the file's existing `makeStore()` helper — match how the surrounding tests construct a store. If the local helper is named differently or takes args, mirror the nearest existing schema test in the same file.)
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-store.test.ts src/main/__tests__/kanban-review-store.test.ts` — expect all green (the new test passes, all `toBe(18)` pass). Then `npm run typecheck` — note it will FAIL until Task 2 adds the type fields; that is expected. To make this task self-verifiable, Task 2's type changes are a hard prerequisite for typecheck; run only vitest here and defer typecheck to Task 2.
+
+- [ ] Commit:
+
+```
+feat(kanban): schema v18 pipeline columns + qa_verdict + setQaVerdict
+```
+
+---
+
+## Task 2 — Shared types (RunMode, role, PmProposalKind, pipeline types)
+
+**Files**
+- Modify: `src/shared/kanban-types.ts` (`RunMode` ~line 18; `Task` ~line 239; `Feature` ~line 97; `PmProposalKind` ~line 296; `PM_PROPOSAL_KINDS` ~line 320; `CreateTaskInput` ~line 404)
+- Modify: `src/shared/types.ts` (`WorkerProfile.role` line 150)
+- Test: type-only change; verified by `npm run typecheck`
+
+Steps:
+
+- [ ] In `src/shared/kanban-types.ts`, extend `RunMode` (keep the leading-comment intact):
+
+```ts
+export type RunMode =
+  | 'work'
+  | 'decompose'
+  | 'specify'
+  | 'assign'
+  | 'resolve'
+  | 'suggest'
+  | 'verify'
+  | 'review'
+  | 'explore'
+  | 'spec'
+  | 'qa';
+```
+
+- [ ] In `src/shared/kanban-types.ts`, add the two pipeline string-literal unions just below the `RunMode` definition:
+
+```ts
+/** A pipeline template id carried on the root task. NULL ⇒ behaves as quick_fix. */
+export type PipelineTemplateId = 'full_feature' | 'quick_fix';
+
+/** Stage identity carried by generated pipeline tasks. NULL ⇒ ordinary non-pipeline task. */
+export type StageKind = 'explore' | 'spec' | 'gate' | 'implement' | 'review' | 'qa';
+```
+
+- [ ] In `src/shared/kanban-types.ts`, add fields to the `Task` interface, right after `systemKind: string | null;`:
+
+```ts
+  systemKind: string | null;
+  /** Template carried by the root task (NULL ⇒ quick_fix / non-pipeline). */
+  pipelineTemplate: PipelineTemplateId | null;
+  /** Stage identity for a generated pipeline task (NULL ⇒ non-pipeline). */
+  pipelineStage: StageKind | null;
+  createdAt: number;
+```
+
+- [ ] In `src/shared/kanban-types.ts`, add the field to the `Feature` interface, right after `prSkipNotified: boolean;`:
+
+```ts
+  prSkipNotified: boolean;
+  /** Feature-level QA verdict (pipeline §8). NULL ⇒ not yet QA'd / non-pipeline. */
+  qaVerdict: 'pass' | 'request_changes' | null;
+  createdAt: number;
+```
+
+- [ ] In `src/shared/kanban-types.ts`, extend `PmProposalKind`:
+
+```ts
+export type PmProposalKind =
+  | 'merge_review_task'
+  | 'create_pr_for_task'
+  | 'accept_review_task'
+  | 'ship_feature'
+  | 'complete_task'
+  | 'archive_task'
+  | 'approve_spec';
+```
+
+- [ ] In `src/shared/kanban-types.ts`, add `'approve_spec'` to `PM_PROPOSAL_KINDS`:
+
+```ts
+export const PM_PROPOSAL_KINDS = [
+  'merge_review_task',
+  'create_pr_for_task',
+  'accept_review_task',
+  'ship_feature',
+  'complete_task',
+  'archive_task',
+  'approve_spec'
+] as const satisfies readonly PmProposalKind[];
+```
+
+- [ ] In `src/shared/kanban-types.ts`, add to `CreateTaskInput`, right after `systemKind?: string | null;`:
+
+```ts
+  systemKind?: string | null;
+  pipelineTemplate?: PipelineTemplateId | null;
+  pipelineStage?: StageKind | null;
+}
+```
+
+- [ ] In `src/shared/types.ts` line 150, extend `WorkerProfile.role`:
+
+```ts
+  role: 'worker' | 'orchestrator' | 'reviewer' | 'explorer' | 'architect' | 'qa'; // orchestrator drives decompose/specify; reviewer drives code-review runs; explorer/architect/qa drive pipeline stages
+```
+
+- [ ] Run: `npm run typecheck` — expect green (Task 1's store fields now satisfy the new `Task`/`Feature`/`CreateTaskInput` shapes). Then `npx vitest run src/main/__tests__/kanban-store.test.ts` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): pipeline run modes, roles, proposal kind, and shared types
+```
+
+---
+
+## Task 3 — pipeline-templates.ts (template constants + getTemplate lookup)
+
+**Files**
+- Create: `src/main/kanban/pipeline-templates.ts`
+- Create: `src/main/__tests__/pipeline-templates.test.ts`
+- Test: `src/main/__tests__/pipeline-templates.test.ts`
+
+Steps:
+
+- [ ] Create `src/main/kanban/pipeline-templates.ts`:
+
+```ts
+import type { PipelineTemplateId, StageKind } from '../../shared/kanban-types';
+
+export interface PipelineTemplate {
+  id: PipelineTemplateId;
+  /**
+   * Ordered stages the expander lays down. Excludes the LLM-fanned implement
+   * children + their per-child review, which the architect emits at the spec stage.
+   */
+  stages: StageKind[];
+}
+
+/** Max implement children the architect may fan out at the spec stage (spec §5). */
+export const MAX_FANOUT = 12;
+
+/** QA request_changes re-arm cycles before the feature is blocked (spec §8). */
+export const QA_ATTEMPT_CAP = 2;
+
+export const FULL_FEATURE: PipelineTemplate = {
+  id: 'full_feature',
+  stages: ['explore', 'spec', 'gate', 'qa']
+};
+
+export const QUICK_FIX: PipelineTemplate = {
+  id: 'quick_fix',
+  // No expansion: the root task runs today's work → review flow unchanged.
+  stages: []
+};
+
+/** Look up a template by id. Returns QUICK_FIX for null/unknown (the inert default). */
+export function getTemplate(id: PipelineTemplateId | null | undefined): PipelineTemplate {
+  return id === 'full_feature' ? FULL_FEATURE : QUICK_FIX;
+}
+```
+
+- [ ] Create `src/main/__tests__/pipeline-templates.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  FULL_FEATURE,
+  QUICK_FIX,
+  getTemplate,
+  MAX_FANOUT,
+  QA_ATTEMPT_CAP
+} from '../kanban/pipeline-templates';
+
+describe('pipeline-templates', () => {
+  it('FULL_FEATURE lays down explore → spec → gate → qa', () => {
+    expect(FULL_FEATURE.id).toBe('full_feature');
+    expect(FULL_FEATURE.stages).toEqual(['explore', 'spec', 'gate', 'qa']);
+  });
+
+  it('QUICK_FIX is inert (no stages)', () => {
+    expect(QUICK_FIX.id).toBe('quick_fix');
+    expect(QUICK_FIX.stages).toEqual([]);
+  });
+
+  it('getTemplate resolves full_feature and falls back to quick_fix', () => {
+    expect(getTemplate('full_feature')).toBe(FULL_FEATURE);
+    expect(getTemplate('quick_fix')).toBe(QUICK_FIX);
+    expect(getTemplate(null)).toBe(QUICK_FIX);
+    expect(getTemplate(undefined)).toBe(QUICK_FIX);
+  });
+
+  it('caps are the spec values', () => {
+    expect(MAX_FANOUT).toBe(12);
+    expect(QA_ATTEMPT_CAP).toBe(2);
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/pipeline-templates.test.ts` — expect 4 passing. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): pipeline template constants + getTemplate lookup
+```
+
+---
+
+## Task 4 — template-expander.ts (deterministic graph, idempotent, role fallback)
+
+**Files**
+- Create: `src/main/kanban/template-expander.ts`
+- Create: `src/main/__tests__/template-expander.test.ts`
+- Test: `src/main/__tests__/template-expander.test.ts`
+
+Context: this mirrors `createSwarm` in `kanban-swarm.ts`. The store passed in exposes `createTask`, `addLink`, `getTask`, `createFeature`, `getFeature`, `blockTask`, `appendEvent`, `listEvents`. `appendEvent(taskId, runId, kind, payload?)` and `listEvents(taskId)` already exist. Idempotency uses a `pipeline_expanded` event on the root.
+
+Steps:
+
+- [ ] Create `src/main/kanban/template-expander.ts`:
+
+```ts
+import { createLogger } from '../logger';
+import type { KanbanStore } from './kanban-store';
+import type { Task } from '../../shared/kanban-types';
+import type { PipelineTemplate } from './pipeline-templates';
+
+const log = createLogger('template-expander');
+
+/** Profile roles the full_feature pipeline requires; missing any ⇒ fall back to quick_fix. */
+const REQUIRED_ROLES = ['explorer', 'architect', 'qa'] as const;
+
+/** Event kind written on the root once expansion has run, for reclaim-safe idempotency. */
+export const PIPELINE_EXPANDED_EVENT = 'pipeline_expanded';
+
+export interface ExpanderDeps {
+  /** Profile names present per role, used for the graceful-degradation check. */
+  hasRole: (role: string) => boolean;
+}
+
+/**
+ * Lay down the full_feature skeleton for a triage root task, mirroring createSwarm:
+ * ensure a feature, then create explore(ready) → spec(todo) → gate(blocked) → qa(todo)
+ * with the gating links. The implement-children fan-out is NOT created here — the
+ * architect emits it at the spec stage (§5). Idempotent: re-running is a no-op once
+ * the PIPELINE_EXPANDED_EVENT is present. Falls back to quick_fix (no expansion) if a
+ * required role profile is missing.
+ */
+export function expandTemplate(
+  root: Task,
+  template: PipelineTemplate,
+  store: KanbanStore,
+  deps: ExpanderDeps
+): void {
+  if (template.id !== 'full_feature') return; // quick_fix / inert: no expansion
+
+  // Idempotency: a prior expansion left an event on the root.
+  if (store.listEvents(root.id).some((e) => e.kind === PIPELINE_EXPANDED_EVENT)) {
+    return;
+  }
+
+  // Graceful degradation: a missing SDLC role makes the pipeline unrunnable, so
+  // degrade to quick_fix (root runs the normal flow) rather than wedging.
+  const missing = REQUIRED_ROLES.filter((r) => !deps.hasRole(r));
+  if (missing.length > 0) {
+    log.warn('pipeline role(s) missing; falling back to quick_fix', {
+      rootId: root.id,
+      missing
+    });
+    store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, {
+      fallback: 'quick_fix',
+      missing
+    });
+    return; // root stays a triage task and runs today's flow
+  }
+
+  store.transaction(() => {
+    // 1. Ensure the root has a feature so all stages ship as one unit.
+    let featureId = root.featureId;
+    if (!featureId) {
+      const feature = store.createFeature({
+        boardId: root.boardId,
+        name: root.title,
+        repoPath: root.repoPath,
+        baseBranch: root.baseBranch
+      });
+      featureId = feature.id;
+      store.setFeatureId(root.id, featureId);
+    }
+
+    const common = {
+      boardId: root.boardId,
+      featureId,
+      repoPath: root.repoPath ?? undefined,
+      baseBranch: root.baseBranch ?? null,
+      priority: root.priority
+    };
+
+    // 2. explore (read-only mapping) — starts ready so it spawns immediately.
+    const explore = store.createTask({
+      title: `Explore: ${root.title}`,
+      body:
+        `Map the codebase relevant to root task ${root.id}: affected files/modules/patterns, ` +
+        `risks and unknowns. Write NO code. Register findings as a kanban_artifact and post a ` +
+        `one-paragraph summary comment on ${root.id}.\n\nRoot:\n${root.body}`,
+      assignee: 'explorer',
+      status: 'ready',
+      pipelineStage: 'explore',
+      ...common
+    });
+
+    // 3. spec (architect) — gated on explore.
+    const spec = store.createTask({
+      title: `Spec: ${root.title}`,
+      body:
+        `Read the explore artifact + root task ${root.id}, write a concrete implementation spec, ` +
+        `then fan out implementation work by calling kanban_create once per unit (the create path ` +
+        `wires links + feature for you). Do not implement. Root:\n${root.body}`,
+      assignee: 'architect',
+      status: 'todo',
+      pipelineStage: 'spec',
+      ...common
+    });
+    store.addLink(explore.id, spec.id);
+
+    // 4. gate — blocked; only executeProposal('approve_spec') moves it to done.
+    const gate = store.createTask({
+      title: `Approve spec: ${root.title}`,
+      body: `Spec approval gate for feature ${featureId}. Released only by an approve_spec proposal.`,
+      status: 'blocked',
+      systemKind: 'pipeline_gate',
+      pipelineStage: 'gate',
+      ...common
+    });
+    store.addLink(spec.id, gate.id);
+
+    // 5. qa — gated on the gate (baseline; implement children also link → qa in §5).
+    const qa = store.createTask({
+      title: `QA: ${root.title}`,
+      body:
+        `Validate feature ${featureId} against root task ${root.id}'s acceptance criteria. Run the ` +
+        `project verify commands, exercise end-to-end behavior, check explore-identified risks, then ` +
+        `emit a verdict.`,
+      assignee: 'qa',
+      status: 'todo',
+      pipelineStage: 'qa',
+      ...common
+    });
+    store.addLink(gate.id, qa.id);
+
+    // 6. Idempotency marker + audit record of the laid-down graph.
+    store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, {
+      featureId,
+      exploreId: explore.id,
+      specId: spec.id,
+      gateId: gate.id,
+      qaId: qa.id
+    });
+    // The root is the planning anchor; complete it so it doesn't sit in triage.
+    store.completeTask(root.id, 'Pipeline expanded; stages laid down.');
+  });
+}
+```
+
+- [ ] In `src/main/kanban/kanban-store.ts`, add a `setFeatureId` accessor (the expander calls it; verify it does not already exist — if it does, skip this step). Add near `setStatus` (~line 1797):
+
+```ts
+  /** Attach a task to a feature (pipeline expander backfills the root's feature). */
+  setFeatureId(taskId: string, featureId: string): void {
+    this.db
+      .prepare('UPDATE tasks SET feature_id=@f, updated_at=@ts WHERE id=@id')
+      .run({ id: taskId, f: featureId, ts: this.now() });
+  }
+```
+
+- [ ] Create `src/main/__tests__/template-expander.test.ts` (mirrors the swarm test structure — real store, tmp db):
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { KanbanStore } from '../kanban/kanban-store';
+import { expandTemplate, PIPELINE_EXPANDED_EVENT } from '../kanban/template-expander';
+import { FULL_FEATURE, QUICK_FIX } from '../kanban/pipeline-templates';
+
+const DIR = join(tmpdir(), `fleet-expander-test-${Date.now()}`);
+const allRoles = { hasRole: () => true };
+
+function store(): KanbanStore {
+  return new KanbanStore(join(DIR, `e-${Math.random()}.db`), { now: () => 1000 });
+}
+
+function stageOf(s: KanbanStore, id: string): string | null {
+  return s.getTask(id)?.pipelineStage ?? null;
+}
+
+describe('expandTemplate', () => {
+  beforeEach(() => mkdirSync(DIR, { recursive: true }));
+  afterEach(() => rmSync(DIR, { recursive: true, force: true }));
+
+  it('lays down explore→spec→gate→qa with the gating links + a feature', () => {
+    const s = store();
+    const root = s.createTask({ title: 'Add billing', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, allRoles);
+
+    const ev = s.listEvents(root.id).find((e) => e.kind === PIPELINE_EXPANDED_EVENT);
+    expect(ev).toBeTruthy();
+    const { exploreId, specId, gateId, qaId, featureId } = ev!.payload as Record<string, string>;
+
+    expect(s.getFeature(featureId)).toBeTruthy();
+    expect(stageOf(s, exploreId)).toBe('explore');
+    expect(s.getTask(exploreId)?.status).toBe('ready');
+    expect(stageOf(s, specId)).toBe('spec');
+    expect(s.getTask(specId)?.status).toBe('todo');
+    expect(stageOf(s, gateId)).toBe('gate');
+    expect(s.getTask(gateId)?.status).toBe('blocked');
+    expect(s.getTask(gateId)?.systemKind).toBe('pipeline_gate');
+    expect(stageOf(s, qaId)).toBe('qa');
+
+    // Links: explore→spec, spec→gate, gate→qa.
+    expect(s.childrenOf(exploreId)).toContain(specId);
+    expect(s.childrenOf(specId)).toContain(gateId);
+    expect(s.childrenOf(gateId)).toContain(qaId);
+    s.close();
+  });
+
+  it('is a no-op on re-run (idempotent)', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, allRoles);
+    const before = s.listTasks().length;
+    expandTemplate(s.getTask(root.id)!, FULL_FEATURE, s, allRoles);
+    expect(s.listTasks().length).toBe(before);
+    s.close();
+  });
+
+  it('falls back to quick_fix when a required role profile is missing', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, { hasRole: (r) => r !== 'qa' });
+    // No stages created; only the fallback marker event.
+    expect(s.listTasks().some((t) => t.pipelineStage !== null)).toBe(false);
+    const ev = s.listEvents(root.id).find((e) => e.kind === PIPELINE_EXPANDED_EVENT);
+    expect((ev!.payload as Record<string, unknown>).fallback).toBe('quick_fix');
+    s.close();
+  });
+
+  it('does not expand quick_fix / inert template', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'quick_fix' });
+    expandTemplate(root, QUICK_FIX, s, allRoles);
+    expect(s.listTasks().some((t) => t.pipelineStage !== null)).toBe(false);
+    s.close();
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/template-expander.test.ts` — expect 4 passing. Then `npm run typecheck` — expect green. (If `setFeatureId` already existed and you skipped adding it, confirm no duplicate-method TS error.)
+
+- [ ] Commit:
+
+```
+feat(kanban): template-expander lays down full_feature stage graph
+```
+
+---
+
+## Task 5 — Dispatcher decompose routing to the expander
+
+**Files**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`decompose()` ~line 436; imports ~line 1-20; add a `hasRole`/profiles dep to `DispatcherDeps` ~line 124)
+- Modify: `src/main/__tests__/kanban-dispatcher.test.ts` (add a describe block)
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+Context: `decompose()` iterates `store.pendingDecomposeTasks()` (triage tasks with a pending mode) and spawns an orchestrator run. A `full_feature` root should be routed to `expandTemplate` instead of spawning the orchestrator. The expander needs a `hasRole` predicate; add it as a dispatcher dep sourced from the profile list.
+
+Steps:
+
+- [ ] In `kanban-dispatcher.ts`, add imports at the top (after the existing `import { readLogTail } from './spawn-worker';`):
+
+```ts
+import { expandTemplate } from './template-expander';
+import { getTemplate } from './pipeline-templates';
+```
+
+- [ ] In `kanban-dispatcher.ts`, add to `DispatcherDeps` (after `workerProfileNames?`):
+
+```ts
+  /** All profile role names present, for the pipeline expander's graceful-degradation check. */
+  profileRoles?: () => string[];
+```
+
+- [ ] In `kanban-dispatcher.ts` `decompose()`, route full_feature roots to the expander before the orchestrator spawn. Replace the loop body's start (right after `if (!this.store.claimForDecompose(task.id, lock, ttl)) continue;`) — but the gate must be claimed first to avoid double work. Insert this BEFORE the `let runId` line, inside the `try`-free path:
+
+```ts
+    for (const task of this.store.pendingDecomposeTasks()) {
+      if (slots <= 0) break;
+      const mode = task.pendingMode;
+      if (mode == null) continue;
+
+      // Full-feature pipeline roots are expanded deterministically (no orchestrator).
+      if (task.pipelineTemplate === 'full_feature') {
+        const lock = this.nextLock();
+        if (!this.store.claimForDecompose(task.id, lock, ttl)) continue;
+        const roles = new Set(this.deps.profileRoles?.() ?? []);
+        try {
+          expandTemplate(task, getTemplate(task.pipelineTemplate), this.store, {
+            hasRole: (r) => roles.has(r)
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.store.blockTask(task.id, `pipeline expansion failed: ${msg}`);
+          log.error('pipeline expand failed', { taskId: task.id, error: msg });
+        }
+        slots -= 1;
+        continue;
+      }
+
+      const lock = this.nextLock();
+      if (!this.store.claimForDecompose(task.id, lock, ttl)) continue; // lost the race
+      let runId: number | null = null;
+      // ... (existing orchestrator spawn body unchanged)
+```
+
+(The existing `const mode = task.pendingMode; if (mode == null) continue;` and the following orchestrator body remain; only the full_feature branch and the lock-declaration move are new. Ensure `lock` is declared once per iteration — the original declared it after the `mode` check, so keep that single declaration for the orchestrator path and use a locally-scoped `lock` inside the pipeline `if` block as shown.)
+
+- [ ] In `src/main/kanban/kanban-ipc.ts` (or wherever the dispatcher is constructed — search for `new KanbanDispatcher`), wire `profileRoles` from the settings profile list. Find the existing `workerProfileNames` dep and add alongside it:
+
+```ts
+      profileRoles: () => (getProfiles() ?? []).map((p) => p.role),
+```
+
+(Use the same profile-source function already used for `workerProfileNames` in that construction site; mirror its exact call.)
+
+- [ ] Add a dispatcher test. Append to `src/main/__tests__/kanban-dispatcher.test.ts`:
+
+```ts
+describe('KanbanDispatcher.decompose pipeline routing', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('routes a full_feature triage root to the expander, not the orchestrator', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const root = store.createTask({
+      title: 'Add billing',
+      status: 'triage',
+      pipelineTemplate: 'full_feature'
+    });
+    store.setPendingMode(root.id, 'decompose');
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => {
+        spawned += 1;
+        return 1;
+      },
+      profileRoles: () => ['explorer', 'architect', 'qa', 'worker'],
+      config: {
+        failureLimit: 2,
+        claimGraceMs: 0,
+        maxInProgress: 3,
+        claimTtlMs: 1000,
+        autoDecompose: false,
+        autoAssign: false,
+        autoIntegrate: false,
+        autoReview: false,
+        maxDecompose: 1,
+        artifactRetentionDays: 0
+      }
+    });
+    disp.decompose();
+    expect(spawned).toBe(0); // expander runs in-process; no orchestrator spawn
+    const stages = store.listTasks().map((t) => t.pipelineStage).filter(Boolean).sort();
+    expect(stages).toEqual(['explore', 'gate', 'qa', 'spec']);
+    store.close();
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts` — expect green (existing + new). Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): route full_feature triage roots to the template expander
+```
+
+---
+
+## Task 6 — Explore stage (prompt + read-only tools + spawn path)
+
+**Files**
+- Modify: `src/main/kanban/spawn-worker.ts` (`buildPrompt` ~line 81; `requireToolsForMode` ~line 186)
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`claimAndSpawn()` ~line 394; add a stage→mode helper)
+- Modify/Create test: `src/main/__tests__/spawn-worker.test.ts` (check it exists; if not, create it)
+- Test: `src/main/__tests__/spawn-worker.test.ts`
+
+Context: `claimAndSpawn()` spawns every `readyTasks()` with `mode: 'work'`. A `pipeline_stage === 'explore'` ready task must spawn with `mode: 'explore'`. `buildPrompt` already takes `WorkerTaskInfo` (no `pipelineStage`); the dispatcher passes `mode` explicitly, so the prompt branch keys off `mode`.
+
+Steps:
+
+- [ ] In `spawn-worker.ts` `buildPrompt`, add an `explore` branch before the final `work` return (after the `review` branch, ~line 140):
+
+```ts
+  if (mode === 'explore') {
+    return (
+      `explore kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are a read-only cartographer. Map the codebase relevant to this task: affected ` +
+      `files, modules, and patterns; surface risks and unknowns. Write NO code and make NO ` +
+      `edits. Register your findings as a kanban_artifact (path relative to your working ` +
+      `directory) and post a one-paragraph summary comment on this task with kanban_comment. ` +
+      `When done, call kanban_complete with a one-line summary.`
+    );
+  }
+```
+
+- [ ] In `spawn-worker.ts` `requireToolsForMode`, add the `explore` case (terminal tool is `kanban_complete`/`kanban_block`, same family as work):
+
+```ts
+    case 'work':
+    case 'decompose':
+    case 'resolve':
+    case 'explore':
+      return 'kanban_complete,kanban_block';
+```
+
+- [ ] In `kanban-dispatcher.ts`, add a private helper to map a task's stage to its run mode, near `claimAndSpawn`:
+
+```ts
+  /** The run mode for a ready pipeline-stage task; non-pipeline ready tasks are plain 'work'. */
+  private modeForReadyTask(task: Task): RunMode {
+    if (task.pipelineStage === 'explore') return 'explore';
+    if (task.pipelineStage === 'spec') return 'spec';
+    if (task.pipelineStage === 'qa') return 'qa';
+    return 'work';
+  }
+```
+
+- [ ] In `kanban-dispatcher.ts` `claimAndSpawn()`, replace the hard-coded `mode: 'work'` in the `spawnWorker` call with the computed mode:
+
+```ts
+        const mode = this.modeForReadyTask(task);
+        pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode });
+```
+
+(Keep the `clearReviewVerdict`/`resetReviewAttempts` calls — they are harmless for pipeline stages and reset on each fresh claim.)
+
+- [ ] Add/extend a prompt-builder test. Check whether `src/main/__tests__/spawn-worker.test.ts` exists (`ls src/main/__tests__/`). If it exists, append; otherwise create it with this header importing the real `buildWorkerInvocation`/`buildPrompt`. Since `buildPrompt` is module-private, assert through the exported `buildWorkerInvocation`'s `args` (the `--prompt` value) and `--require-tool`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildWorkerInvocation } from '../kanban/spawn-worker';
+
+function ws(): string {
+  return mkdtempSync(join(tmpdir(), 'fleet-spawn-'));
+}
+const baseTask = {
+  id: 't1',
+  title: 'Add billing',
+  body: 'body',
+  assignee: 'explorer',
+  modelOverride: null
+};
+
+describe('buildWorkerInvocation explore mode', () => {
+  it('emits a read-only mapping prompt and complete/block require-tool', () => {
+    const inv = buildWorkerInvocation({
+      task: baseTask,
+      workspace: ws(),
+      mcpPort: 1,
+      runToken: 'tok',
+      logPath: '/tmp/x.log',
+      mode: 'explore'
+    });
+    const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
+    expect(prompt).toContain('explore kanban task t1');
+    expect(prompt).toContain('Write NO code');
+    expect(prompt).toContain('kanban_artifact');
+    expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_complete,kanban_block');
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/spawn-worker.test.ts src/main/__tests__/kanban-dispatcher.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): explore stage prompt, read-only tools, and spawn routing
+```
+
+---
+
+## Task 7 — Spec stage + idempotent fan-out + auto-link (create path)
+
+**Files**
+- Modify: `src/main/kanban/spawn-worker.ts` (`buildPrompt` spec branch; `requireToolsForMode` spec case)
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`claimAndSpawn` spec is `work`-family? No — spec is its own mode; extend `modeForReadyTask`. But the spec task starts `todo`, promoted to `ready` after explore completes — so it flows through `claimAndSpawn`.)
+- Modify: `src/main/kanban/kanban-mcp-server.ts` (worker-scope `kanban_create` handler ~line 1493: auto-wire links + idempotency + cap)
+- Modify: `src/main/__tests__/kanban-mcp-server.test.ts`
+- Test: `src/main/__tests__/kanban-mcp-server.test.ts`
+
+Context: when the architect (a `spec`-stage run) calls `kanban_create`, the handler must: set `pipelineStage='implement'` on the child, set the child's `featureId` to the root feature, `addLink(gateTask, child)` and `addLink(child, qaTask)`, enforce `MAX_FANOUT`, and record a `children_emitted` event on the spec task so a reclaim re-run does not double-fan-out. The handler resolves the gate/qa ids from the root's `pipeline_expanded` event (the spec task's feature → root → event). Empty-fan-out guard lives in `kanban_complete` (spec completed with zero children → block, no proposal — proposal creation is Task 8 in the dispatcher, which already won't fire on zero children).
+
+Steps:
+
+- [ ] In `spawn-worker.ts` `buildPrompt`, add a `spec` branch (after the `explore` branch):
+
+```ts
+  if (mode === 'spec') {
+    return (
+      `spec kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are the architect. Read the explore artifact and this task with kanban_show, then write ` +
+      `a concrete implementation spec. Decompose the work into independent units: call kanban_create ` +
+      `once per unit with a clear title and a body containing that unit's slice of the spec. Do NOT ` +
+      `set parents, feature_id, or links — the system wires them. Cap your fan-out at ${MAX_FANOUT} ` +
+      `children. Do not implement anything. When the fan-out is complete, call kanban_complete with a ` +
+      `one-line plan summary.`
+    );
+  }
+```
+
+- [ ] Import `MAX_FANOUT` at the top of `spawn-worker.ts`:
+
+```ts
+import { MAX_FANOUT } from './pipeline-templates';
+```
+
+- [ ] In `spawn-worker.ts` `requireToolsForMode`, add the `spec` case (terminal tool `kanban_complete`/`kanban_block`):
+
+```ts
+    case 'work':
+    case 'decompose':
+    case 'resolve':
+    case 'explore':
+    case 'spec':
+      return 'kanban_complete,kanban_block';
+```
+
+- [ ] In `kanban-store.ts`, add `pipelineAnchorForFeature` (near `getFeature`). It resolves the gate/qa ids from the root's `pipeline_expanded` event **keyed by feature** — NOT by walking parent links, because the expander does not link `root → explore` (explore is a standalone `ready` task, so a parent-walk from the spec would dead-end). The expander records `featureId` in the event payload (Task 4); query it with `json_extract`. Match the file's existing row-cast idiom (`as Record<string, unknown>` / typed-row casts are used throughout this store) and validate the extracted ids with `typeof` at runtime:
+
+```ts
+  /**
+   * Resolve a full_feature pipeline's gate/qa task ids from the root's pipeline_expanded
+   * event, keyed by feature id. Returns null for non-pipeline features or fallback
+   * expansions (which record `fallback` and no stage ids).
+   */
+  pipelineAnchorForFeature(
+    featureId: string
+  ): { gateId: string; qaId: string; featureId: string } | null {
+    const row = this.db
+      .prepare(
+        "SELECT payload FROM task_events WHERE kind='pipeline_expanded' " +
+          "AND json_extract(payload, '$.featureId')=@f " +
+          "AND json_extract(payload, '$.fallback') IS NULL LIMIT 1"
+      )
+      .get({ f: featureId }) as { payload: string } | undefined;
+    if (!row) return null;
+    const p = JSON.parse(row.payload) as Record<string, unknown>;
+    const gateId = p.gateId;
+    const qaId = p.qaId;
+    if (typeof gateId !== 'string' || typeof qaId !== 'string') return null;
+    return { gateId, qaId, featureId };
+  }
+```
+
+(Verify `appendEvent` stores `payload` as a JSON string — it does; `json_extract` requires it. better-sqlite3 ships SQLite with JSON1 enabled.)
+
+- [ ] In `kanban-mcp-server.ts`, the worker-scope `kanban_create` handler (~line 1493) must auto-wire children when the calling task is a spec stage. Add a private helper on the server class that delegates to the feature-keyed store lookup. Place it near the other private helpers:
+
+```ts
+  /** For a spec-stage task, resolve the pipeline gate/qa task ids (feature-keyed; no parent walk). */
+  private pipelineAnchor(specTask: Task): { gateId: string; qaId: string; featureId: string } | null {
+    if (specTask.pipelineStage !== 'spec' || !specTask.featureId) return null;
+    return this.store.pipelineAnchorForFeature(specTask.featureId);
+  }
+```
+
+- [ ] In the worker-scope `kanban_create` handler, after parsing `a` and the assignee guard but before `const inherit = this.inheritWorkspace(task);`, insert the spec-stage branch (so a spec run gets the deterministic wiring + cap + idempotency, and other modes keep today's behavior):
+
+```ts
+          const anchor = this.pipelineAnchor(task);
+          if (anchor) {
+            // Idempotency keyed on the RUN, not on existence of children. The first child a
+            // run creates stamps `children_emitted` with that runId. A reclaim re-run is a
+            // DIFFERENT run: if a children_emitted event from another run exists, this run's
+            // fan-out is a duplicate — reject it so the prior children stand. Within the same
+            // run, subsequent kanban_create calls share the runId and are allowed. (Dismiss
+            // re-arm deletes the event via clearSpecFanout, so a re-armed run fans out fresh.)
+            const emittedEvents = this.store
+              .listEvents(task.id)
+              .filter((e) => e.kind === 'children_emitted');
+            const priorRun = emittedEvents.find((e) => e.payload?.runId !== scope.runId);
+            if (priorRun) {
+              return this.rpcError(
+                res,
+                rpcReq.id,
+                'children already emitted by a prior run; call kanban_complete'
+              );
+            }
+            const existing = this.store
+              .childrenOf(task.id)
+              .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement').length;
+            if (existing >= MAX_FANOUT) {
+              return this.rpcError(
+                res,
+                rpcReq.id,
+                `fan-out cap reached (${MAX_FANOUT}); stop creating children and call kanban_complete`
+              );
+            }
+            const child = this.store.createTask({
+              title: a.title,
+              body: a.body ?? '',
+              assignee,
+              priority: a.priority ?? 0,
+              status: 'todo',
+              boardId: task.boardId,
+              featureId: anchor.featureId,
+              pipelineStage: 'implement',
+              ...this.inheritWorkspace(task)
+            });
+            this.store.addLink(anchor.gateId, child.id); // held until approval
+            this.store.addLink(child.id, anchor.qaId); // QA waits for it
+            this.store.appendEvent(child.id, scope.runId, 'task_created', {
+              by: 'architect',
+              parent: task.id
+            });
+            if (emittedEvents.length === 0) {
+              this.store.appendEvent(task.id, scope.runId, 'children_emitted', {
+                runId: scope.runId
+              });
+            }
+            return this.text(res, rpcReq.id, child.id);
+          }
+```
+
+(Note: `pipeline_expanded` payload uses `featureId` so the `inheritWorkspace(task)` for a spec task whose feature has a repo will produce a worktree child — the desired implement behavior. Confirm `inheritWorkspace` returns repo/baseBranch from the task; the spec task carries the feature's repo via `common` in Task 4.)
+
+- [ ] Add MCP-server tests. Append to `src/main/__tests__/kanban-mcp-server.test.ts` (cast scope/handler helpers in tests are allowed). Use the file's existing test harness for invoking a worker-scope `kanban_create`; assert topology + idempotency + cap. Pattern (adapt to the file's actual `callTool`/scope helper names):
+
+```ts
+describe('kanban_create spec-stage auto-link', () => {
+  it('wires implement children to gate + qa and is idempotent + capped', () => {
+    // Arrange: build a full_feature graph (root → explore → spec → gate → qa) via expandTemplate,
+    // then drive kanban_create as the spec run.
+    // (Use the suite's existing makeServer()/store helpers; seed explorer/architect/qa roles.)
+    // Assert each created child has pipelineStage 'implement', parent gateId, child link → qaId.
+    // Assert a re-run with children_emitted present creates no duplicate (single children_emitted event).
+    // Assert creating a 13th child returns an rpcError mentioning the cap.
+  });
+});
+```
+
+(IMPORTANT for the implementer: open `src/main/__tests__/kanban-mcp-server.test.ts`, copy the nearest existing worker-scope tool-call test's setup verbatim — how it constructs the server, registers a run/scope, and calls the tool — then fill the asserts above with real ids from the `pipeline_expanded` event. Do not invent helper names.)
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): spec-stage fan-out auto-links children to gate + qa (idempotent, capped)
+```
+
+---
+
+## Task 8 — approve_spec proposal creation (dispatcher, PM-independent)
+
+**Files**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (new private `raiseSpecApprovals()` + a call in `tick()` ~line 1159; empty-fan-out guard)
+- Modify: `src/main/__tests__/kanban-dispatcher.test.ts`
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+Context: when a `spec`-stage task reaches `done` with ≥1 implement child, the dispatcher (not a PM turn) creates an `approve_spec` proposal targeting the gate task. With zero children, the spec is blocked and NO proposal is raised. Idempotency: only raise once per spec task (guard on an event or on an existing pending/resolved proposal for the gate).
+
+Steps:
+
+- [ ] In `kanban-dispatcher.ts`, add a private method (place near `integrateFeatures`):
+
+```ts
+  /**
+   * For each freshly-done spec stage: with ≥1 implement child, create an approve_spec
+   * proposal targeting the gate task (PM-agent-independent — created at the store level).
+   * With zero children, block the spec ("architect produced no implementation tasks") and
+   * raise NO proposal. Idempotent via a one-shot 'spec_approval_raised' event.
+   */
+  private raiseSpecApprovals(): void {
+    for (const spec of this.store.doneSpecTasks()) {
+      if (this.store.listEvents(spec.id).some((e) => e.kind === 'spec_approval_raised')) continue;
+      const children = this.store
+        .childrenOf(spec.id) // spec → gate; find implement children via the gate's children
+        .flatMap((gateId) => this.store.childrenOf(gateId))
+        .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement');
+      const gateId = this.store.childrenOf(spec.id).find((id) => this.store.getTask(id)?.pipelineStage === 'gate');
+      if (!gateId) continue;
+      if (children.length === 0) {
+        this.store.blockTask(spec.id, 'architect produced no implementation tasks');
+        this.store.appendEvent(spec.id, null, 'spec_approval_raised', { empty: true });
+        continue;
+      }
+      const rationale =
+        `Architect plan: ${spec.result ?? spec.title}. ` +
+        `${children.length} implementation task(s). Review explore findings before approving.`;
+      this.store.createProposal({
+        boardId: spec.boardId,
+        kind: 'approve_spec',
+        targetId: gateId,
+        rationale
+      });
+      this.store.appendEvent(spec.id, null, 'spec_approval_raised', { gateId, children: children.length });
+    }
+  }
+```
+
+- [ ] In `kanban-store.ts`, add `doneSpecTasks()` (near `reviewPendingTasks`):
+
+```ts
+  /** Spec-stage tasks that have completed (status done), for approval-proposal raising. */
+  doneSpecTasks(): Task[] {
+    const rows = this.db
+      .prepare("SELECT * FROM tasks WHERE pipeline_stage='spec' AND status='done'")
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+```
+
+- [ ] In `kanban-dispatcher.ts` `tick()`, add the call after `this.reviewTasks();`:
+
+```ts
+    this.reviewTasks();
+    this.raiseSpecApprovals();
+    this.integrate();
+```
+
+- [ ] Add a test. Append to `src/main/__tests__/kanban-dispatcher.test.ts`:
+
+```ts
+describe('KanbanDispatcher.raiseSpecApprovals', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('creates an approve_spec proposal when a done spec has children (autopilot OFF)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const spec = store.createTask({ title: 'Spec', status: 'done', pipelineStage: 'spec', featureId: f.id, result: 'plan summary' });
+    const gate = store.createTask({ title: 'Gate', status: 'blocked', pipelineStage: 'gate', systemKind: 'pipeline_gate', featureId: f.id });
+    const child = store.createTask({ title: 'impl', status: 'todo', pipelineStage: 'implement', featureId: f.id });
+    store.addLink(spec.id, gate.id);
+    store.addLink(gate.id, child.id);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => undefined,
+      config: { failureLimit: 2, claimGraceMs: 0, maxInProgress: 3, claimTtlMs: 1000, autoDecompose: false, autoAssign: false, autoIntegrate: false, autoReview: false, maxDecompose: 1, artifactRetentionDays: 0 }
+    });
+    disp['raiseSpecApprovals']();
+    const props = store.listProposals('default', { status: 'pending' });
+    expect(props.map((p) => p.kind)).toContain('approve_spec');
+    expect(props.find((p) => p.kind === 'approve_spec')?.targetId).toBe(gate.id);
+    store.close();
+  });
+
+  it('blocks the spec and raises no proposal on empty fan-out', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const spec = store.createTask({ title: 'Spec', status: 'done', pipelineStage: 'spec', featureId: f.id });
+    const gate = store.createTask({ title: 'Gate', status: 'blocked', pipelineStage: 'gate', systemKind: 'pipeline_gate', featureId: f.id });
+    store.addLink(spec.id, gate.id);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => undefined,
+      config: { failureLimit: 2, claimGraceMs: 0, maxInProgress: 3, claimTtlMs: 1000, autoDecompose: false, autoAssign: false, autoIntegrate: false, autoReview: false, maxDecompose: 1, artifactRetentionDays: 0 }
+    });
+    disp['raiseSpecApprovals']();
+    expect(store.getTask(spec.id)?.status).toBe('blocked');
+    expect(store.listProposals('default', { status: 'pending' })).toHaveLength(0);
+    store.close();
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): dispatcher raises approve_spec proposal on non-empty spec completion
+```
+
+---
+
+## Task 9 — proposal-executor approve_spec + dismiss re-arm
+
+**Files**
+- Modify: `src/main/kanban/proposal-executor.ts` (add `approve_spec` case ~line 18)
+- Modify: `src/main/kanban/kanban-commands.ts` (`dismissProposal` ~line 1101: re-arm spec on `approve_spec` dismiss; add `approveSpec` helper)
+- Modify: `src/main/__tests__/kanban-commands.test.ts`
+- Test: `src/main/__tests__/kanban-commands.test.ts`
+
+Context: `executeProposal` is `switch (kind)` and calls `KanbanCommands` methods. Approve marks the gate task `done` (releasing implement children via `promotableTodoTasks`). Dismiss (handled in `dismissProposal`) re-arms the spec stage: reset its status to `ready` with the dismissal comment as guidance and clear the `children_emitted` guard so the new run may re-fan-out.
+
+Steps:
+
+- [ ] In `kanban-commands.ts`, add an `approveSpec` method (near `acceptReviewTask`):
+
+```ts
+  /** Release a pipeline approval gate: mark the gate task done so its implement children promote. */
+  approveSpec(gateTaskId: string): KanbanReviewActionResult {
+    const gate = this.store.getTask(gateTaskId);
+    if (!gate) return { ok: false, error: 'gate task not found' };
+    if (gate.pipelineStage !== 'gate') return { ok: false, error: 'target is not a pipeline gate' };
+    this.store.setStatus(gateTaskId, 'done');
+    this.store.appendEvent(gateTaskId, null, 'spec_approved', {});
+    return { ok: true };
+  }
+```
+
+(Confirm `setStatus` does not clear/touch `result` in a way that breaks the gate — `setStatus` at ~line 1797 only updates status + updated_at. A `blocked`→`done` transition is fine; `promotableTodoTasks` treats `done` as settled.)
+
+- [ ] In `proposal-executor.ts`, add the `approve_spec` case to the switch (before the `default`):
+
+```ts
+    case 'approve_spec':
+      expectOk(commands.approveSpec(targetId));
+      return;
+```
+
+- [ ] In `kanban-commands.ts` `dismissProposal`, re-arm the spec when an `approve_spec` proposal is dismissed. Replace the method body:
+
+```ts
+  dismissProposal(id: string): void {
+    const p = this.store.getProposal(id);
+    if (!p) throw new CodedError('proposal not found', 'NOT_FOUND');
+    if (p.status !== 'pending') return; // already resolved — dismiss is a no-op
+    this.store.resolveProposal(id, 'dismissed', null);
+    if (p.kind === 'approve_spec') {
+      // Re-arm the spec stage. p.targetId is the gate task. First archive the prior
+      // fan-out's implement children (linked gate→child) so the re-armed architect run
+      // starts clean instead of piling a second set on top. Archived children count as
+      // settled, so they don't gate QA. (Don't touch the gate→qa link target.)
+      for (const childId of this.store.childrenOf(p.targetId)) {
+        if (this.store.getTask(childId)?.pipelineStage === 'implement') {
+          this.store.setStatus(childId, 'archived');
+        }
+      }
+      // Find the spec via the gate (gate's only parent is the spec), inject the dismissal
+      // as guidance, reset to ready, and clear the fan-out guard so it may re-fan-out.
+      const specId = this.store.parentsOf(p.targetId).find(
+        (pid) => this.store.getTask(pid)?.pipelineStage === 'spec'
+      );
+      if (specId) {
+        this.store.addComment(specId, 'pm', `Spec dismissed: revise and re-fan-out. ${p.rationale}`);
+        this.store.clearSpecFanout(specId);
+        this.store.setStatus(specId, 'ready');
+      }
+    }
+  }
+```
+
+- [ ] In `kanban-store.ts`, add `clearSpecFanout` (deletes the `children_emitted` event so a re-run may re-fan-out). Add near `appendEvent`:
+
+```ts
+  /** Drop a spec task's children_emitted guard so a re-armed run may re-fan-out (pipeline §6). */
+  clearSpecFanout(specTaskId: string): void {
+    this.db
+      .prepare("DELETE FROM task_events WHERE task_id=? AND kind='children_emitted'")
+      .run(specTaskId);
+  }
+```
+
+- [ ] Add tests. Append to `src/main/__tests__/kanban-commands.test.ts` (it uses the real store + commands; mirror its existing setup):
+
+```ts
+describe('approve_spec proposal', () => {
+  it('approve marks the gate done so children can promote; before approve they cannot', () => {
+    // Build feature + spec(done) → gate(blocked) → implement child(todo) with proper links.
+    // Assert promotableTodoTasks() does NOT include the child while gate is blocked.
+    // proposeAction('approve_spec', gateId) then approveProposal(); assert gate is 'done'
+    // and the child now appears in promotableTodoTasks().
+  });
+
+  it('dismiss re-arms the spec (ready), archives prior children, clears the guard', () => {
+    // Seed spec(blocked-on)→gate→implement child + a children_emitted event on the spec;
+    // create + dismiss the approve_spec proposal (targetId = gate). Assert: spec status is
+    // 'ready', a 'Spec dismissed' comment exists, no children_emitted event remains, and the
+    // prior implement child is now 'archived'.
+  });
+});
+```
+
+(Implementer: open `src/main/__tests__/kanban-commands.test.ts`, copy the nearest proposal test's store/commands construction, and fill the asserts with real ids. `promotableTodoTasks` lives on the store.)
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-commands.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): approve_spec executor + dismiss re-arms the spec stage
+```
+
+---
+
+## Task 10 — QA stage (prompt + tools + verdict path + spawn)
+
+**Files**
+- Modify: `src/main/kanban/spawn-worker.ts` (`buildPrompt` qa branch; `requireToolsForMode` qa case)
+- Modify: `src/main/kanban/kanban-mcp-server.ts` (new `kanban_qa_verdict` tool: worker-tool list + handler; `toolsForMode` includes it for `qa`)
+- Modify: `src/main/__tests__/spawn-worker.test.ts`, `src/main/__tests__/kanban-mcp-server.test.ts`
+- Test: those two files
+
+Context: the qa task is created `todo` (Task 4), promoted to `ready` after the gate + all implement children settle, and spawned with `mode: 'qa'` (Task 6's `modeForReadyTask` already returns `'qa'`). QA records the verdict on the feature via a new MCP tool `kanban_qa_verdict` (decision `pass|request_changes`, summary). The tool sets `features.qa_verdict` and is the qa run's terminal tool.
+
+Steps:
+
+- [ ] In `spawn-worker.ts` `buildPrompt`, add a `qa` branch (after `spec`):
+
+```ts
+  if (mode === 'qa') {
+    return (
+      `qa kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are QA for this feature. Validate the whole feature against the root task's acceptance ` +
+      `criteria. Run the project's verify commands and exercise end-to-end behavior (execution-based, ` +
+      `not a re-read of diffs). Re-check the risks the explore stage flagged. When done, call ` +
+      `kanban_qa_verdict with decision 'pass' or 'request_changes' and a one-line summary.`
+    );
+  }
+```
+
+- [ ] In `spawn-worker.ts` `requireToolsForMode`, add the `qa` case:
+
+```ts
+    case 'qa':
+      return 'kanban_qa_verdict';
+```
+
+- [ ] In `kanban-mcp-server.ts`, register `kanban_qa_verdict`. Add the tool descriptor near `kanban_review_verdict` in the worker tool list and include it in `toolsForMode` for `'qa'`:
+
+```ts
+  {
+    name: 'kanban_qa_verdict',
+    description:
+      "Record the feature-level QA verdict. decision 'pass' lets the feature PR become ready; " +
+      "'request_changes' bounces the implement tasks for a fix.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        decision: { type: 'string', enum: ['pass', 'request_changes'] },
+        summary: { type: 'string' }
+      },
+      required: ['decision', 'summary']
+    }
+  },
+```
+
+(Find the function that maps a `RunMode` to its allowed tools — `toolsForMode` — and ensure mode `'qa'` returns a list containing `kanban_show`, `kanban_comment`, `kanban_heartbeat`, `kanban_artifact`, and `kanban_qa_verdict`. Mirror how `'review'` maps to `kanban_review_verdict`.)
+
+- [ ] In `kanban-mcp-server.ts`, add the handler case in the worker-scope switch (near `kanban_review_verdict`):
+
+```ts
+        case 'kanban_qa_verdict': {
+          const a = z
+            .object({
+              decision: z.enum(['pass', 'request_changes']),
+              summary: z.string().min(1)
+            })
+            .parse(args);
+          if (scope.runId !== task.currentRunId || task.status !== 'running') {
+            this.unregisterRun(token);
+            return this.text(res, rpcReq.id, `Verdict ignored: task ${task.id} moved on.`);
+          }
+          if (!task.featureId) {
+            return this.rpcError(res, rpcReq.id, 'qa task has no feature');
+          }
+          this.store.setQaVerdict(task.featureId, a.decision);
+          this.store.addComment(task.id, 'qa', `qa ${a.decision}: ${a.summary}`);
+          this.store.appendEvent(
+            task.id,
+            scope.runId,
+            a.decision === 'pass' ? 'qa_passed' : 'qa_changes_requested',
+            { summary: a.summary }
+          );
+          // 'pass' completes the qa task (it satisfies the rollup); 'request_changes'
+          // leaves re-arming to the dispatcher (Task 11).
+          if (a.decision === 'pass') {
+            this.store.completeTask(task.id, `QA pass: ${a.summary}`);
+          }
+          this.store.finishRun(scope.runId, 'completed', { summary: a.summary });
+          this.unregisterRun(token);
+          return this.text(res, rpcReq.id, `QA verdict recorded for feature ${task.featureId}.`);
+        }
+```
+
+- [ ] Add prompt + verdict tests. In `src/main/__tests__/spawn-worker.test.ts` append a qa prompt assertion (mirror Task 6's explore test, asserting `qa kanban task`, `Run the project's verify commands`, and `--require-tool` === `kanban_qa_verdict`). In `src/main/__tests__/kanban-mcp-server.test.ts`, append a test driving a `qa`-scope run calling `kanban_qa_verdict` with `pass` and asserting `store.getFeature(fid)?.qaVerdict === 'pass'` and the qa task is `done` (copy the nearest verdict-tool test's setup).
+
+- [ ] Run: `npx vitest run src/main/__tests__/spawn-worker.test.ts src/main/__tests__/kanban-mcp-server.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): qa stage prompt, kanban_qa_verdict tool, feature verdict
+```
+
+---
+
+## Task 11 — QA gates PR-ready + request_changes re-arm
+
+**Files**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (`markFeaturePrReady` ~line 990: add qa_verdict guard; new `processQaChanges()` + `tick()` call; import `QA_ATTEMPT_CAP`)
+- Modify: `src/main/__tests__/kanban-dispatcher.test.ts`
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+Context: a pipeline feature (`qaVerdict !== null` OR has a qa-stage task) must not flip its PR to ready until `qaVerdict === 'pass'`. On `request_changes`, re-arm the implement children for a fix run, bounded by `QA_ATTEMPT_CAP` cycles tracked via a `qa_attempt` event count on the feature's qa task; on cap exhaustion mark the feature blocked + notify.
+
+Steps:
+
+- [ ] In `kanban-dispatcher.ts`, import the cap at the top:
+
+```ts
+import { getTemplate, MAX_FANOUT, QA_ATTEMPT_CAP } from './pipeline-templates';
+```
+
+(Adjust the existing import line from Task 5 to include `QA_ATTEMPT_CAP`; `MAX_FANOUT` only if used here — if not, omit it.)
+
+- [ ] In `kanban-dispatcher.ts` `markFeaturePrReady`, add the QA guard at the top of the method (after the existing early return):
+
+```ts
+  private markFeaturePrReady(feature: Feature): void {
+    if (feature.prState !== 'draft' || feature.prNumber == null || !feature.repoPath) return;
+    // Pipeline features gate PR-ready on a passing QA verdict. A feature that has been
+    // QA'd (verdict non-null) but not passed must wait; non-pipeline features (verdict
+    // null AND no qa task) are unaffected.
+    if (feature.qaVerdict !== null && feature.qaVerdict !== 'pass') return;
+    if (feature.qaVerdict === null && this.store.featureHasQaStage(feature.id)) return;
+    // ... existing markPrReady body unchanged
+```
+
+- [ ] In `kanban-store.ts`, add `featureHasQaStage`:
+
+```ts
+  /** True when a feature has a qa-stage task (it is a pipeline feature awaiting QA). */
+  featureHasQaStage(featureId: string): boolean {
+    const row = this.db
+      .prepare("SELECT 1 FROM tasks WHERE feature_id=? AND pipeline_stage='qa' LIMIT 1")
+      .get(featureId);
+    return row != null;
+  }
+```
+
+- [ ] In `kanban-dispatcher.ts`, add `processQaChanges()` (near `raiseSpecApprovals`):
+
+```ts
+  /**
+   * Handle QA request_changes: re-arm the feature's implement children for a fix run, once
+   * per qa_changes_requested event, bounded by QA_ATTEMPT_CAP. On cap exhaustion mark the
+   * feature blocked and emit a 'blocked' event (the #233 autopilot trigger surfaces it).
+   */
+  private processQaChanges(): void {
+    for (const qa of this.store.qaTasksNeedingRearm()) {
+      if (!qa.featureId) continue;
+      const attempts = this.store.listEvents(qa.id).filter((e) => e.kind === 'qa_rearmed').length;
+      if (attempts >= QA_ATTEMPT_CAP) {
+        this.store.updateFeature(qa.featureId, { status: 'active' }); // keep active; block the qa task
+        this.store.blockTask(qa.id, `QA still failing after ${QA_ATTEMPT_CAP} attempt(s)`);
+        this.store.appendEvent(qa.id, null, 'blocked', { reason: 'qa_attempt_cap' });
+        continue;
+      }
+      // Re-arm implement children: set them back to ready with the QA findings as guidance.
+      for (const childId of this.store.implementChildrenOf(qa.id)) {
+        this.store.setStatus(childId, 'ready');
+      }
+      this.store.setQaVerdict(qa.featureId, null); // clear so the next QA run can re-verdict
+      this.store.setStatus(qa.id, 'todo'); // qa re-gates on the children again
+      this.store.appendEvent(qa.id, null, 'qa_rearmed', { attempt: attempts + 1 });
+    }
+  }
+```
+
+- [ ] In `kanban-store.ts`, add the two helpers:
+
+```ts
+  /** qa-stage tasks whose feature verdict is request_changes and which haven't been re-armed for it yet. */
+  qaTasksNeedingRearm(): Task[] {
+    const rows = this.db
+      .prepare(
+        `SELECT t.* FROM tasks t JOIN features f ON f.id = t.feature_id
+          WHERE t.pipeline_stage='qa' AND f.qa_verdict='request_changes'`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
+  /** Implement-stage tasks linked as parents of a qa task (the children QA waits on). */
+  implementChildrenOf(qaTaskId: string): string[] {
+    return this.parentsOf(qaTaskId).filter(
+      (id) => this.getTask(id)?.pipelineStage === 'implement'
+    );
+  }
+```
+
+- [ ] In `kanban-dispatcher.ts` `tick()`, add the call after `raiseSpecApprovals`:
+
+```ts
+    this.raiseSpecApprovals();
+    this.processQaChanges();
+    this.integrate();
+```
+
+- [ ] Add tests. Append to `src/main/__tests__/kanban-dispatcher.test.ts`:
+
+```ts
+describe('KanbanDispatcher QA gating', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  function disp(store: KanbanStore, clock: { t: number }, ops?: Partial<IntegrationOps>): KanbanDispatcher {
+    return new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => undefined,
+      integration: { ...({} as IntegrationOps), ...ops },
+      config: { failureLimit: 2, claimGraceMs: 0, maxInProgress: 3, claimTtlMs: 1000, autoDecompose: false, autoAssign: false, autoIntegrate: true, autoReview: false, maxDecompose: 1, artifactRetentionDays: 0 }
+    });
+  }
+
+  it('request_changes re-arms implement children, then blocks the qa task at the cap', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const qa = store.createTask({ title: 'QA', status: 'todo', pipelineStage: 'qa', featureId: f.id });
+    const child = store.createTask({ title: 'impl', status: 'done', pipelineStage: 'implement', featureId: f.id });
+    store.addLink(child.id, qa.id);
+    store.setQaVerdict(f.id, 'request_changes');
+    const d = disp(store, clock);
+
+    d['processQaChanges'](); // attempt 1
+    expect(store.getTask(child.id)?.status).toBe('ready');
+    expect(store.getFeature(f.id)?.qaVerdict).toBeNull();
+
+    store.setQaVerdict(f.id, 'request_changes');
+    d['processQaChanges'](); // attempt 2 (== cap)
+    store.setQaVerdict(f.id, 'request_changes');
+    d['processQaChanges'](); // cap exhausted -> block
+    expect(store.getTask(qa.id)?.status).toBe('blocked');
+    store.close();
+  });
+});
+```
+
+(Note: `markFeaturePrReady` is private and exercised via `integrate()`; a focused unit test for the verdict guard can call `disp['markFeaturePrReady'](feature)` after seeding a draft PR feature with `qaVerdict='request_changes'` and asserting `setFeaturePrState` was never reached — but since `markPrReady` is injected via `ops`, assert the injected `markPrReady` spy was NOT called. Add that as a second `it` using a `markPrReady: () => { called = true; return { ok: true }; }` op.)
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): QA gates PR-ready; request_changes re-arms within QA_ATTEMPT_CAP
+```
+
+---
+
+## Task 12 — sweepStalePipelines liveness sweep
+
+**Files**
+- Modify: `src/main/kanban/kanban-dispatcher.ts` (new `sweepStalePipelines()` + `tick()` call; threshold constant)
+- Modify: `src/main/__tests__/kanban-dispatcher.test.ts`
+- Test: `src/main/__tests__/kanban-dispatcher.test.ts`
+
+Context: flag a pipeline whose current stage has been idle past a threshold (gate never approved, QA looping, dead stage) → mark the feature blocked + emit a `blocked` event. Idle = the feature's most-recently-updated pipeline task hasn't changed in `PIPELINE_STALE_MS`, and no pipeline task is `running`/`ready`.
+
+Steps:
+
+- [ ] In `kanban-dispatcher.ts`, add the threshold constant near the other caps (~line 58):
+
+```ts
+/** A pipeline whose current stage is idle longer than this is flagged stale (spec §12). */
+const PIPELINE_STALE_MS = 24 * 60 * 60 * 1000;
+```
+
+- [ ] In `kanban-dispatcher.ts`, add the sweep (near `sweepArtifacts`):
+
+```ts
+  /**
+   * Flag pipelines stalled at their current stage past PIPELINE_STALE_MS (gate never
+   * approved, QA looping, dead stage). Marks the feature blocked + emits a 'blocked'
+   * event so the #233 autopilot trigger surfaces it. Fire-once per feature.
+   */
+  sweepStalePipelines(): void {
+    const cutoff = this.deps.now() - PIPELINE_STALE_MS;
+    for (const f of this.store.activePipelineFeatures()) {
+      const tasks = this.store.pipelineTasksForFeature(f.id);
+      if (tasks.length === 0) continue;
+      const live = tasks.some((t) => t.status === 'running' || t.status === 'ready');
+      if (live) continue;
+      const settled = tasks.every((t) => t.status === 'done' || t.status === 'archived');
+      if (settled) continue; // pipeline finished, not stalled
+      const lastUpdate = Math.max(...tasks.map((t) => t.updatedAt));
+      if (lastUpdate > cutoff) continue; // still within the idle window
+      this.store.updateFeature(f.id, { status: 'active' });
+      this.store.appendEvent(f.id, null, 'blocked', { reason: 'pipeline_stalled' });
+    }
+  }
+```
+
+- [ ] In `kanban-store.ts`, add the two helpers:
+
+```ts
+  /** Active features that have at least one pipeline-stage task. */
+  activePipelineFeatures(): Feature[] {
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT f.* FROM features f JOIN tasks t ON t.feature_id = f.id
+          WHERE f.status='active' AND t.pipeline_stage IS NOT NULL`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToFeature(r));
+  }
+
+  /** All pipeline-stage tasks for a feature. */
+  pipelineTasksForFeature(featureId: string): Task[] {
+    const rows = this.db
+      .prepare('SELECT * FROM tasks WHERE feature_id=? AND pipeline_stage IS NOT NULL')
+      .all(featureId) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+```
+
+- [ ] In `kanban-dispatcher.ts` `tick()`, add the call after `sweepMergedWorktrees()`:
+
+```ts
+    this.sweepMergedWorktrees();
+    this.sweepStalePipelines();
+```
+
+- [ ] Add a test. Append to `src/main/__tests__/kanban-dispatcher.test.ts`:
+
+```ts
+describe('KanbanDispatcher.sweepStalePipelines', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('flags an idle-past-threshold pipeline as blocked + emits the event', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    // A blocked gate (not running/ready, not settled), last updated at t=1000.
+    store.createTask({ title: 'Gate', status: 'blocked', pipelineStage: 'gate', systemKind: 'pipeline_gate', featureId: f.id });
+    clock.t = 1000 + 25 * 60 * 60 * 1000; // 25h later, past the 24h threshold
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t, isAlive: () => true, spawnWorker: () => undefined,
+      config: { failureLimit: 2, claimGraceMs: 0, maxInProgress: 3, claimTtlMs: 1000, autoDecompose: false, autoAssign: false, autoIntegrate: false, autoReview: false, maxDecompose: 1, artifactRetentionDays: 0 }
+    });
+    disp.sweepStalePipelines();
+    expect(store.listEvents(f.id).some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled')).toBe(true);
+    store.close();
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-dispatcher.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): sweepStalePipelines flags idle pipelines as blocked
+```
+
+---
+
+## Task 13 — Default profiles seed (explorer, architect, reviewer, qa)
+
+**Files**
+- Modify: `src/shared/constants.ts` (`profiles` array ~line 126)
+- Modify/Create test: `src/main/__tests__/constants.test.ts` (check if it exists; if not, create a small one)
+- Test: that file
+
+Context: today only `default` (worker) and `orchestrator` are seeded. Add `explorer`, `architect`, `reviewer`, `qa` with personas from spec §9. The reviewer is distinct from worker and may set a different model (leave `model: ''` to inherit, but the instructions note it should differ — keep it minimal and within style).
+
+Steps:
+
+- [ ] In `src/shared/constants.ts`, append to the `profiles` array (after the `orchestrator` entry, before the closing `]`):
+
+```ts
+      {
+        name: 'explorer',
+        role: 'explorer',
+        model: '',
+        skills: [],
+        instructions:
+          'You are a read-only cartographer. Map the files, modules, and patterns affected by the ' +
+          'task; surface risks and unknowns. Never write code. Register your findings as a ' +
+          'kanban_artifact and post a one-paragraph summary on the root task, then call kanban_complete.'
+      },
+      {
+        name: 'architect',
+        role: 'architect',
+        model: '',
+        skills: [],
+        instructions:
+          'You are the architect. Consume the explore findings, write a concrete implementation spec, ' +
+          'then emit the implementation work by calling kanban_create once per unit (capped). Do not ' +
+          'implement anything yourself. Call kanban_complete with a plan summary when the fan-out is done.'
+      },
+      {
+        name: 'reviewer',
+        role: 'reviewer',
+        model: '',
+        skills: ['requesting-code-review'],
+        instructions:
+          'You are an independent code reviewer, distinct from the implementer (prefer a different model ' +
+          'to counter self-preference bias). Judge the diff against the task goal and acceptance criteria; ' +
+          'call kanban_review_verdict with approve or request_changes plus specific findings.'
+      },
+      {
+        name: 'qa',
+        role: 'qa',
+        model: '',
+        skills: [],
+        instructions:
+          'You are feature-level QA. Validate the whole feature against acceptance criteria using ' +
+          'execution (run the project verify commands and exercise behavior), not a re-read of diffs. ' +
+          'Emit your verdict with kanban_qa_verdict: pass or request_changes.'
+      }
+```
+
+- [ ] Add a test. Check `ls src/main/__tests__/` and `src/shared/__tests__/` for an existing constants test. If none, create `src/main/__tests__/default-profiles.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../shared/constants';
+
+describe('DEFAULT_SETTINGS.kanban.profiles', () => {
+  it('seeds all six SDLC roles', () => {
+    const byName = new Map(DEFAULT_SETTINGS.kanban.profiles.map((p) => [p.name, p.role]));
+    expect(byName.get('default')).toBe('worker');
+    expect(byName.get('orchestrator')).toBe('orchestrator');
+    expect(byName.get('explorer')).toBe('explorer');
+    expect(byName.get('architect')).toBe('architect');
+    expect(byName.get('reviewer')).toBe('reviewer');
+    expect(byName.get('qa')).toBe('qa');
+    expect(DEFAULT_SETTINGS.kanban.profiles).toHaveLength(6);
+  });
+});
+```
+
+- [ ] Run: `npx vitest run src/main/__tests__/default-profiles.test.ts` — expect green. Then `npm run typecheck` — expect green (the new roles already valid after Task 2).
+
+- [ ] Commit:
+
+```
+feat(kanban): seed explorer, architect, reviewer, qa default profiles
+```
+
+---
+
+## Task 14 — Intake: pipeline_template arg (MCP + commands + IPC + preload)
+
+**Files**
+- Modify: `src/main/kanban/kanban-mcp-server.ts` (PM-scope `kanban_create` schema ~line 826 + the `commands.create({...})` call ~line 905; tool descriptor ~line 150 for the worker list is NOT needed — intake is the PM/board scope)
+- Modify: `src/main/kanban/kanban-commands.ts` (`create` ~line 94 already spreads `input`; verify `pipelineTemplate` flows through — it does via the spread)
+- Modify: `src/main/kanban/kanban-ipc.ts` (`KANBAN_CREATE_TASK` handler ~line 59 already passes `CreateTaskInput` through — verify)
+- Modify: `src/preload/index.ts` (`createTask` ~line 544 already passes `CreateTaskInput` — verify the type includes the new field after Task 2)
+- Modify: `src/main/__tests__/kanban-mcp-server.test.ts`
+- Test: `src/main/__tests__/kanban-mcp-server.test.ts`
+
+Steps:
+
+- [ ] In `kanban-mcp-server.ts` PM-scope `kanban_create` zod schema (~line 826), add the optional enum:
+
+```ts
+              docs: z.array(z.string()).optional(),
+              pipeline_template: z.enum(['full_feature', 'quick_fix']).optional()
+            })
+            .parse(args);
+```
+
+- [ ] In the same PM-scope handler, pass it into `commands.create({...})` (~line 905) — add `pipelineTemplate`:
+
+```ts
+          const task = commands.create({
+            title: a.title,
+            body: a.body ?? '',
+            assignee,
+            priority: a.priority ?? 0,
+            status: a.status ?? 'todo',
+            boardId: scope.boardId,
+            featureId: a.feature_id ?? null,
+            docs: a.docs ?? [],
+            pipelineTemplate: a.pipeline_template ?? null,
+            ...workspace
+          });
+```
+
+(Confirm the existing trailing fields/spread; insert `pipelineTemplate` alongside them without reordering the others.)
+
+- [ ] In the PM `kanban_create` tool DESCRIPTOR (the board/PM tool definition — find the one with `status` enum and `project`/`docs` properties, distinct from the worker descriptor at line 150), add to `properties`:
+
+```ts
+        pipeline_template: { type: 'string', enum: ['full_feature', 'quick_fix'] }
+```
+
+- [ ] Verify (no code change expected): `commands.create` (`kanban-commands.ts` line 94) does `this.store.createTask({ ...input, ... })`, so `pipelineTemplate` flows through. `kanban-ipc.ts` `KANBAN_CREATE_TASK` does `commands.create(input)`. `src/preload/index.ts` `createTask(input: CreateTaskInput)` invokes the channel with the full input. After Task 2's `CreateTaskInput` change these all typecheck and carry the field. If any of these explicitly destructure fields (rather than spread), add `pipelineTemplate` there — open each and confirm.
+
+- [ ] Add a test. Append to `src/main/__tests__/kanban-mcp-server.test.ts` driving a PM/board-scope `kanban_create` with `pipeline_template: 'full_feature'` and asserting `store.getTask(id)?.pipelineTemplate === 'full_feature'` (copy the nearest PM-scope `kanban_create` test's setup).
+
+- [ ] Run: `npx vitest run src/main/__tests__/kanban-mcp-server.test.ts` — expect green. Then `npm run typecheck` — expect green.
+
+- [ ] Commit:
+
+```
+feat(kanban): pipeline_template intake arg through MCP, commands, IPC, preload
+```
+
+---
+
+## Task 15 — Renderer: template dropdown + approve_spec card + stage badges
+
+**Files**
+- Modify: `src/renderer/src/components/kanban/KanbanBoard.tsx` (create-task form ~line 186; add a `newTemplate` state + dropdown)
+- Verify: `src/renderer/src/components/kanban/PmChatPanel.tsx` (~line 217-237 — the proposal card already renders `p.kind.replace(/_/g, ' ')` + Approve/Dismiss generically)
+- Modify: `src/renderer/src/components/kanban/KanbanCard.tsx` (stage badge from `pipelineStage`)
+- Test: NONE — the repo has no React-component render tests for these views (renderer tests under `src/renderer/.../__tests__/` are pure-util tests like `kanban-utils.test.ts`, `tree-utils.test.ts`; no RTL/jsdom component tests). State this explicitly and verify via `npm run typecheck` + manual smoke is out of scope for the executor.
+
+Steps:
+
+- [ ] In `KanbanBoard.tsx`, add a template state near the other `new*` form state (e.g. `newStatus`):
+
+```tsx
+  const [newTemplate, setNewTemplate] = useState<'quick_fix' | 'full_feature'>('quick_fix');
+```
+
+- [ ] In `KanbanBoard.tsx`, pass it into the `createTask` call (~line 186). Only send `full_feature` when chosen so non-pipeline tasks stay NULL-equivalent:
+
+```tsx
+        await createTask({
+          title,
+          boardId: activeBoardSlug,
+          status: newStatus,
+          featureId,
+          pipelineTemplate: newTemplate === 'full_feature' ? 'full_feature' : 'quick_fix',
+          ...workspace
+        });
+```
+
+- [ ] In `KanbanBoard.tsx`, add the dropdown to the create-task form near the existing status/mode controls (match the existing `<select>`/control styling in that form):
+
+```tsx
+      <select
+        value={newTemplate}
+        onChange={(e) => setNewTemplate(e.target.value === 'full_feature' ? 'full_feature' : 'quick_fix')}
+        className="<copy the className of the adjacent status select>"
+      >
+        <option value="quick_fix">Quick fix (default)</option>
+        <option value="full_feature">Full feature (explore → spec → QA)</option>
+      </select>
+```
+
+- [ ] In `KanbanBoard.tsx`, reset it on form close alongside `setNewStatus('triage')`:
+
+```tsx
+    setNewStatus('triage');
+    setNewTemplate('quick_fix');
+```
+
+- [ ] Verify `PmChatPanel.tsx` renders the `approve_spec` card. The existing card (lines ~217-237) maps over `proposals` and renders `<span>{p.kind.replace(/_/g, ' ')}</span>` with Approve/Dismiss buttons calling the existing approve/dismiss handlers — so `approve_spec` renders as "approve spec" automatically with no code change. Confirm by reading the block; only adjust copy if a kind-specific label map exists (it does not — leave as-is).
+
+- [ ] In `KanbanCard.tsx`, render a stage badge when `task.pipelineStage` is set. Add near the existing status/PR badges (match the badge styling already used, e.g. `PrStatusBadge`):
+
+```tsx
+      {card.pipelineStage && (
+        <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-neutral-400">
+          {card.pipelineStage}
+        </span>
+      )}
+```
+
+(`KanbanCard` receives a `BoardCard` which extends `Task`, so `card.pipelineStage` is available after Task 2. Confirm the prop name — it may be `task` or `card`; use whichever the component already binds.)
+
+- [ ] Run: `npm run typecheck` (covers `typecheck:web`) — expect green. No renderer unit test to run (stated above).
+
+- [ ] Commit:
+
+```
+feat(kanban): template dropdown, stage badges, approve_spec proposal card
+```
+
+---
+
+## Task 16 — Final verification
+
+**Files**
+- None (verification only)
+
+Steps:
+
+- [ ] Run `npm run typecheck` — expect: both `typecheck:node` and `typecheck:web` pass with no errors.
+- [ ] Run `npm run lint` — expect: no NEW lint errors attributable to the new/changed files (the repo is pre-existing-red; compare against the baseline — your new files in `src/main/kanban/pipeline-templates.ts`, `src/main/kanban/template-expander.ts`, and the test files must not introduce new violations).
+- [ ] Run `npx vitest run` — expect: all suites green, including `pipeline-templates.test.ts`, `template-expander.test.ts`, `kanban-store.test.ts` (all `toBe(18)`), `kanban-dispatcher.test.ts`, `kanban-mcp-server.test.ts`, `kanban-commands.test.ts`, `spawn-worker.test.ts`, `default-profiles.test.ts`.
+- [ ] Run `npm run build` — expect: typecheck passes then electron-vite build succeeds with no errors.
+- [ ] Confirm the end-to-end shape against the spec: a `full_feature` triage task → expander lays down explore(ready)/spec(todo)/gate(blocked)/qa(todo) → explore spawns `explore` mode → spec spawns `spec` mode and fans out implement children linked to gate+qa → dispatcher raises `approve_spec` → approve marks gate done → children promote → review (existing autoReview) → qa spawns `qa` mode → `qa_verdict='pass'` lets `markFeaturePrReady` flip the PR. `quick_fix`/NULL is unchanged.
+
+---
+
+## Notes for the executor
+
+- Several MCP-server and commands tests say "copy the nearest existing test's setup" — this is deliberate: those suites have suite-local harness helpers (server construction, run/scope registration) whose exact names must be read from the file, not guessed. Open the file, copy the closest analogous test verbatim, then swap in the pipeline assertions given here.
+- Private dispatcher methods are tested via bracket access (`disp['raiseSpecApprovals']()`) — this is allowed in test files only.
+- The `pipeline_expanded` event payload field names (`exploreId`, `specId`, `gateId`, `qaId`, `featureId`) are the contract shared by Tasks 4, 7, and 8 — keep them identical.
+- Event kinds shared across tasks (`children_emitted`, `spec_approval_raised`, `spec_approved`, `qa_rearmed`, `qa_passed`, `qa_changes_requested`, `blocked`, `pipeline_expanded`) are string contracts — spell them identically.

--- a/docs/superpowers/specs/2026-06-16-sdlc-pipeline-templates-design.md
+++ b/docs/superpowers/specs/2026-06-16-sdlc-pipeline-templates-design.md
@@ -1,0 +1,345 @@
+# SDLC Pipeline Templates — Explore → Spec → Implement → Review → QA
+
+**Date:** 2026-06-16
+**Status:** Approved design
+**Issue:** #234 (autonomous-dev-team epic #236; builds on #233's proposal machinery)
+
+## Problem
+
+The pipeline shape is hardcoded: `(decompose) → work → human review`. The orchestrator
+decomposes a task by calling `kanban_create` freely **without ever reading the code**, and
+profiles support only `worker | orchestrator | reviewer` — so SDLC roles (explorer, architect,
+QA) have nowhere to live and nothing routes work through a design or QA stage. A feature-sized
+ticket cannot flow through exploration and design before implementation, nor through QA before
+integration, without a human wiring every task by hand.
+
+This spec adds **selectable pipeline templates**: a feature ticket flows automatically through
+`explore → spec → (human approval) → implement → review → QA` while a small fix keeps today's
+lightweight `work → review` flow.
+
+## Goals
+
+- A feature-sized ticket runs explore + design before implementation and review + QA before
+  integration, with **no manual task wiring**.
+- The pipeline shape is **deterministic** (a code-defined skeleton) while the number/shape of
+  implementation sub-tasks is **LLM-decided** by the architect.
+- A **human approves the spec** before implementation begins — the one high-leverage gate.
+- Ship default profiles for the new SDLC roles.
+- **Off by default**: a task with no template behaves exactly as today. Pipelines work whether
+  or not the PM agent (#233 autopilot) is enabled.
+
+## Non-goals
+
+- Auto-merging the feature PR to main — staying a human/PM action (`ship_feature` proposal,
+  #233). The feature PR is the terminal human gate, and it already exists.
+- A second long-lived process — the pipeline is driven entirely by the existing dispatcher tick.
+- User-editable templates / a template builder UI — templates are code constants (YAGNI).
+- Mid-flight `quick_fix → full_feature` escalation — deferred follow-up (see §11).
+- Cross-feature coordination — everything is feature/board-scoped.
+
+## Background: machinery this builds on
+
+Grounded in the current code (verified during design review):
+
+- **Dispatcher tick** (`kanban-dispatcher.ts`) runs `decompose → autoAssign → promote →
+  claimAndSpawn → reviewTasks → integrate` each tick. Task statuses:
+  `triage | scheduled | todo | ready | running | blocked | review | done | archived`.
+- **Gating** is a parent→child DAG in `task_links`. `promotableTodoTasks()` promotes a `todo`
+  child to `ready` only when **every** parent is `done`/`archived`
+  (`kanban-store.ts`, the `NOT EXISTS … status NOT IN ('done','archived')` predicate).
+- **Swarm skeleton** (`kanban-swarm.ts` `createSwarm`) is the precedent: it deterministically
+  creates root → workers → verifier → synthesizer tasks and wires `addLink(parent, child)`,
+  gating verifier on all workers and synthesizer on the verifier. The template expander mirrors
+  this exactly.
+- **Review per child is already automatic**: `reviewTasks()` spawns a `review` run on every
+  `review`-status worktree task **when `config.autoReview` is true** (default true,
+  `constants.ts`). `request_changes` → `spawnReviewFix`; `approve` → integration-eligible.
+- **Proposals (#233)**: `pm_proposals` table + `kanban_propose` + `executeProposal` +
+  `PM_PROPOSAL_KINDS`. Approve/Dismiss cards render in PM chat. `approveProposal` /
+  `executeProposal` run over IPC **independent of `pmAutopilotEnabled`**. A proposal row can be
+  created directly via `store.createProposal()` without any PM turn.
+- **Feature integration**: `integrateFeatures()` flips the feature PR from draft to ready via
+  `markFeaturePrReady` once `featureRollup` shows all member tasks `done`/`archived`. Merge to
+  main stays a human/PM action.
+- **Schema**: `SCHEMA_VERSION` currently **17**; additive columns via `addColumnIfMissing` under
+  the `user_version` migration pattern. `SCHEMA_SQL` runs **before** migrations (never put an
+  index on a migration-added column there — see `docs/learnings/2026-06-16-migration-column-index-in-schema-sql.md`).
+
+## Architecture
+
+A pipeline **template** is a TS constant listing ordered **stages**. A new
+**`template-expander.ts`** turns a chosen template into a task graph + `task_links`, mirroring
+`createSwarm`. Only the implement-children fan-out is produced by an LLM (the architect); every
+other task and every link is created deterministically by code.
+
+```
+PM/UI sets tasks.pipeline_template = 'full_feature' at intake
+        │
+        ▼
+dispatcher.decompose() routes a templated triage task to the expander
+        │  expandTemplate(rootTask, FULL_FEATURE)   ← deterministic
+        ▼
+   explore ──▶ spec ──▶ ⟨approval gate task: blocked⟩ ──▶ [impl children] ──▶ review/child ──▶ qa
+  (explorer)  (architect)   (released by approve_spec)     (LLM fan-out)      (reviewer, auto)  (qa)
+        │                          ▲                                                            │
+        │                   store.createProposal('approve_spec')                                │
+        │                   → Approve/Dismiss card in PM chat (PM-agent-independent)             │
+        │                                                                                        ▼
+        └────── artifacts (capped) carry explore findings + spec slices ──────▶ QA gates feature PR-ready
+```
+
+No new process, no new table. The graph lives in `task_links`; the gate lives in `pm_proposals`;
+stage identity lives in a column.
+
+## 1. Data model
+
+`SCHEMA_VERSION` **17 → 18**. All additive via `addColumnIfMissing`.
+
+**`tasks` — two new columns:**
+
+| Column             | Type | Meaning                                                                 |
+|--------------------|------|-------------------------------------------------------------------------|
+| `pipeline_template`| TEXT | `'full_feature' \| 'quick_fix' \| NULL`. Carried by the **root** task. NULL ⇒ treated as `quick_fix` (today's flow). |
+| `pipeline_stage`   | TEXT | `'explore' \| 'spec' \| 'gate' \| 'implement' \| 'review' \| 'qa' \| NULL`. Carried by **generated** stage tasks. NULL ⇒ ordinary non-pipeline task. |
+
+**Role union** (`WorkerProfile.role`, `src/shared/types.ts`):
+
+```ts
+role: 'worker' | 'orchestrator' | 'reviewer' | 'explorer' | 'architect' | 'qa'
+```
+
+**Run modes** (`RunMode`, `src/shared/kanban-types.ts`) — add three:
+
+```ts
+'work' | 'decompose' | 'specify' | 'assign' | 'resolve' | 'suggest' | 'verify' | 'review'
+  | 'explore' | 'spec' | 'qa'
+```
+
+**Proposal kind** — extend `PmProposalKind` / `PM_PROPOSAL_KINDS` (#233) with one:
+
+```ts
+'approve_spec'
+```
+
+**Feature QA verdict** — one new `features` column so QA can gate PR-ready distinctly from mere
+task completion:
+
+| Column       | Type | Meaning                                              |
+|--------------|------|------------------------------------------------------|
+| `qa_verdict` | TEXT | `'pass' \| 'request_changes' \| NULL`. NULL ⇒ not yet QA'd or non-pipeline feature. |
+
+No new tables.
+
+## 2. Templates
+
+`src/main/kanban/pipeline-templates.ts`:
+
+```ts
+export type StageKind = 'explore' | 'spec' | 'gate' | 'implement' | 'review' | 'qa'
+
+export interface PipelineTemplate {
+  id: 'full_feature' | 'quick_fix'
+  /** Ordered stages the expander lays down (excludes LLM-fanned implement children,
+   *  which the architect emits at the spec stage). */
+  stages: StageKind[]
+}
+
+export const FULL_FEATURE: PipelineTemplate = {
+  id: 'full_feature',
+  stages: ['explore', 'spec', 'gate', 'qa'] // implement + per-child review are dynamic
+}
+
+export const QUICK_FIX: PipelineTemplate = {
+  id: 'quick_fix',
+  stages: [] // no expansion: the root task runs today's work → review flow unchanged
+}
+```
+
+`quick_fix` is intentionally inert — selecting it (or leaving the template NULL) preserves the
+current behavior with zero new code paths exercised.
+
+## 3. The expander (`template-expander.ts`)
+
+`expandTemplate(root: Task, template: PipelineTemplate, store, deps): void`, called from
+`decompose()` when a triage task carries `pipeline_template === 'full_feature'` (instead of the
+blind orchestrator decompose). It mirrors `createSwarm`:
+
+1. Ensure the root has a `featureId` (create a feature if absent) so all stages ship as one unit.
+2. Create **explore** (`pipeline_stage='explore'`, `explorer` role, status `ready`).
+3. Create **spec** (`pipeline_stage='spec'`, `architect` role, status `todo`); `addLink(explore, spec)`.
+4. Create the **gate task** (`pipeline_stage='gate'`, `system_kind='pipeline_gate'`, status
+   **`blocked`**); `addLink(spec, gate)`. The gate starts blocked and is **only** released —
+   marked `done` — by `executeProposal('approve_spec')`; promotion never touches a `blocked`
+   task, so nothing else can release it. Implement children are gated on **this gate task**, not
+   on the spec task — the spec task completes when the architect's run finishes (before
+   approval), so gating children on spec would release them early. (Marking `system_kind` keeps
+   the gate out of `featureRollup`, which already excludes `system_kind IS NOT NULL`.)
+5. Create **qa** (`pipeline_stage='qa'`, `qa` role, status `todo`); `addLink(gate, qa)` as a
+   baseline link so QA cannot precede approval. Implement children, when emitted, are **also**
+   linked `child → qa` so QA waits for all implementation + review too.
+6. Persist a `pipeline_expanded` task event on the root for idempotency: if present, a re-run of
+   `expandTemplate` is a no-op (reclaim safety).
+
+The fan-out (implement children) is **not** created here — the architect creates them in §5.
+
+**Graceful degradation:** if a required role profile (`explorer`/`architect`/`qa`) is missing,
+the expander logs and **falls back to `quick_fix`** (root runs the normal flow) rather than
+wedging. This is the master safety valve — there is no separate feature toggle because the
+template is opt-in per task.
+
+## 4. Explore stage
+
+- New `explore` run mode. `spawn-worker.ts` `buildPrompt` gains an `explore` branch:
+  *read the codebase relevant to the root task; map affected files/modules/patterns; surface
+  risks and unknowns; **write no code**; register findings as a `kanban_artifact` and post a
+  one-paragraph summary comment on the root task.*
+- `requireToolsForMode('explore')` grants read tools only (no write/PR tools).
+- Output is a **capped artifact** (read via the existing 64 KB-capped artifact path), not a prose
+  blob on the blackboard — this is the explorer→architect handoff.
+
+## 5. Spec stage + idempotent fan-out
+
+- New `spec` run mode. `buildPrompt` `spec` branch: *read the explore artifact + root task; write
+  a concrete implementation spec; decompose the work by calling `kanban_create` once per unit,
+  passing `pipeline_stage='implement'` and a per-child slice of the spec in the body; cap the
+  fan-out at `MAX_FANOUT` (12) children; then stop — do not implement.* The architect does **not**
+  manage parent links manually — the create path wires them (below).
+- **Auto-linking (create path):** when a `spec`-stage run calls `kanban_create`, the tool path
+  detects the full_feature pipeline and deterministically wires the new child: `featureId =`
+  the root feature, `addLink(gateTask, child)` (gating the child on the **gate**, so it stays held
+  until approval), and `addLink(child, qaTask)` (gating QA on it). The architect never needs the
+  internal gate/qa ids.
+- **Idempotency:** the first child-creating call on a spec task records a `children_emitted` event;
+  if a reclaim re-runs the spec stage and that event exists, child creation is a no-op (prevents
+  double fan-out). Enforced in the same `kanban_create` tool path.
+- **Empty fan-out guard:** if the spec stage completes having emitted **zero** children, the spec
+  stage is marked `blocked` with a reason ("architect produced no implementation tasks") and **no
+  approval proposal is raised** — closing the "approve nothing → ship nothing" hole.
+- On a non-empty spec completion, the **dispatcher** (not a PM turn) calls
+  `store.createProposal({ kind:'approve_spec', boardId, targetId: gateTaskId, rationale })`. The
+  rationale embeds the architect's plan summary + the affected-file citations from explore so the
+  human can judge it (anti-rubber-stamping); there is no auto-approve default.
+
+## 6. Spec approval gate (reuses #233, PM-agent-independent)
+
+- The `approve_spec` proposal surfaces as an Approve/Dismiss card in PM chat (created directly at
+  the store level, so it appears **with or without** `pmAutopilotEnabled`).
+- **Approve** → `executeProposal('approve_spec')` deterministically marks the **gate task `done`**.
+  Its children (linked `gate → child`) then promote via normal `task_links` gating on the next
+  tick. Approval is an explicit, auditable event that a kanban card drag cannot trigger (the gate
+  is `blocked`, and only `executeProposal` moves it to `done`).
+- **Dismiss** → the spec stage is re-armed with the human's dismissal comment injected as
+  guidance, and re-runs (the `children_emitted` guard is reset on an explicit re-arm so the new
+  run may re-fan-out).
+- `executeProposal` already throws-on-failure and marks the row `failed` with the error surfaced
+  to chat — inherited unchanged.
+
+## 7. Implement + review stages
+
+- Implement children are ordinary `work` runs in worktrees — **no new code**. The architect may
+  add inter-child `task_links` for true dependencies.
+- Review per child is the existing automatic path (`reviewTasks()` with `autoReview` true).
+  **Reviewer independence:** the default `reviewer` profile is distinct from `worker` and may set
+  a different model — recommended in the profile instructions to counter self-preference bias.
+- This spec documents the **`autoReview` dependency**: `full_feature` assumes `config.autoReview`
+  (default true). If disabled, implement children land in `review` and wait for a human reviewer —
+  the pipeline still flows, just with manual review.
+
+## 8. QA stage
+
+- New `qa` run mode, gated on the gate task **and** every implement child (so it runs only after
+  all implementation + per-child review is done).
+- `buildPrompt` `qa` branch: *validate the whole feature against the root task's acceptance
+  criteria; **run the project verify commands** and exercise end-to-end behavior (execution-based,
+  not a re-read of diffs); check the explore-identified risks; emit a verdict.* QA calls a tool to
+  record `features.qa_verdict = 'pass' | 'request_changes'`.
+- **QA gates PR-ready explicitly:** `markFeaturePrReady` gains a guard
+  `&& feature.qa_verdict === 'pass'` for pipeline features (mirrors the existing review-verdict
+  guard at integrate). Without this, completing QA would satisfy the rollup and flip the PR on the
+  same tick — the verdict would never gate. Non-pipeline features (`qa_verdict` NULL, no QA task)
+  are unaffected.
+- **`request_changes`** posts findings and re-arms the relevant implement children (reusing the
+  review-fix attempt budget), bounded by a new `QA_ATTEMPT_CAP`. On cap exhaustion the feature is
+  marked blocked and the human is notified.
+
+## 9. Default profiles
+
+Seed in `DEFAULT_SETTINGS.kanban.profiles` (`src/shared/constants.ts`) — currently only `default`
+(worker) and `orchestrator` are seeded. Add **all** of:
+
+| Name        | Role        | Persona (instructions)                                                            |
+|-------------|-------------|-----------------------------------------------------------------------------------|
+| `explorer`  | `explorer`  | Read-only cartographer: map affected files/modules/patterns, surface risks, register an artifact + root summary. Never writes code. |
+| `architect` | `architect` | Consume explore findings, write a concrete impl spec, emit the implement-children fan-out (capped), then stop. |
+| `reviewer`  | `reviewer`  | Already referenced (auto-materialized when review is enabled); seed it explicitly. Distinct from worker; may use a different model. |
+| `qa`        | `qa`        | Feature-level, execution-based validation against acceptance criteria; run verify commands; emit pass / request_changes. |
+
+Reserved singleton names like the existing `orchestrator`.
+
+## 10. Intake & selection surface
+
+- **PM tool:** `kanban_create` (and the PM intake path) gains an optional `pipeline_template` arg
+  (`z.enum(['full_feature','quick_fix'])`, optional). The PM persona documents when to pick each.
+- **UI:** the task-create form gets a template dropdown (`quick_fix` default; `full_feature`
+  opt-in), wired via the existing `typedInvoke` preload pattern (no new architectural surface).
+- **Board/feature view:** a templated task renders a stage badge per child (`pipeline_stage`) so
+  the explore→spec→…→qa progress is legible.
+
+## 11. Config & rollout
+
+- **No new master toggle** — `full_feature` is opt-in per task and degrades to `quick_fix` if
+  roles are missing (§3). The PM-agent dependency is removed by §6.
+- New tuning constants (co-located, not user settings): `MAX_FANOUT` (12), `QA_ATTEMPT_CAP` (2).
+- **Default behavior unchanged**: NULL/`quick_fix` template = today's flow exactly. Existing
+  boards/tasks see no difference.
+- **Deferred follow-ups:** mid-flight `quick_fix → full_feature` escalation; a routing
+  classifier that auto-picks the template at intake; a third "standard" template tier.
+
+## 12. Liveness & error handling
+
+- **Per-task failures** inherit existing coverage: `reclaim()` (lease/PID), `failureLimit`→`giveUp`
+  (→ `blocked`), verify/review attempt caps.
+- **Pipeline-level stalls** (the gap today): a new tick sweep `sweepStalePipelines()` flags any
+  pipeline whose current stage has been idle past a threshold (e.g. spec approved but no child
+  progress, gate never approved, QA looping) — marks the feature `blocked` and emits a `blocked`
+  event (which the #233 autopilot trigger set already surfaces). This covers
+  human-never-approves, QA-never-passes, dead-stage, and abandoned-gate.
+- **Expander failure** marks the root task `blocked` with a reason rather than throwing into the
+  tick loop.
+- **All mutations** route through `KanbanCommands` / store accessors, inheriting validation.
+
+## 13. Testing
+
+- **Expander:** `full_feature` produces the expected graph (explore→spec→gate, gate→qa, no impl
+  children yet); the `pipeline_expanded` event makes a second `expandTemplate` a no-op; missing
+  roles → falls back to `quick_fix`; `quick_fix`/NULL → no expansion.
+- **Fan-out idempotency:** a spec re-run with `children_emitted` present creates no duplicate
+  children; an explicit re-arm (Dismiss) resets the guard.
+- **Gate:** the gate task starts `blocked`; children cannot promote while it is blocked;
+  `approve_spec` proposal Approve unblocks it → children promote; Dismiss re-arms the spec;
+  empty fan-out blocks the spec and raises **no** proposal.
+- **PM independence:** the `approve_spec` proposal is created and approvable with
+  `pmAutopilotEnabled` false.
+- **QA gating:** QA stays `todo` until gate + all impl children are done; `markFeaturePrReady`
+  does not flip until `qa_verdict==='pass'`; `request_changes` re-arms children within
+  `QA_ATTEMPT_CAP`, then blocks.
+- **Run modes:** `explore`/`spec`/`qa` prompt-builder tests assert read-only stages get no write
+  mandate and the right context is injected.
+- **Stall sweep:** an idle-past-threshold pipeline is marked blocked + emits the event.
+- **Schema:** bump the 12 `toBe(17)` assertions to `toBe(18)` (10 in
+  `kanban-store.test.ts`, 1 in `kanban-review-store.test.ts`, plus any added) and add migration
+  coverage for the new columns.
+
+## Research basis
+
+The structure follows current best practice (verified against external sources during design
+review): explore-before-plan (Anthropic Claude Code "explore, plan, code"; Agentless localization);
+hybrid deterministic-skeleton + LLM-decided fan-out (Anthropic "Building Effective Agents"
+orchestrator-workers; AWS agentic guidance; LangGraph); a human gate at the spec/plan boundary as
+the highest-leverage checkpoint (Devin Interactive Planning; GitHub Copilot Plan mode; shift-left
+defect economics); a per-diff review distinct from an **execution-based** QA stage (DeepMind
+self-correction limits; SWE-bench execution verification; LLM-as-judge bias → reviewer
+independence); and process-weight matched to task type via templates (Anthropic "routing" +
+"simplest solution first"). The known multi-agent failure mode — parallel agents writing code with
+divergent assumptions (Cognition "Don't Build Multi-Agents"; Berkeley MAST) — is contained by
+keeping parallelism to **independent** worktrees and passing artifacts/spec-slices between stages.

--- a/src/main/__tests__/default-profiles.test.ts
+++ b/src/main/__tests__/default-profiles.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../shared/constants';
+
+describe('DEFAULT_SETTINGS.kanban.profiles', () => {
+  it('seeds the SDLC roles required by the full_feature pipeline', () => {
+    const byName = new Map(DEFAULT_SETTINGS.kanban.profiles.map((p) => [p.name, p.role]));
+    expect(byName.get('explorer')).toBe('explorer');
+    expect(byName.get('architect')).toBe('architect');
+    expect(byName.get('reviewer')).toBe('reviewer');
+    expect(byName.get('qa')).toBe('qa');
+  });
+
+  it('has the expected total profile count with no duplicate names', () => {
+    const names = DEFAULT_SETTINGS.kanban.profiles.map((p) => p.name);
+    expect(names).toHaveLength(6);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/src/main/__tests__/kanban-commands.test.ts
+++ b/src/main/__tests__/kanban-commands.test.ts
@@ -1150,3 +1150,108 @@ describe('KanbanCommands verify commands', () => {
     expect(store.getProject(p.id)?.verifyCommands).toEqual([{ label: 'tests', command: 'npm test' }]);
   });
 });
+
+describe('approve_spec proposal', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  // Mirrors the real fan-out topology (template-expander + architect run):
+  // spec(done) → gate(blocked); implement child linked gate→child and child→qa; qa linked gate→qa.
+  function seedPipeline(store: KanbanStore): {
+    specId: string;
+    gateId: string;
+    childId: string;
+    qaId: string;
+  } {
+    const spec = store.createTask({ title: 'spec', status: 'done', pipelineStage: 'spec' });
+    const gate = store.createTask({ title: 'gate', status: 'blocked', pipelineStage: 'gate' });
+    const child = store.createTask({ title: 'impl', status: 'todo', pipelineStage: 'implement' });
+    const qa = store.createTask({ title: 'qa', status: 'todo', pipelineStage: 'qa' });
+    store.addLink(spec.id, gate.id);
+    store.addLink(gate.id, child.id);
+    store.addLink(gate.id, qa.id);
+    store.addLink(child.id, qa.id);
+    return { specId: spec.id, gateId: gate.id, childId: child.id, qaId: qa.id };
+  }
+
+  it('approve marks the gate done so children can promote; before approve they cannot', () => {
+    const { store, commands } = makeCommands();
+    const { gateId, childId } = seedPipeline(store);
+
+    // Gate is blocked: the implement child is gated and must NOT be promotable.
+    expect(store.promotableTodoTasks().map((t) => t.id)).not.toContain(childId);
+
+    // Mark the gate done directly and confirm the gating releases (the child becomes
+    // promotable) before the dispatcher tick consumes it.
+    store.setStatus(gateId, 'done');
+    expect(store.promotableTodoTasks().map((t) => t.id)).toContain(childId);
+    store.setStatus(gateId, 'blocked'); // reset for the real executor path below
+
+    // Drive the real executor path via an approve_spec proposal targeting the gate.
+    // approveSpec marks the gate done and ticks the dispatcher, which promotes the
+    // now-ungated implement child from 'todo' to 'ready'.
+    const proposal = commands.proposeAction('default', 'approve_spec', gateId, 'looks good');
+    const after = commands.approveProposal(proposal.id);
+    expect(after.status).toBe('accepted');
+
+    expect(store.getTask(gateId)?.status).toBe('done');
+    expect(store.getTask(childId)?.status).toBe('ready');
+    store.close();
+  });
+
+  it('dismiss re-arms the spec (ready), archives prior children, clears both guards', () => {
+    const { store, commands } = makeCommands();
+    const { specId, gateId, childId, qaId } = seedPipeline(store);
+    // Seed both guards the prior architect run + dispatcher would have stamped on the spec:
+    // the fan-out guard and the one-shot approval guard.
+    store.appendEvent(specId, null, 'children_emitted', { runId: 1 });
+    store.appendEvent(specId, null, 'spec_approval_raised', { gateId, children: 1 });
+
+    const proposal = commands.proposeAction('default', 'approve_spec', gateId, 'needs work');
+    commands.dismissProposal(proposal.id);
+
+    expect(store.getTask(specId)?.status).toBe('ready');
+    expect(store.getTask(childId)?.status).toBe('archived');
+    // The qa task is a direct child of the gate too, but the implement-only filter
+    // must leave it untouched so it can still gate QA after the re-armed fan-out.
+    expect(store.getTask(qaId)?.status).toBe('todo');
+    // Both guards must be cleared — leaving spec_approval_raised would permanently
+    // silence the dispatcher's raiseSpecApprovals so no second proposal could ever fire.
+    expect(store.listEvents(specId).some((e) => e.kind === 'children_emitted')).toBe(false);
+    expect(store.listEvents(specId).some((e) => e.kind === 'spec_approval_raised')).toBe(false);
+    expect(
+      store.listComments(specId).some((c) => c.body.includes('Spec dismissed'))
+    ).toBe(true);
+    store.close();
+  });
+
+  it('after dismiss, a re-armed spec that completes again raises a fresh approval proposal', () => {
+    const { store, commands } = makeCommands();
+    const { specId, gateId, childId, qaId } = seedPipeline(store);
+    void qaId;
+    store.appendEvent(specId, null, 'children_emitted', { runId: 1 });
+    store.appendEvent(specId, null, 'spec_approval_raised', { gateId, children: 1 });
+
+    const first = commands.proposeAction('default', 'approve_spec', gateId, 'needs work');
+    commands.dismissProposal(first.id);
+    expect(store.getTask(childId)?.status).toBe('archived'); // prior child settled
+
+    // Simulate the re-armed architect run: a fresh implement child off the gate, then the
+    // spec completes again. The dispatcher tick must raise a NEW approve_spec proposal
+    // (it would not if the spec_approval_raised guard had survived the dismiss).
+    const child2 = store.createTask({
+      title: 'impl-v2',
+      status: 'todo',
+      pipelineStage: 'implement'
+    });
+    store.addLink(gateId, child2.id);
+    store.setStatus(specId, 'done');
+    commands.dispatch();
+
+    const pending = store.listProposals('default', { status: 'pending' });
+    expect(pending.filter((p) => p.kind === 'approve_spec' && p.targetId === gateId)).toHaveLength(
+      1
+    );
+    store.close();
+  });
+});

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -441,7 +441,7 @@ const baseConfig = {
   autoDecompose: false,
   autoAssign: false,
   autoIntegrate: false,
-        autoReview: false,
+  autoReview: false,
   maxDecompose: 1,
   artifactRetentionDays: 0
 };
@@ -658,7 +658,12 @@ describe('KanbanDispatcher.decompose', () => {
     // First tick: expansion is a no-op fallback; no stages, no orchestrator spawn, root re-armed.
     disp.decompose();
     expect(spawned).toEqual([]);
-    expect(store.listTasks().map((t) => t.pipelineStage).filter(Boolean)).toEqual([]);
+    expect(
+      store
+        .listTasks()
+        .map((t) => t.pipelineStage)
+        .filter(Boolean)
+    ).toEqual([]);
     expect(store.getTask(root.id)?.status).toBe('triage');
     expect(store.getTask(root.id)?.pendingMode).toBe('decompose');
 
@@ -701,7 +706,10 @@ describe('KanbanDispatcher.autoAssign', () => {
     const disp = new KanbanDispatcher(store, {
       now: () => clock.t,
       isAlive: () => true,
-      spawnWorker: (args) => { spawned.push({ id: args.task.id, mode: args.mode }); return 4242; },
+      spawnWorker: (args) => {
+        spawned.push({ id: args.task.id, mode: args.mode });
+        return 4242;
+      },
       config: { ...baseConfig, autoAssign: true },
       prepareWorkspaceFn: () => '/tmp/ws',
       workerProfileNames: () => ['alpha', 'beta']
@@ -722,7 +730,10 @@ describe('KanbanDispatcher.autoAssign', () => {
     const disp = new KanbanDispatcher(store, {
       now: () => clock.t,
       isAlive: () => true,
-      spawnWorker: (args) => { spawned.push({ id: args.task.id, mode: args.mode }); return 4242; },
+      spawnWorker: (args) => {
+        spawned.push({ id: args.task.id, mode: args.mode });
+        return 4242;
+      },
       config: { ...baseConfig, autoAssign: true },
       prepareWorkspaceFn: () => '/tmp/ws',
       workerProfileNames: () => ['alpha', 'beta']
@@ -742,7 +753,8 @@ describe('KanbanDispatcher.autoAssign', () => {
     store.recordFailure(t.id, 'a2'); // consecutiveFailures = 2 == cap
     let spawned = 0;
     const disp = new KanbanDispatcher(store, {
-      now: () => clock.t, isAlive: () => true,
+      now: () => clock.t,
+      isAlive: () => true,
       spawnWorker: () => (spawned++, 1),
       config: { ...baseConfig, autoAssign: true },
       prepareWorkspaceFn: () => '/tmp/ws',
@@ -761,7 +773,9 @@ describe('KanbanDispatcher.autoAssign', () => {
     const store = makeStore(clock);
     const t = store.createTask({ title: 'x', status: 'ready' });
     const disp = new KanbanDispatcher(store, {
-      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
       config: { ...baseConfig, autoAssign: false },
       workerProfileNames: () => ['alpha', 'beta']
     });
@@ -776,7 +790,9 @@ describe('KanbanDispatcher.autoAssign', () => {
     const store = makeStore(clock);
     const t = store.createTask({ title: 'x', status: 'ready' });
     const disp = new KanbanDispatcher(store, {
-      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
       config: { ...baseConfig, autoAssign: true },
       workerProfileNames: () => []
     });
@@ -793,7 +809,9 @@ describe('KanbanDispatcher.autoAssign', () => {
     store.startRun(t.id, 'orchestrator', 9999, 'assign');
     clock.t = 2000; // claim expired
     const disp = new KanbanDispatcher(store, {
-      now: () => clock.t, isAlive: () => true, spawnWorker: () => 1,
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => 1,
       config: { ...baseConfig }
     });
     disp.reclaim();
@@ -1008,7 +1026,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           autoDecompose: false,
           autoAssign: false,
           autoIntegrate: false,
-        autoReview: false,
+          autoReview: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },
@@ -1023,7 +1041,7 @@ describe('KanbanDispatcher.reconfigure', () => {
           autoDecompose: false,
           autoAssign: false,
           autoIntegrate: false,
-        autoReview: false,
+          autoReview: false,
           maxDecompose: 1,
           artifactRetentionDays: 0
         },
@@ -1645,10 +1663,27 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('spawns a suggest run for a repo with ≥2 ungrouped worktree tasks', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    store.createTask({ title: 'a', status: 'ready', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
-    store.createTask({ title: 'b', status: 'todo', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
+    store.createTask({
+      title: 'a',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
+    store.createTask({
+      title: 'b',
+      status: 'todo',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
     const spawned: SpawnWorkerArgs[] = [];
-    const disp = makeDisp(store, clock, (a) => { spawned.push(a); return 4321; });
+    const disp = makeDisp(store, clock, (a) => {
+      spawned.push(a);
+      return 4321;
+    });
     disp.detectFeatureGroups();
     expect(spawned).toHaveLength(1);
     expect(spawned[0].mode).toBe('suggest');
@@ -1660,13 +1695,33 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('does not spawn twice for the same repo within the cooldown', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    store.createTask({ title: 'a', status: 'ready', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
-    store.createTask({ title: 'b', status: 'ready', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
+    store.createTask({
+      title: 'a',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
+    store.createTask({
+      title: 'b',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
     let n = 0;
-    const disp = makeDisp(store, clock, () => { n++; return 1; });
+    const disp = makeDisp(store, clock, () => {
+      n++;
+      return 1;
+    });
     disp.detectFeatureGroups();
     // even after the first run's system task is gone, the cooldown blocks a re-spawn
-    store.listTasks().filter((t) => t.systemKind === 'suggest').forEach((t) => store.deleteTask(t.id));
+    store
+      .listTasks()
+      .filter((t) => t.systemKind === 'suggest')
+      .forEach((t) => store.deleteTask(t.id));
     clock.t = 1000 + 60_000;
     disp.detectFeatureGroups();
     expect(n).toBe(1);
@@ -1676,10 +1731,27 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('preserves a repo path containing a space (no key-split truncation)', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    store.createTask({ title: 'a', status: 'ready', workspaceKind: 'worktree', repoPath: '/repo with space', baseBranch: 'main', boardId: 'default' });
-    store.createTask({ title: 'b', status: 'ready', workspaceKind: 'worktree', repoPath: '/repo with space', baseBranch: 'main', boardId: 'default' });
+    store.createTask({
+      title: 'a',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/repo with space',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
+    store.createTask({
+      title: 'b',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/repo with space',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
     const spawned: SpawnWorkerArgs[] = [];
-    const disp = makeDisp(store, clock, (a) => { spawned.push(a); return 1; });
+    const disp = makeDisp(store, clock, (a) => {
+      spawned.push(a);
+      return 1;
+    });
     disp.detectFeatureGroups();
     expect(spawned).toHaveLength(1);
     // the un-truncated path reached the store
@@ -1690,11 +1762,28 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('does not spawn when a pending suggestion already exists for the repo', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    store.createTask({ title: 'a', status: 'ready', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
-    store.createTask({ title: 'b', status: 'ready', workspaceKind: 'worktree', repoPath: '/r', baseBranch: 'main', boardId: 'default' });
+    store.createTask({
+      title: 'a',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
+    store.createTask({
+      title: 'b',
+      status: 'ready',
+      workspaceKind: 'worktree',
+      repoPath: '/r',
+      baseBranch: 'main',
+      boardId: 'default'
+    });
     store.createSuggestion({ boardId: 'default', repoPath: '/r', name: 'x', taskIds: [] });
     let n = 0;
-    const disp = makeDisp(store, clock, () => { n++; return 1; });
+    const disp = makeDisp(store, clock, () => {
+      n++;
+      return 1;
+    });
     disp.detectFeatureGroups();
     expect(n).toBe(0);
     store.close();
@@ -1703,13 +1792,24 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('reclaim drops a dead suggest run (deletes the system task, no triage)', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    const sys = store.createTask({ title: 'detect', status: 'review', boardId: 'default', systemKind: 'suggest', repoPath: '/r' });
+    const sys = store.createTask({
+      title: 'detect',
+      status: 'review',
+      boardId: 'default',
+      systemKind: 'suggest',
+      repoPath: '/r'
+    });
     store.claimForSuggest(sys.id, 'L', 100); // expires 1100
     const run = store.startRun(sys.id, 'orchestrator', null, 'suggest');
     store.setWorkerPid(sys.id, run.id, 999);
     clock.t = 5000;
     let alive = true;
-    const disp = makeDisp(store, clock, () => undefined, () => alive);
+    const disp = makeDisp(
+      store,
+      clock,
+      () => undefined,
+      () => alive
+    );
     // simulate a dead pid
     alive = false;
     disp.reclaim();
@@ -1720,7 +1820,13 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('reclaim drops a suggest run that exited 3 (deleted, never parked as blocked)', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    const sys = store.createTask({ title: 'detect', status: 'review', boardId: 'default', systemKind: 'suggest', repoPath: '/r' });
+    const sys = store.createTask({
+      title: 'detect',
+      status: 'review',
+      boardId: 'default',
+      systemKind: 'suggest',
+      repoPath: '/r'
+    });
     store.claimForSuggest(sys.id, 'L', 100000); // long ttl, not expired
     const run = store.startRun(sys.id, 'orchestrator', null, 'suggest');
     store.setWorkerPid(sys.id, run.id, 999);
@@ -1742,7 +1848,13 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
   it('reclaim drops a suggest run on the fatal blockNow path (deleted, never blocked)', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);
-    const sys = store.createTask({ title: 'detect', status: 'review', boardId: 'default', systemKind: 'suggest', repoPath: '/r' });
+    const sys = store.createTask({
+      title: 'detect',
+      status: 'review',
+      boardId: 'default',
+      systemKind: 'suggest',
+      repoPath: '/r'
+    });
     store.claimForSuggest(sys.id, 'L', 100000); // long ttl, not expired
     const run = store.startRun(sys.id, 'orchestrator', null, 'suggest');
     store.setWorkerPid(sys.id, run.id, 999);
@@ -1859,6 +1971,136 @@ describe('KanbanDispatcher.raiseSpecApprovals', () => {
     disp['raiseSpecApprovals']();
     expect(store.getTask(spec.id)?.status).toBe('blocked');
     expect(store.listProposals('default', { status: 'pending' })).toHaveLength(0);
+    store.close();
+  });
+});
+
+describe('KanbanDispatcher QA gating', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('request_changes re-arms implement children, then blocks the qa task at the cap', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const qa = store.createTask({
+      title: 'QA',
+      status: 'todo',
+      pipelineStage: 'qa',
+      featureId: f.id
+    });
+    const child = store.createTask({
+      title: 'impl',
+      status: 'done',
+      pipelineStage: 'implement',
+      featureId: f.id
+    });
+    store.addLink(child.id, qa.id); // child -> qa (qa gates on the implement child)
+    store.setQaVerdict(f.id, 'request_changes');
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig }
+    });
+
+    disp['processQaChanges'](); // attempt 1
+    expect(store.getTask(child.id)?.status).toBe('ready');
+    expect(store.getFeature(f.id)?.qaVerdict).toBeNull();
+    expect(store.getTask(qa.id)?.status).toBe('todo');
+
+    store.setQaVerdict(f.id, 'request_changes');
+    disp['processQaChanges'](); // attempt 2 (== cap boundary)
+    expect(store.getTask(qa.id)?.status).toBe('todo');
+
+    store.setQaVerdict(f.id, 'request_changes');
+    disp['processQaChanges'](); // cap exhausted -> block
+    expect(store.getTask(qa.id)?.status).toBe('blocked');
+    expect(store.listEvents(qa.id).filter((e) => e.kind === 'blocked')).toHaveLength(1);
+
+    // A blocked qa task (verdict stays request_changes) must NOT be reselected on later ticks.
+    store.setQaVerdict(f.id, 'request_changes');
+    disp['processQaChanges'](); // no-op: the qa task is already blocked
+    expect(store.listEvents(qa.id).filter((e) => e.kind === 'blocked')).toHaveLength(1);
+    store.close();
+  });
+
+  it('markFeaturePrReady does NOT flip a pipeline feature whose verdict is request_changes', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({
+      boardId: 'default',
+      name: 'feat',
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    store.setFeaturePr(f.id, 'https://x/pull/9', 9, 'draft');
+    store.createTask({ title: 'QA', status: 'todo', pipelineStage: 'qa', featureId: f.id });
+    store.setQaVerdict(f.id, 'request_changes');
+    const markPrReady = vi.fn(() => ({ ok: true as const }));
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig },
+      integration: fakeIntegration({ markPrReady })
+    });
+
+    disp['markFeaturePrReady'](store.getFeature(f.id)!);
+    expect(markPrReady).not.toHaveBeenCalled();
+    expect(store.getFeature(f.id)?.prState).toBe('draft');
+    store.close();
+  });
+
+  it('markFeaturePrReady flips a pipeline feature once QA passes', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({
+      boardId: 'default',
+      name: 'feat',
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    store.setFeaturePr(f.id, 'https://x/pull/9', 9, 'draft');
+    store.createTask({ title: 'QA', status: 'done', pipelineStage: 'qa', featureId: f.id });
+    store.setQaVerdict(f.id, 'pass');
+    const markPrReady = vi.fn(() => ({ ok: true as const }));
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig },
+      integration: fakeIntegration({ markPrReady })
+    });
+
+    disp['markFeaturePrReady'](store.getFeature(f.id)!);
+    expect(markPrReady).toHaveBeenCalledTimes(1);
+    expect(store.getFeature(f.id)?.prState).toBe('open');
+    store.close();
+  });
+
+  it('markFeaturePrReady flips a non-pipeline feature (no qa task, null verdict)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({
+      boardId: 'default',
+      name: 'feat',
+      repoPath: '/repo',
+      baseBranch: 'main'
+    });
+    store.setFeaturePr(f.id, 'https://x/pull/9', 9, 'draft'); // no qa task; qaVerdict stays null
+    const markPrReady = vi.fn(() => ({ ok: true as const }));
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig },
+      integration: fakeIntegration({ markPrReady })
+    });
+
+    disp['markFeaturePrReady'](store.getFeature(f.id)!);
+    expect(markPrReady).toHaveBeenCalledTimes(1);
+    expect(store.getFeature(f.id)?.prState).toBe('open');
     store.close();
   });
 });

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -2104,3 +2104,117 @@ describe('KanbanDispatcher QA gating', () => {
     store.close();
   });
 });
+
+describe('KanbanDispatcher.sweepStalePipelines', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  function makeDisp(store: KanbanStore, clock: { t: number }): KanbanDispatcher {
+    return new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig }
+    });
+  }
+
+  it('flags an idle-past-threshold pipeline as blocked + emits the event', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    // A blocked gate (not running/ready, not settled), last updated at t=1000.
+    store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      systemKind: 'pipeline_gate',
+      featureId: f.id
+    });
+    clock.t = 1000 + 25 * 60 * 60 * 1000; // 25h later, past the 24h threshold
+    makeDisp(store, clock).sweepStalePipelines();
+    expect(
+      store
+        .listEvents(f.id)
+        .some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled')
+    ).toBe(true);
+    store.close();
+  });
+
+  it('fires once: a second sweep does not re-emit the blocked event', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      systemKind: 'pipeline_gate',
+      featureId: f.id
+    });
+    clock.t = 1000 + 25 * 60 * 60 * 1000;
+    const disp = makeDisp(store, clock);
+    disp.sweepStalePipelines();
+    disp.sweepStalePipelines();
+    const blocked = store
+      .listEvents(f.id)
+      .filter((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled');
+    expect(blocked).toHaveLength(1);
+    store.close();
+  });
+
+  it('does not flag a pipeline with a live (ready) stage task', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    store.createTask({
+      title: 'Impl',
+      status: 'ready',
+      pipelineStage: 'implement',
+      featureId: f.id
+    });
+    clock.t = 1000 + 25 * 60 * 60 * 1000;
+    makeDisp(store, clock).sweepStalePipelines();
+    expect(
+      store
+        .listEvents(f.id)
+        .some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled')
+    ).toBe(false);
+    store.close();
+  });
+
+  it('does not flag a fully-settled pipeline (all done)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    store.createTask({ title: 'Gate', status: 'done', pipelineStage: 'gate', featureId: f.id });
+    store.createTask({ title: 'QA', status: 'done', pipelineStage: 'qa', featureId: f.id });
+    clock.t = 1000 + 25 * 60 * 60 * 1000;
+    makeDisp(store, clock).sweepStalePipelines();
+    expect(
+      store
+        .listEvents(f.id)
+        .some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled')
+    ).toBe(false);
+    store.close();
+  });
+
+  it('does not flag a pipeline still within the idle window', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      featureId: f.id
+    });
+    clock.t = 1000 + 23 * 60 * 60 * 1000; // 23h — under the 24h threshold
+    makeDisp(store, clock).sweepStalePipelines();
+    expect(
+      store
+        .listEvents(f.id)
+        .some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled')
+    ).toBe(false);
+    store.close();
+  });
+});

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -594,6 +594,42 @@ describe('KanbanDispatcher.decompose', () => {
     expect(stages).toEqual(['explore', 'gate', 'qa', 'spec']);
     store.close();
   });
+
+  it('degrades a full_feature root to the orchestrator when a required role is missing', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const root = store.createTask({
+      title: 'Add billing',
+      status: 'triage',
+      pipelineTemplate: 'full_feature'
+    });
+    store.setPendingMode(root.id, 'decompose');
+    const spawned: string[] = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => {
+        spawned.push(args.mode);
+        return 1;
+      },
+      profileRoles: () => ['worker'], // missing explorer/architect/qa → expansion falls back
+      config: { ...baseConfig },
+      prepareWorkspaceFn: () => '/tmp/ws'
+    });
+
+    // First tick: expansion is a no-op fallback; no stages, no orchestrator spawn, root re-armed.
+    disp.decompose();
+    expect(spawned).toEqual([]);
+    expect(store.listTasks().map((t) => t.pipelineStage).filter(Boolean)).toEqual([]);
+    expect(store.getTask(root.id)?.status).toBe('triage');
+    expect(store.getTask(root.id)?.pendingMode).toBe('decompose');
+
+    // Next tick: the marker is present, so the root falls through to the orchestrator (today's flow).
+    disp.decompose();
+    expect(spawned).toEqual(['decompose']);
+    expect(store.getTask(root.id)?.status).toBe('running');
+    store.close();
+  });
 });
 
 describe('KanbanDispatcher.autoAssign', () => {

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -324,6 +324,44 @@ describe('KanbanDispatcher.claimAndSpawn', () => {
     store.close();
   });
 
+  it('routes an explore-stage ready task with mode explore (plain task stays work)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const exp = store.createTask({
+      title: 'map',
+      status: 'ready',
+      assignee: 'r',
+      pipelineStage: 'explore'
+    });
+    const plain = store.createTask({ title: 'do', status: 'ready', assignee: 'r' });
+    const spawned: Array<{ id: string; mode: string }> = [];
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: (args) => {
+        spawned.push({ id: args.task.id, mode: args.mode });
+        return 1;
+      },
+      config: {
+        failureLimit: 2,
+        claimGraceMs: 0,
+        maxInProgress: 3,
+        claimTtlMs: 1000,
+        autoDecompose: false,
+        autoAssign: false,
+        autoIntegrate: false,
+        autoReview: false,
+        maxDecompose: 1,
+        artifactRetentionDays: 0
+      },
+      prepareWorkspaceFn: () => '/tmp/ws'
+    });
+    disp.claimAndSpawn();
+    expect(spawned.find((s) => s.id === exp.id)?.mode).toBe('explore');
+    expect(spawned.find((s) => s.id === plain.id)?.mode).toBe('work');
+    store.close();
+  });
+
   it('respects the maxInProgress concurrency cap', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -2025,6 +2025,42 @@ describe('KanbanDispatcher QA gating', () => {
     store.close();
   });
 
+  it('reclaim parks a request_changes qa task as todo without recording a failure', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const qa = store.createTask({
+      title: 'QA',
+      status: 'ready',
+      assignee: 'qa',
+      pipelineStage: 'qa',
+      featureId: f.id
+    });
+    // Drive the qa task into the parked-running state kanban_qa_verdict('request_changes')
+    // leaves behind: claimed → running, the qa run finished, and a qa_changes_requested event.
+    store.claimTask(qa.id, 'L', 100000);
+    const run = store.startRun(qa.id, 'qa', 4321, 'qa');
+    store.setWorkerPid(qa.id, run.id, 4321);
+    store.finishRun(run.id, 'completed', { summary: 'needs work' });
+    store.appendEvent(qa.id, run.id, 'qa_changes_requested', { summary: 'needs work' });
+    store.setQaVerdict(f.id, 'request_changes');
+
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => false,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig },
+      workerExit: (id) => (id === run.id ? { code: 0, signal: null } : undefined)
+    });
+
+    disp.reclaim();
+    const got = store.getTask(qa.id);
+    expect(got?.status).toBe('todo'); // parked for processQaChanges, NOT failed back to ready/triage
+    expect(got?.consecutiveFailures).toBe(0); // reclaim must not creep it toward giveUp
+    expect(store.listEvents(qa.id).filter((e) => e.kind === 'gave_up')).toHaveLength(0);
+    store.close();
+  });
+
   it('markFeaturePrReady does NOT flip a pipeline feature whose verdict is request_changes', () => {
     const clock = { t: 1000 };
     const store = makeStore(clock);

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -1764,3 +1764,101 @@ describe('KanbanDispatcher.detectFeatureGroups', () => {
     store.close();
   });
 });
+
+describe('KanbanDispatcher.raiseSpecApprovals', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+  it('creates an approve_spec proposal when a done spec has children (autopilot OFF)', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const spec = store.createTask({ title: 'Spec', pipelineStage: 'spec', featureId: f.id });
+    store.completeTask(spec.id, 'plan summary'); // status='done' + result
+    const gate = store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      systemKind: 'pipeline_gate',
+      featureId: f.id
+    });
+    const child = store.createTask({
+      title: 'impl',
+      status: 'todo',
+      pipelineStage: 'implement',
+      featureId: f.id
+    });
+    store.addLink(spec.id, gate.id);
+    store.addLink(gate.id, child.id);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig }
+    });
+    disp['raiseSpecApprovals']();
+    const props = store.listProposals('default', { status: 'pending' });
+    expect(props.map((p) => p.kind)).toContain('approve_spec');
+    expect(props.find((p) => p.kind === 'approve_spec')?.targetId).toBe(gate.id);
+    store.close();
+  });
+
+  it('is idempotent: a second call raises no further proposal', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const spec = store.createTask({ title: 'Spec', pipelineStage: 'spec', featureId: f.id });
+    store.completeTask(spec.id, 'plan summary');
+    const gate = store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      systemKind: 'pipeline_gate',
+      featureId: f.id
+    });
+    const child = store.createTask({
+      title: 'impl',
+      status: 'todo',
+      pipelineStage: 'implement',
+      featureId: f.id
+    });
+    store.addLink(spec.id, gate.id);
+    store.addLink(gate.id, child.id);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig }
+    });
+    disp['raiseSpecApprovals']();
+    disp['raiseSpecApprovals']();
+    expect(store.listProposals('default', { status: 'pending' })).toHaveLength(1);
+    store.close();
+  });
+
+  it('blocks the spec and raises no proposal on empty fan-out', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const spec = store.createTask({ title: 'Spec', pipelineStage: 'spec', featureId: f.id });
+    store.completeTask(spec.id, null);
+    const gate = store.createTask({
+      title: 'Gate',
+      status: 'blocked',
+      pipelineStage: 'gate',
+      systemKind: 'pipeline_gate',
+      featureId: f.id
+    });
+    store.addLink(spec.id, gate.id);
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => undefined,
+      config: { ...baseConfig }
+    });
+    disp['raiseSpecApprovals']();
+    expect(store.getTask(spec.id)?.status).toBe('blocked');
+    expect(store.listProposals('default', { status: 'pending' })).toHaveLength(0);
+    store.close();
+  });
+});

--- a/src/main/__tests__/kanban-dispatcher.test.ts
+++ b/src/main/__tests__/kanban-dispatcher.test.ts
@@ -563,6 +563,37 @@ describe('KanbanDispatcher.decompose', () => {
     expect(store.getTask(t.id)?.status).toBe('review');
     store.close();
   });
+
+  it('routes a full_feature triage root to the expander, not the orchestrator', () => {
+    const clock = { t: 1000 };
+    const store = makeStore(clock);
+    const root = store.createTask({
+      title: 'Add billing',
+      status: 'triage',
+      pipelineTemplate: 'full_feature'
+    });
+    store.setPendingMode(root.id, 'decompose');
+    let spawned = 0;
+    const disp = new KanbanDispatcher(store, {
+      now: () => clock.t,
+      isAlive: () => true,
+      spawnWorker: () => {
+        spawned += 1;
+        return 1;
+      },
+      profileRoles: () => ['explorer', 'architect', 'qa', 'worker'],
+      config: { ...baseConfig }
+    });
+    disp.decompose();
+    expect(spawned).toBe(0); // expander runs in-process; no orchestrator spawn
+    const stages = store
+      .listTasks()
+      .map((t) => t.pipelineStage)
+      .filter(Boolean)
+      .sort();
+    expect(stages).toEqual(['explore', 'gate', 'qa', 'spec']);
+    store.close();
+  });
 });
 
 describe('KanbanDispatcher.autoAssign', () => {

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -410,6 +410,42 @@ describe('KanbanMcpServer', () => {
     expect(implementChildren).toHaveLength(MAX_FANOUT);
   });
 
+  // --- QA-stage verdict (full_feature pipeline) ---------------------------------
+
+  /** Promote the qa-stage task to running with a current run, mirroring the dispatcher. */
+  function startQaRun(qaId: string, tok: string): void {
+    store.returnToReady(qaId);
+    store.claimTask(qaId, 'L', 15 * 60 * 1000);
+    const run = store.startRun(qaId, 'qa', 1, 'qa');
+    server.registerRun(tok, { kind: 'task', taskId: qaId, runId: run.id, mode: 'qa' }, 'L');
+  }
+
+  it('kanban_qa_verdict pass sets the feature verdict and completes the qa task', async () => {
+    const { featureId, qaId } = buildPipeline();
+    startQaRun(qaId, 'qaPass');
+
+    const r = await rpc(`${base}?run=qaPass`, 'tools/call', {
+      name: 'kanban_qa_verdict',
+      arguments: { decision: 'pass', summary: 'all green end-to-end' }
+    });
+    expect(r.error).toBeFalsy();
+    expect(store.getFeature(featureId)?.qaVerdict).toBe('pass');
+    expect(store.getTask(qaId)?.status).toBe('done');
+  });
+
+  it('kanban_qa_verdict request_changes sets the verdict without completing the qa task', async () => {
+    const { featureId, qaId } = buildPipeline();
+    startQaRun(qaId, 'qaChanges');
+
+    const r = await rpc(`${base}?run=qaChanges`, 'tools/call', {
+      name: 'kanban_qa_verdict',
+      arguments: { decision: 'request_changes', summary: 'login flow regressed' }
+    });
+    expect(r.error).toBeFalsy();
+    expect(store.getFeature(featureId)?.qaVerdict).toBe('request_changes');
+    expect(store.getTask(qaId)?.status).toBe('running');
+  });
+
   it('kanban_update (specify) rewrites the body and returns the task to todo', async () => {
     const t = store.createTask({ title: 'vague', body: 'old', status: 'running' });
     const run = store.startRun(t.id, 'orchestrator', 1, 'specify');

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -738,6 +738,16 @@ describe('KanbanMcpServer board scope (PM chat)', () => {
     expect(task?.workspaceKind).toBe('scratch');
   });
 
+  it('kanban_create carries a pipeline_template onto the created task', async () => {
+    const r = await rpc(`${base}?run=pmtok`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'templated', pipeline_template: 'full_feature' }
+    });
+    const id = String(r.result.content[0].text).trim();
+    const task = store.getTask(id);
+    expect(task?.pipelineTemplate).toBe('full_feature');
+  });
+
   it('kanban_create links listed parents', async () => {
     const parent = store.createTask({ title: 'parent', status: 'todo' });
     const r = await rpc(`${base}?run=pmtok`, 'tools/call', {

--- a/src/main/__tests__/kanban-mcp-server.test.ts
+++ b/src/main/__tests__/kanban-mcp-server.test.ts
@@ -7,6 +7,8 @@ import { KanbanMcpServer } from '../kanban/kanban-mcp-server';
 import { KanbanDispatcher } from '../kanban/kanban-dispatcher';
 import { KanbanCommands } from '../kanban/kanban-commands';
 import { createSwarm } from '../kanban/kanban-swarm';
+import { expandTemplate } from '../kanban/template-expander';
+import { FULL_FEATURE, MAX_FANOUT } from '../kanban/pipeline-templates';
 
 const TEST_DIR = join(tmpdir(), `fleet-kanban-mcp-test-${Date.now()}`);
 
@@ -316,6 +318,96 @@ describe('KanbanMcpServer', () => {
     });
     const childId = String(r.result.content[0].text).trim();
     expect(store.parentsOf(childId).sort()).toEqual([dep.id, parent.id].sort());
+  });
+
+  // --- Spec-stage fan-out (full_feature pipeline) -------------------------------
+
+  /** Expand a fresh full_feature root and return its laid-down stage ids. */
+  function buildPipeline(): {
+    featureId: string;
+    specId: string;
+    gateId: string;
+    qaId: string;
+  } {
+    const root = store.createTask({
+      title: 'Big feature',
+      body: 'do a big thing',
+      status: 'triage',
+      pipelineTemplate: 'full_feature'
+    });
+    expandTemplate(root, FULL_FEATURE, store, { hasRole: () => true });
+    const ev = store.listEvents(root.id).find((e) => e.kind === 'pipeline_expanded');
+    const p = ev?.payload as Record<string, string>;
+    return { featureId: p.featureId, specId: p.specId, gateId: p.gateId, qaId: p.qaId };
+  }
+
+  it('spec-stage kanban_create makes an implement child auto-linked to gate and qa', async () => {
+    const { featureId, specId, gateId, qaId } = buildPipeline();
+    const run = store.startRun(specId, 'architect', 1, 'spec');
+    server.registerRun('spec1', { kind: 'task', taskId: specId, runId: run.id, mode: 'spec' }, 'L');
+
+    const r = await rpc(`${base}?run=spec1`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'unit A', body: 'slice of the spec' }
+    });
+    const childId = String(r.result.content[0].text).trim();
+    const child = store.getTask(childId);
+    expect(child?.pipelineStage).toBe('implement');
+    expect(child?.featureId).toBe(featureId);
+    expect(store.parentsOf(childId)).toContain(gateId);
+    expect(store.childrenOf(childId)).toContain(qaId);
+    expect(store.listEvents(childId).some((e) => e.kind === 'task_created')).toBe(true);
+    expect(store.listEvents(specId).filter((e) => e.kind === 'children_emitted')).toHaveLength(1);
+  });
+
+  it('spec-stage fan-out rejects a different run after children were emitted', async () => {
+    const { specId, gateId } = buildPipeline();
+    const run1 = store.startRun(specId, 'architect', 1, 'spec');
+    server.registerRun('specA', { kind: 'task', taskId: specId, runId: run1.id, mode: 'spec' }, 'L');
+    const first = await rpc(`${base}?run=specA`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'unit A' }
+    });
+    const firstChild = String(first.result.content[0].text).trim();
+    expect(store.getTask(firstChild)).toBeTruthy();
+
+    // A reclaim re-run is a DIFFERENT run on the same spec task.
+    const run2 = store.startRun(specId, 'architect', 1, 'spec');
+    server.registerRun('specB', { kind: 'task', taskId: specId, runId: run2.id, mode: 'spec' }, 'L');
+    const second = await rpc(`${base}?run=specB`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'duplicate unit' }
+    });
+    expect(String(second.error?.message ?? '')).toMatch(/already emitted/i);
+    // No duplicate fan-out: still exactly one children_emitted event and one implement child.
+    expect(store.listEvents(specId).filter((e) => e.kind === 'children_emitted')).toHaveLength(1);
+    const implementChildren = store
+      .childrenOf(gateId)
+      .filter((id) => store.getTask(id)?.pipelineStage === 'implement');
+    expect(implementChildren).toHaveLength(1);
+  });
+
+  it('spec-stage fan-out caps at MAX_FANOUT children within one run', async () => {
+    const { gateId, specId } = buildPipeline();
+    const run = store.startRun(specId, 'architect', 1, 'spec');
+    server.registerRun('specC', { kind: 'task', taskId: specId, runId: run.id, mode: 'spec' }, 'L');
+
+    for (let i = 0; i < MAX_FANOUT; i++) {
+      const r = await rpc(`${base}?run=specC`, 'tools/call', {
+        name: 'kanban_create',
+        arguments: { title: `unit ${i}` }
+      });
+      expect(r.error).toBeFalsy();
+    }
+    const r13 = await rpc(`${base}?run=specC`, 'tools/call', {
+      name: 'kanban_create',
+      arguments: { title: 'one too many' }
+    });
+    expect(String(r13.error?.message ?? '')).toMatch(/cap/i);
+    const implementChildren = store
+      .childrenOf(gateId)
+      .filter((id) => store.getTask(id)?.pipelineStage === 'implement');
+    expect(implementChildren).toHaveLength(MAX_FANOUT);
   });
 
   it('kanban_update (specify) rewrites the body and returns the task to todo', async () => {

--- a/src/main/__tests__/kanban-review-store.test.ts
+++ b/src/main/__tests__/kanban-review-store.test.ts
@@ -8,7 +8,7 @@ const db = () => join(tmpdir(), `fleet-review-${Math.random()}.db`);
 describe('review schema (migration 15)', () => {
   it('is at schema version 15 with review columns defaulting correctly', () => {
     const store = new KanbanStore(db(), { now: () => 1000 });
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
     const t = store.createTask({ title: 'x' });
     const got = store.getTask(t.id)!;
     expect(got.reviewVerdict).toBeNull();

--- a/src/main/__tests__/kanban-store.test.ts
+++ b/src/main/__tests__/kanban-store.test.ts
@@ -25,7 +25,23 @@ describe('KanbanStore', () => {
 
   it('creates the db file and runs migrations', () => {
     expect(existsSync(DB_PATH)).toBe(true);
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
+  });
+
+  it('persists pipeline columns and qa verdict at schema v18', () => {
+    expect(store.schemaVersion()).toBe(18);
+    const f = store.createFeature({ boardId: 'default', name: 'feat' });
+    const t = store.createTask({
+      title: 'root',
+      pipelineTemplate: 'full_feature',
+      pipelineStage: 'explore',
+      featureId: f.id
+    });
+    const got = store.getTask(t.id);
+    expect(got?.pipelineTemplate).toBe('full_feature');
+    expect(got?.pipelineStage).toBe('explore');
+    store.setQaVerdict(f.id, 'pass');
+    expect(store.getFeature(f.id)?.qaVerdict).toBe('pass');
   });
 
   it('fresh db is created at v14 with the new columns', () => {
@@ -34,14 +50,14 @@ describe('KanbanStore', () => {
     expect(store.getTask(t.id)?.pendingMode).toBeNull();
     const run = store.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
   });
 
   it('fresh db is created at v14 and persists repoPath', () => {
     const t = store.createTask({ title: 'wt', workspaceKind: 'worktree', repoPath: '/src/repo' });
     expect(store.getTask(t.id)?.repoPath).toBe('/src/repo');
     expect(store.getTask(t.id)?.workspaceKind).toBe('worktree');
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
   });
 
   it('repoPath defaults to null when omitted', () => {
@@ -72,7 +88,7 @@ describe('KanbanStore', () => {
     const s = new KanbanStore(v2Path);
     const t = s.createTask({ title: 'x', workspaceKind: 'worktree', repoPath: '/r' });
     expect(s.getTask(t.id)?.repoPath).toBe('/r');
-    expect(s.schemaVersion()).toBe(17);
+    expect(s.schemaVersion()).toBe(18);
     s.close();
   });
 
@@ -97,7 +113,7 @@ describe('KanbanStore', () => {
     raw.close();
 
     const s = new KanbanStore(preV5Path);
-    expect(s.schemaVersion()).toBe(17);
+    expect(s.schemaVersion()).toBe(18);
     expect(s.getTask('abc')?.boardId).toBe('default');
     expect(s.listBoards().map((b) => b.slug)).toEqual(['default']);
     s.close();
@@ -118,7 +134,7 @@ describe('KanbanStore', () => {
 
     // Opening the store must run the ALTER-based upgrade path (+ idempotent SCHEMA_SQL).
     const s = new KanbanStore(v9Path);
-    expect(s.schemaVersion()).toBe(17);
+    expect(s.schemaVersion()).toBe(18);
     expect(s.getTask('pre10')?.docs).toEqual([]); // pre-migration row gets the default
     const t = s.createTask({ title: 'x', docs: ['guide.md'] });
     expect(s.getTask(t.id)?.docs).toEqual(['guide.md']);
@@ -141,7 +157,7 @@ describe('KanbanStore', () => {
 
     // Opening the store must run the ALTER-based upgrade path.
     const s = new KanbanStore(v10Path);
-    expect(s.schemaVersion()).toBe(17);
+    expect(s.schemaVersion()).toBe(18);
     expect(s.getTask('pre11')?.resolveAttempts).toBe(0); // pre-migration row gets the default
     expect(s.getTask('pre11')?.systemKind).toBeNull();
     s.close();
@@ -163,7 +179,7 @@ describe('KanbanStore', () => {
     expect(s.getTask(t.id)?.pendingMode).toBeNull();
     const run = s.startRun(t.id, 'p', null);
     expect(run.mode).toBe('work');
-    expect(s.schemaVersion()).toBe(17);
+    expect(s.schemaVersion()).toBe(18);
     s.close();
   });
 
@@ -590,7 +606,7 @@ describe('KanbanStore schema v6 migration', () => {
     raw.close();
 
     const store = new KanbanStore(dbPath, { now: () => 1000 });
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
     const t = store.getTask('legacy1');
     expect(t?.title).toBe('old task');
     expect(t?.scheduleKind).toBeNull();
@@ -1014,7 +1030,7 @@ describe('projects schema (v10)', () => {
   });
 
   it('migrates to v10 with a projects table and tasks.docs column', () => {
-    expect(store.schemaVersion()).toBe(17);
+    expect(store.schemaVersion()).toBe(18);
     const t = store.createTask({ title: 'x' });
     expect(t.docs).toEqual([]);
     expect(store.listProjects('default')).toEqual([]);

--- a/src/main/__tests__/pipeline-templates.test.ts
+++ b/src/main/__tests__/pipeline-templates.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FULL_FEATURE,
+  QUICK_FIX,
+  getTemplate,
+  MAX_FANOUT,
+  QA_ATTEMPT_CAP
+} from '../kanban/pipeline-templates';
+
+describe('pipeline-templates', () => {
+  it('FULL_FEATURE lays down explore → spec → gate → qa', () => {
+    expect(FULL_FEATURE.id).toBe('full_feature');
+    expect(FULL_FEATURE.stages).toEqual(['explore', 'spec', 'gate', 'qa']);
+  });
+
+  it('QUICK_FIX is inert (no stages)', () => {
+    expect(QUICK_FIX.id).toBe('quick_fix');
+    expect(QUICK_FIX.stages).toEqual([]);
+  });
+
+  it('getTemplate resolves full_feature and falls back to quick_fix', () => {
+    expect(getTemplate('full_feature')).toBe(FULL_FEATURE);
+    expect(getTemplate('quick_fix')).toBe(QUICK_FIX);
+    expect(getTemplate(null)).toBe(QUICK_FIX);
+    expect(getTemplate(undefined)).toBe(QUICK_FIX);
+  });
+
+  it('caps are the spec values', () => {
+    expect(MAX_FANOUT).toBe(12);
+    expect(QA_ATTEMPT_CAP).toBe(2);
+  });
+});

--- a/src/main/__tests__/spawn-worker.test.ts
+++ b/src/main/__tests__/spawn-worker.test.ts
@@ -32,3 +32,20 @@ describe('buildWorkerInvocation explore mode', () => {
     expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_complete,kanban_block');
   });
 });
+
+describe('buildWorkerInvocation qa mode', () => {
+  it('emits a feature-validation prompt and the qa_verdict require-tool', () => {
+    const inv = buildWorkerInvocation({
+      task: baseTask,
+      workspace: ws(),
+      mcpPort: 1,
+      runToken: 'tok',
+      logPath: '/tmp/x.log',
+      mode: 'qa'
+    });
+    const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
+    expect(prompt).toContain('qa kanban task t1');
+    expect(prompt).toContain("Run the project's verify commands");
+    expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_qa_verdict');
+  });
+});

--- a/src/main/__tests__/spawn-worker.test.ts
+++ b/src/main/__tests__/spawn-worker.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildWorkerInvocation } from '../kanban/spawn-worker';
+
+function ws(): string {
+  return mkdtempSync(join(tmpdir(), 'fleet-spawn-'));
+}
+const baseTask = {
+  id: 't1',
+  title: 'Add billing',
+  body: 'body',
+  assignee: 'explorer',
+  modelOverride: null
+};
+
+describe('buildWorkerInvocation explore mode', () => {
+  it('emits a read-only mapping prompt and complete/block require-tool', () => {
+    const inv = buildWorkerInvocation({
+      task: baseTask,
+      workspace: ws(),
+      mcpPort: 1,
+      runToken: 'tok',
+      logPath: '/tmp/x.log',
+      mode: 'explore'
+    });
+    const prompt = inv.args[inv.args.indexOf('--prompt') + 1];
+    expect(prompt).toContain('explore kanban task t1');
+    expect(prompt).toContain('Write NO code');
+    expect(prompt).toContain('kanban_artifact');
+    expect(inv.args[inv.args.indexOf('--require-tool') + 1]).toBe('kanban_complete,kanban_block');
+  });
+});

--- a/src/main/__tests__/template-expander.test.ts
+++ b/src/main/__tests__/template-expander.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { KanbanStore } from '../kanban/kanban-store';
+import { expandTemplate, PIPELINE_EXPANDED_EVENT } from '../kanban/template-expander';
+import { FULL_FEATURE, QUICK_FIX } from '../kanban/pipeline-templates';
+
+const DIR = join(tmpdir(), `fleet-expander-test-${Date.now()}`);
+const allRoles = { hasRole: () => true };
+
+function store(): KanbanStore {
+  return new KanbanStore(join(DIR, `e-${Math.random()}.db`), { now: () => 1000 });
+}
+
+function stageOf(s: KanbanStore, id: string): string | null {
+  return s.getTask(id)?.pipelineStage ?? null;
+}
+
+describe('expandTemplate', () => {
+  beforeEach(() => mkdirSync(DIR, { recursive: true }));
+  afterEach(() => rmSync(DIR, { recursive: true, force: true }));
+
+  it('lays down explore→spec→gate→qa with the gating links + a feature', () => {
+    const s = store();
+    const root = s.createTask({ title: 'Add billing', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, allRoles);
+
+    const ev = s.listEvents(root.id).find((e) => e.kind === PIPELINE_EXPANDED_EVENT);
+    expect(ev).toBeTruthy();
+    const { exploreId, specId, gateId, qaId, featureId } = ev!.payload as Record<string, string>;
+
+    expect(s.getFeature(featureId)).toBeTruthy();
+    expect(stageOf(s, exploreId)).toBe('explore');
+    expect(s.getTask(exploreId)?.status).toBe('ready');
+    expect(stageOf(s, specId)).toBe('spec');
+    expect(s.getTask(specId)?.status).toBe('todo');
+    expect(stageOf(s, gateId)).toBe('gate');
+    expect(s.getTask(gateId)?.status).toBe('blocked');
+    expect(s.getTask(gateId)?.systemKind).toBe('pipeline_gate');
+    expect(stageOf(s, qaId)).toBe('qa');
+
+    expect(s.childrenOf(exploreId)).toContain(specId);
+    expect(s.childrenOf(specId)).toContain(gateId);
+    expect(s.childrenOf(gateId)).toContain(qaId);
+    s.close();
+  });
+
+  it('is a no-op on re-run (idempotent)', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, allRoles);
+    const before = s.listTasks().length;
+    expandTemplate(s.getTask(root.id)!, FULL_FEATURE, s, allRoles);
+    expect(s.listTasks().length).toBe(before);
+    s.close();
+  });
+
+  it('falls back to quick_fix when a required role profile is missing', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'full_feature' });
+    expandTemplate(root, FULL_FEATURE, s, { hasRole: (r) => r !== 'qa' });
+    expect(s.listTasks().some((t) => t.pipelineStage !== null)).toBe(false);
+    const ev = s.listEvents(root.id).find((e) => e.kind === PIPELINE_EXPANDED_EVENT);
+    expect((ev!.payload as Record<string, unknown>).fallback).toBe('quick_fix');
+    s.close();
+  });
+
+  it('does not expand quick_fix / inert template', () => {
+    const s = store();
+    const root = s.createTask({ title: 'X', pipelineTemplate: 'quick_fix' });
+    expandTemplate(root, QUICK_FIX, s, allRoles);
+    expect(s.listTasks().some((t) => t.pipelineStage !== null)).toBe(false);
+    s.close();
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1073,6 +1073,11 @@ void app.whenReady().then(async () => {
           instructions: DEFAULT_REVIEWER_INSTRUCTIONS
         };
         reviewDiff = worktreeDiff({ workspacePath: workspace, baseBranch: task.baseBranch });
+      } else if (mode === 'explore' || mode === 'spec' || mode === 'qa') {
+        // Pipeline stage roles run under their own persona, selected by the assignee the
+        // expander stamped on the task ('explorer'/'architect'/'qa'). NEVER overwrite the
+        // assignee and offer NO worker roster — these are single-role runs, not orchestrations.
+        profile = profiles.find((p) => p.name === task.assignee) ?? null;
       } else {
         // decompose/specify: run as an orchestrator profile; offer the worker roster.
         profile =

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -947,6 +947,7 @@ void app.whenReady().then(async () => {
         .get()
         .kanban.profiles.filter((p) => p.role === 'worker')
         .map((p) => p.name),
+    profileRoles: () => settingsStore.get().kanban.profiles.map((p) => p.role),
     isAlive: (pid) => {
       try {
         process.kill(pid, 0);

--- a/src/main/kanban/kanban-commands.ts
+++ b/src/main/kanban/kanban-commands.ts
@@ -737,6 +737,18 @@ export class KanbanCommands {
     return { ok: true, message: 'accepted; branch preserved' };
   }
 
+  /** Release a pipeline approval gate: mark the gate task done so its implement children promote. */
+  approveSpec(gateTaskId: string): KanbanReviewActionResult {
+    const gate = this.store.getTask(gateTaskId);
+    if (!gate) return { ok: false, error: 'gate task not found' };
+    if (gate.pipelineStage !== 'gate') return { ok: false, error: 'target is not a pipeline gate' };
+    this.store.setStatus(gateTaskId, 'done');
+    this.store.appendEvent(gateTaskId, null, 'spec_approved', {});
+    // Gate advanced to done — let gated implement children promote without waiting for the poll.
+    this.dispatcher.tick();
+    return { ok: true, message: 'spec approved; gate released' };
+  }
+
   /**
    * Predict whether a worktree task's branch will merge cleanly into its base
    * (the feature integration branch, for feature tasks) and persist the result so
@@ -1103,6 +1115,27 @@ export class KanbanCommands {
     if (!p) throw new CodedError('proposal not found', 'NOT_FOUND');
     if (p.status !== 'pending') return; // already resolved — dismiss is a no-op
     this.store.resolveProposal(id, 'dismissed', null);
+    if (p.kind === 'approve_spec') {
+      // Re-arm the spec stage. p.targetId is the gate task. First archive the prior
+      // fan-out's implement children (linked gate→child) so the re-armed architect run
+      // starts clean instead of piling a second set on top. Archived children count as
+      // settled, so they don't gate QA. (Don't touch the gate→qa link target.)
+      for (const childId of this.store.childrenOf(p.targetId)) {
+        if (this.store.getTask(childId)?.pipelineStage === 'implement') {
+          this.store.setStatus(childId, 'archived');
+        }
+      }
+      // Find the spec via the gate (gate's only parent is the spec), inject the dismissal
+      // as guidance, reset to ready, and clear the fan-out guard so it may re-fan-out.
+      const specId = this.store
+        .parentsOf(p.targetId)
+        .find((pid) => this.store.getTask(pid)?.pipelineStage === 'spec');
+      if (specId) {
+        this.store.addComment(specId, 'pm', `Spec dismissed: revise and re-fan-out. ${p.rationale}`);
+        this.store.clearSpecFanout(specId);
+        this.store.setStatus(specId, 'ready');
+      }
+    }
   }
 
   // ---- Standup digest config ----

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -891,6 +891,43 @@ export class KanbanDispatcher {
     }
   }
 
+  /**
+   * For each freshly-done spec stage: with ≥1 implement child, create an approve_spec
+   * proposal targeting the gate task (PM-agent-independent — created at the store level).
+   * With zero children, block the spec ("architect produced no implementation tasks") and
+   * raise NO proposal. Idempotent via a one-shot 'spec_approval_raised' event.
+   */
+  private raiseSpecApprovals(): void {
+    for (const spec of this.store.doneSpecTasks()) {
+      if (this.store.listEvents(spec.id).some((e) => e.kind === 'spec_approval_raised')) continue;
+      const gateId = this.store
+        .childrenOf(spec.id)
+        .find((id) => this.store.getTask(id)?.pipelineStage === 'gate');
+      if (!gateId) continue;
+      const children = this.store
+        .childrenOf(gateId)
+        .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement');
+      if (children.length === 0) {
+        this.store.blockTask(spec.id, 'architect produced no implementation tasks');
+        this.store.appendEvent(spec.id, null, 'spec_approval_raised', { empty: true });
+        continue;
+      }
+      const rationale =
+        `Architect plan: ${spec.result ?? spec.title}. ` +
+        `${children.length} implementation task(s). Review explore findings before approving.`;
+      this.store.createProposal({
+        boardId: spec.boardId,
+        kind: 'approve_spec',
+        targetId: gateId,
+        rationale
+      });
+      this.store.appendEvent(spec.id, null, 'spec_approval_raised', {
+        gateId,
+        children: children.length
+      });
+    }
+  }
+
   /** Auto-integrate completed feature tasks and sync completed features. Local git only — no push/PR (that is #229). */
   integrate(): void {
     if (!this.deps.config.autoIntegrate) return;
@@ -1212,6 +1249,7 @@ export class KanbanDispatcher {
     this.promote();
     this.claimAndSpawn();
     this.reviewTasks();
+    this.raiseSpecApprovals();
     this.integrate();
     this.sweepArtifacts();
     this.sweepMergedWorktrees();

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -903,7 +903,10 @@ export class KanbanDispatcher {
       const gateId = this.store
         .childrenOf(spec.id)
         .find((id) => this.store.getTask(id)?.pipelineStage === 'gate');
-      if (!gateId) continue;
+      if (!gateId) {
+        log.warn('raiseSpecApprovals: spec has no gate child; skipping', { specId: spec.id });
+        continue;
+      }
       const children = this.store
         .childrenOf(gateId)
         .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement');

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -18,7 +18,7 @@ import {
   updateIntegrationBranchFromMain
 } from './workspace';
 import { readLogTail } from './spawn-worker';
-import { expandTemplate } from './template-expander';
+import { expandTemplate, PIPELINE_EXPANDED_EVENT } from './template-expander';
 import { getTemplate } from './pipeline-templates';
 
 const log = createLogger('kanban-dispatcher');
@@ -449,8 +449,15 @@ export class KanbanDispatcher {
       const mode = task.pendingMode;
       if (mode == null) continue;
 
-      // Full-feature pipeline roots are expanded deterministically (no orchestrator).
-      if (task.pipelineTemplate === 'full_feature') {
+      // Full-feature pipeline roots are expanded deterministically (no orchestrator). A root
+      // that already carries the expansion marker was processed on a prior tick: a successful
+      // expansion would have completed the root (so it wouldn't be a pending triage task here),
+      // which means this one was degraded to quick_fix — fall through to the orchestrator so it
+      // runs today's flow instead of looping back into the expander forever.
+      const alreadyExpanded =
+        task.pipelineTemplate === 'full_feature' &&
+        this.store.listEvents(task.id).some((e) => e.kind === PIPELINE_EXPANDED_EVENT);
+      if (task.pipelineTemplate === 'full_feature' && !alreadyExpanded) {
         const lock = this.nextLock();
         if (!this.store.claimForDecompose(task.id, lock, ttl)) continue; // lost the race
         const roles = new Set(this.deps.profileRoles?.() ?? []);
@@ -458,6 +465,14 @@ export class KanbanDispatcher {
           expandTemplate(task, getTemplate(task.pipelineTemplate), this.store, {
             hasRole: (r) => roles.has(r)
           });
+          // A successful expansion completes the root (it leaves 'running'). If the root is
+          // still 'running', expansion was a graceful-degradation no-op (a required SDLC role
+          // was missing): release the claim back to triage so the next tick takes the
+          // fall-through orchestrator path above instead of reclaiming a dead work run.
+          if (this.store.getTask(task.id)?.status === 'running') {
+            this.store.setStatusCleared(task.id, 'triage');
+            this.store.setPendingMode(task.id, mode);
+          }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           this.store.blockTask(task.id, `pipeline expansion failed: ${msg}`);

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -31,6 +31,9 @@ const WORKTREE_SWEEP_INTERVAL_MS = 300_000;
 /** Min gap between grouping-detection runs for the same repo (debounce; spec §4). */
 const SUGGEST_COOLDOWN_MS = 30 * 60_000;
 
+/** A pipeline whose current stage is idle longer than this is flagged stale (spec §12). */
+const PIPELINE_STALE_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Exit code rune returns from a `--require-tool` run that ended without the
  * model calling a completion tool (it was nudged to the cap and gave up). Kept
@@ -1221,6 +1224,34 @@ export class KanbanDispatcher {
     return task;
   }
 
+  /**
+   * Flag pipelines stalled at their current stage past PIPELINE_STALE_MS (gate never
+   * approved, QA looping, dead stage). There is no 'blocked' feature status, so the signal
+   * is a feature-level 'blocked' event (reason 'pipeline_stalled') that the #233 autopilot
+   * trigger surfaces — the same channel processQaChanges/reclaim emit blocks on. Fire-once
+   * per feature: a prior 'pipeline_stalled' event short-circuits the re-emit.
+   */
+  sweepStalePipelines(): void {
+    const cutoff = this.deps.now() - PIPELINE_STALE_MS;
+    for (const f of this.store.activePipelineFeatures()) {
+      const tasks = this.store.pipelineTasksForFeature(f.id);
+      if (tasks.length === 0) continue;
+      const live = tasks.some((t) => t.status === 'running' || t.status === 'ready');
+      if (live) continue;
+      const settled = tasks.every((t) => t.status === 'done' || t.status === 'archived');
+      if (settled) continue; // pipeline finished, not stalled
+      const lastUpdate = Math.max(...tasks.map((t) => t.updatedAt));
+      if (lastUpdate > cutoff) continue; // still within the idle window
+      // Fire-once: skip if we already flagged this feature as stalled.
+      const alreadyFlagged = this.store
+        .listEvents(f.id)
+        .some((e) => e.kind === 'blocked' && e.payload?.reason === 'pipeline_stalled');
+      if (alreadyFlagged) continue;
+      this.store.appendEvent(f.id, null, 'blocked', { reason: 'pipeline_stalled' });
+      log.warn('pipeline stalled', { featureId: f.id, lastUpdate });
+    }
+  }
+
   /** Purge discarded artifacts past the retention window; surface each deletion as an event. */
   sweepArtifacts(): void {
     const days = this.deps.config.artifactRetentionDays;
@@ -1286,6 +1317,7 @@ export class KanbanDispatcher {
     this.integrate();
     this.sweepArtifacts();
     this.sweepMergedWorktrees();
+    this.sweepStalePipelines();
   }
 
   start(): void {

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -279,6 +279,31 @@ export class KanbanDispatcher {
         continue;
       }
 
+      // A terminal qa run that recorded request_changes: kanban_qa_verdict already finished the
+      // run + emitted qa_changes_requested, leaving the task parked 'running' (mirrors review).
+      // Park it WITHOUT recording a failure — processQaChanges() owns the re-arm/cap accounting,
+      // so reclaim must not let the generic failure path creep the task toward giveUp(). An
+      // inconclusive qa run (no verdict event) is NOT intercepted here; it falls through to the
+      // generic retry budget below.
+      if (reclaimMode === 'qa') {
+        const runId = task.currentRunId;
+        // A long qa run (heavy verify/e2e) can outlive its claim window. While alive, keep waiting.
+        if (exit == null && task.workerPid != null && this.deps.isAlive(task.workerPid)) {
+          if (task.claimLock) this.store.extendClaim(task.id, task.claimLock, VERIFY_CLAIM_TTL_MS);
+          continue;
+        }
+        const requestedChanges = this.store
+          .listEvents(task.id)
+          .some((e) => e.kind === 'qa_changes_requested' && e.runId === runId);
+        if (requestedChanges) {
+          // Park as todo and clear claim/run fields; processQaChanges() re-arms + caps it.
+          this.store.setStatusCleared(task.id, 'todo');
+          if (runId != null) this.deps.clearWorkerExit?.(runId);
+          continue;
+        }
+        // No verdict recorded — fall through to the generic failure/retry handling below.
+      }
+
       // Clean exit without a terminal tool: rune nudged to its cap and gave up
       // (exit 3). This is deterministic — retrying re-rolls the same wall — so
       // route to a deliberate review-required block, and do NOT count it as a
@@ -426,9 +451,9 @@ export class KanbanDispatcher {
         const workspace = this.deps.prepareWorkspaceFn
           ? this.deps.prepareWorkspaceFn(task)
           : (task.workspacePath ?? '');
-        const run = this.store.startRun(task.id, task.assignee, null);
-        runId = run.id;
         const mode = this.modeForReadyTask(task);
+        const run = this.store.startRun(task.id, task.assignee, null, mode);
+        runId = run.id;
         pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode });
         if (pid != null) {
           this.store.setWorkerPid(task.id, run.id, pid);
@@ -910,9 +935,13 @@ export class KanbanDispatcher {
         log.warn('raiseSpecApprovals: spec has no gate child; skipping', { specId: spec.id });
         continue;
       }
-      const children = this.store
-        .childrenOf(gateId)
-        .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement');
+      const children = this.store.childrenOf(gateId).filter((id) => {
+        const t = this.store.getTask(id);
+        // Exclude archived children: a prior dismiss re-arm archives the old implement
+        // fan-out, and counting those as evidence of a non-empty plan would raise a
+        // misleading approval targeting a gate with no runnable work.
+        return t?.pipelineStage === 'implement' && t.status !== 'archived';
+      });
       if (children.length === 0) {
         this.store.blockTask(spec.id, 'architect produced no implementation tasks');
         this.store.appendEvent(spec.id, null, 'spec_approval_raised', { empty: true });

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -395,6 +395,14 @@ export class KanbanDispatcher {
     return `${this.deps.now()}-${this.genLock}`;
   }
 
+  /** The run mode for a ready pipeline-stage task; non-pipeline ready tasks are plain 'work'. */
+  private modeForReadyTask(task: Task): RunMode {
+    if (task.pipelineStage === 'explore') return 'explore';
+    if (task.pipelineStage === 'spec') return 'spec';
+    if (task.pipelineStage === 'qa') return 'qa';
+    return 'work';
+  }
+
   claimAndSpawn(): void {
     const cap = this.deps.config.maxInProgress;
     const ttl = this.deps.config.claimTtlMs;
@@ -417,7 +425,8 @@ export class KanbanDispatcher {
           : (task.workspacePath ?? '');
         const run = this.store.startRun(task.id, task.assignee, null);
         runId = run.id;
-        pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode: 'work' });
+        const mode = this.modeForReadyTask(task);
+        pid = this.deps.spawnWorker({ task, runId: run.id, lock, workspace, mode });
         if (pid != null) {
           this.store.setWorkerPid(task.id, run.id, pid);
         }

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -19,7 +19,7 @@ import {
 } from './workspace';
 import { readLogTail } from './spawn-worker';
 import { expandTemplate, PIPELINE_EXPANDED_EVENT } from './template-expander';
-import { getTemplate } from './pipeline-templates';
+import { getTemplate, QA_ATTEMPT_CAP } from './pipeline-templates';
 
 const log = createLogger('kanban-dispatcher');
 
@@ -931,6 +931,30 @@ export class KanbanDispatcher {
     }
   }
 
+  /**
+   * Handle QA request_changes: re-arm the feature's implement children for a fix run, once
+   * per qa_changes_requested event, bounded by QA_ATTEMPT_CAP. On cap exhaustion mark the
+   * qa task blocked and emit a 'blocked' event (the #233 autopilot trigger surfaces it).
+   */
+  private processQaChanges(): void {
+    for (const qa of this.store.qaTasksNeedingRearm()) {
+      if (!qa.featureId) continue;
+      const attempts = this.store.listEvents(qa.id).filter((e) => e.kind === 'qa_rearmed').length;
+      if (attempts >= QA_ATTEMPT_CAP) {
+        this.store.blockTask(qa.id, `QA still failing after ${QA_ATTEMPT_CAP} attempt(s)`);
+        this.store.appendEvent(qa.id, null, 'blocked', { reason: 'qa_attempt_cap' });
+        continue;
+      }
+      // Re-arm implement children: set them back to ready with the QA findings as guidance.
+      for (const childId of this.store.implementChildrenOf(qa.id)) {
+        this.store.setStatus(childId, 'ready');
+      }
+      this.store.setQaVerdict(qa.featureId, null); // clear so the next QA run can re-verdict
+      this.store.setStatus(qa.id, 'todo'); // qa re-gates on the children again
+      this.store.appendEvent(qa.id, null, 'qa_rearmed', { attempt: attempts + 1 });
+    }
+  }
+
   /** Auto-integrate completed feature tasks and sync completed features. Local git only — no push/PR (that is #229). */
   integrate(): void {
     if (!this.deps.config.autoIntegrate) return;
@@ -1076,6 +1100,11 @@ export class KanbanDispatcher {
    */
   private markFeaturePrReady(feature: Feature): void {
     if (feature.prState !== 'draft' || feature.prNumber == null || !feature.repoPath) return;
+    // Pipeline features gate PR-ready on a passing QA verdict. A feature that has been
+    // QA'd (verdict non-null) but not passed must wait; non-pipeline features (verdict
+    // null AND no qa task) are unaffected.
+    if (feature.qaVerdict !== null && feature.qaVerdict !== 'pass') return;
+    if (feature.qaVerdict === null && this.store.featureHasQaStage(feature.id)) return;
     const r = this.ops.markPrReady({ repoPath: feature.repoPath, prNumber: feature.prNumber });
     if (r.ok) {
       this.store.setFeaturePrState(feature.id, 'open');
@@ -1253,6 +1282,7 @@ export class KanbanDispatcher {
     this.claimAndSpawn();
     this.reviewTasks();
     this.raiseSpecApprovals();
+    this.processQaChanges();
     this.integrate();
     this.sweepArtifacts();
     this.sweepMergedWorktrees();

--- a/src/main/kanban/kanban-dispatcher.ts
+++ b/src/main/kanban/kanban-dispatcher.ts
@@ -18,6 +18,8 @@ import {
   updateIntegrationBranchFromMain
 } from './workspace';
 import { readLogTail } from './spawn-worker';
+import { expandTemplate } from './template-expander';
+import { getTemplate } from './pipeline-templates';
 
 const log = createLogger('kanban-dispatcher');
 
@@ -137,6 +139,8 @@ export interface DispatcherDeps {
   verifyLogPath?: (runId: number) => string;
   /** Worker-role profile names (in profile order), for the auto-assign fast path and fallback. */
   workerProfileNames?: () => string[];
+  /** All profile role names present, for the pipeline expander's graceful-degradation check. */
+  profileRoles?: () => string[];
   /** Git ops for integrate(); injected in tests, defaults to real workspace.ts fns. */
   integration?: IntegrationOps;
 }
@@ -444,6 +448,25 @@ export class KanbanDispatcher {
       if (slots <= 0) break;
       const mode = task.pendingMode;
       if (mode == null) continue;
+
+      // Full-feature pipeline roots are expanded deterministically (no orchestrator).
+      if (task.pipelineTemplate === 'full_feature') {
+        const lock = this.nextLock();
+        if (!this.store.claimForDecompose(task.id, lock, ttl)) continue; // lost the race
+        const roles = new Set(this.deps.profileRoles?.() ?? []);
+        try {
+          expandTemplate(task, getTemplate(task.pipelineTemplate), this.store, {
+            hasRole: (r) => roles.has(r)
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.store.blockTask(task.id, `pipeline expansion failed: ${msg}`);
+          log.error('pipeline expand failed', { taskId: task.id, error: msg });
+        }
+        slots -= 1;
+        continue;
+      }
+
       const lock = this.nextLock();
       if (!this.store.claimForDecompose(task.id, lock, ttl)) continue; // lost the race
       let runId: number | null = null;

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -582,6 +582,30 @@ const REVIEW_TOOLS: McpTool[] = [
   }
 ];
 
+/**
+ * QA-stage tools: read the task, run/exercise the feature, then record the
+ * feature-level verdict. kanban_qa_verdict is terminal — it ends the qa run.
+ */
+const QA_TOOLS: McpTool[] = [
+  ...WORKER_TOOLS.filter((t) =>
+    ['kanban_show', 'kanban_comment', 'kanban_heartbeat', 'kanban_artifact'].includes(t.name)
+  ),
+  {
+    name: 'kanban_qa_verdict',
+    description:
+      "Record the feature-level QA verdict. decision 'pass' lets the feature PR become ready; " +
+      "'request_changes' bounces the implement tasks for a fix.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        decision: { type: 'string', enum: ['pass', 'request_changes'] },
+        summary: { type: 'string' }
+      },
+      required: ['decision', 'summary']
+    }
+  }
+];
+
 function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'decompose') return DECOMPOSE_TOOLS;
   if (mode === 'specify') return SPECIFY_TOOLS;
@@ -590,6 +614,7 @@ function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'spec') return SPEC_TOOLS;
   if (mode === 'suggest') return SUGGEST_TOOLS;
   if (mode === 'review') return REVIEW_TOOLS;
+  if (mode === 'qa') return QA_TOOLS;
   return WORKER_TOOLS;
 }
 
@@ -1266,6 +1291,38 @@ export class KanbanMcpServer {
           this.store.finishRun(scope.runId, 'completed', { summary: a.summary });
           this.unregisterRun(token);
           return this.text(res, rpcReq.id, `Verdict recorded for task ${task.id}.`);
+        }
+        case 'kanban_qa_verdict': {
+          const a = z
+            .object({
+              decision: z.enum(['pass', 'request_changes']),
+              summary: z.string().min(1)
+            })
+            .parse(args);
+          if (scope.runId !== task.currentRunId || task.status !== 'running') {
+            this.unregisterRun(token);
+            return this.text(res, rpcReq.id, `Verdict ignored: task ${task.id} moved on.`);
+          }
+          if (!task.featureId) {
+            return this.rpcError(res, rpcReq.id, 'qa task has no feature');
+          }
+          this.store.setQaVerdict(task.featureId, a.decision);
+          this.store.addComment(task.id, 'qa', `qa ${a.decision}: ${a.summary}`);
+          this.store.appendEvent(
+            task.id,
+            scope.runId,
+            a.decision === 'pass' ? 'qa_passed' : 'qa_changes_requested',
+            { summary: a.summary }
+          );
+          // Close the run before mutating the task (mirrors kanban_review_verdict):
+          // 'pass' completes the qa task (it satisfies the rollup); 'request_changes'
+          // leaves re-arming to the dispatcher (Task 11).
+          this.store.finishRun(scope.runId, 'completed', { summary: a.summary });
+          if (a.decision === 'pass') {
+            this.store.completeTask(task.id, `QA pass: ${a.summary}`);
+          }
+          this.unregisterRun(token);
+          return this.text(res, rpcReq.id, `QA verdict recorded for feature ${task.featureId}.`);
         }
         case 'kanban_complete': {
           const a = z

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -20,6 +20,7 @@ import { latestBlackboard, postBlackboardUpdate, isSwarmRoot } from './kanban-sw
 import { finalizeWorktree, reviewStat, checkMergeConflicts, headSha } from './workspace';
 import { pmDocsDir } from './pm-paths';
 import { readArtifactPreview } from './artifact-files';
+import { MAX_FANOUT } from './pipeline-templates';
 
 const log = createLogger('kanban-mcp');
 
@@ -258,6 +259,23 @@ const RESOLVE_TOOLS: McpTool[] = WORKER_TOOLS.filter((t) =>
     t.name
   )
 );
+
+/**
+ * Spec-stage (architect) tools: read the task + explore artifact, fan out implement
+ * children via kanban_create (the create handler auto-wires links/feature), then finish.
+ */
+const SPEC_TOOLS: McpTool[] = [
+  ...WORKER_TOOLS.filter((t) =>
+    [
+      'kanban_show',
+      'kanban_comment',
+      'kanban_heartbeat',
+      'kanban_complete',
+      'kanban_block'
+    ].includes(t.name)
+  ),
+  ...ORCHESTRATOR_EXTRA_TOOLS.filter((t) => t.name === 'kanban_create')
+];
 
 const SUGGEST_TOOLS: McpTool[] = [
   ...WORKER_TOOLS.filter((t) => t.name === 'kanban_show'),
@@ -569,6 +587,7 @@ function toolsForMode(mode: RunMode): McpTool[] {
   if (mode === 'specify') return SPECIFY_TOOLS;
   if (mode === 'assign') return ASSIGN_TOOLS;
   if (mode === 'resolve') return RESOLVE_TOOLS;
+  if (mode === 'spec') return SPEC_TOOLS;
   if (mode === 'suggest') return SUGGEST_TOOLS;
   if (mode === 'review') return REVIEW_TOOLS;
   return WORKER_TOOLS;
@@ -748,6 +767,14 @@ export class KanbanMcpServer {
       return { workspaceKind: 'dir', workspacePath: task.workspacePath, ...feature };
     }
     return { ...feature };
+  }
+
+  /** For a spec-stage task, resolve the pipeline gate/qa task ids (feature-keyed; no parent walk). */
+  private pipelineAnchor(
+    specTask: Task
+  ): { gateId: string; qaId: string; featureId: string } | null {
+    if (specTask.pipelineStage !== 'spec' || !specTask.featureId) return null;
+    return this.store.pipelineAnchorForFeature(specTask.featureId);
   }
 
   /** A task resolved by id, only if it lives on the PM scope's board. */
@@ -1516,6 +1543,60 @@ export class KanbanMcpServer {
               rpcReq.id,
               `unknown worker profile "${assignee}". Valid profiles: ${workerNames.join(', ')}`
             );
+          }
+          const anchor = this.pipelineAnchor(task);
+          if (anchor) {
+            // Idempotency keyed on the RUN, not on existence of children. The first child a
+            // run creates stamps `children_emitted` with that runId. A reclaim re-run is a
+            // DIFFERENT run: if a children_emitted event from another run exists, this run's
+            // fan-out is a duplicate — reject it so the prior children stand. Within the same
+            // run, subsequent kanban_create calls share the runId and are allowed.
+            const emittedEvents = this.store
+              .listEvents(task.id)
+              .filter((e) => e.kind === 'children_emitted');
+            const priorRun = emittedEvents.find((e) => e.payload?.runId !== scope.runId);
+            if (priorRun) {
+              return this.rpcError(
+                res,
+                rpcReq.id,
+                'children already emitted by a prior run; call kanban_complete'
+              );
+            }
+            // Implement children link off the gate (not the spec task), so count the
+            // gate's implement-stage children to enforce the cap.
+            const existing = this.store
+              .childrenOf(anchor.gateId)
+              .filter((id) => this.store.getTask(id)?.pipelineStage === 'implement').length;
+            if (existing >= MAX_FANOUT) {
+              return this.rpcError(
+                res,
+                rpcReq.id,
+                `fan-out cap reached (${MAX_FANOUT}); stop creating children and call kanban_complete`
+              );
+            }
+            const child = this.store.createTask({
+              title: a.title,
+              body: a.body ?? '',
+              assignee,
+              priority: a.priority ?? 0,
+              status: 'todo',
+              boardId: task.boardId,
+              ...this.inheritWorkspace(task),
+              featureId: anchor.featureId,
+              pipelineStage: 'implement'
+            });
+            this.store.addLink(anchor.gateId, child.id); // held until approval
+            this.store.addLink(child.id, anchor.qaId); // QA waits for it
+            this.store.appendEvent(child.id, scope.runId, 'task_created', {
+              by: 'architect',
+              parent: task.id
+            });
+            if (emittedEvents.length === 0) {
+              this.store.appendEvent(task.id, scope.runId, 'children_emitted', {
+                runId: scope.runId
+              });
+            }
+            return this.text(res, rpcReq.id, child.id);
           }
           const inherit = this.inheritWorkspace(task);
           const child = this.store.createTask({

--- a/src/main/kanban/kanban-mcp-server.ts
+++ b/src/main/kanban/kanban-mcp-server.ts
@@ -355,7 +355,8 @@ const PM_TOOLS: McpTool[] = [
         parents: { type: 'array', items: { type: 'string' } },
         feature_id: { type: 'string' },
         project: { type: 'string' },
-        docs: { type: 'array', items: { type: 'string' } }
+        docs: { type: 'array', items: { type: 'string' } },
+        pipeline_template: { type: 'string', enum: ['full_feature', 'quick_fix'] }
       },
       required: ['title']
     }
@@ -884,7 +885,8 @@ export class KanbanMcpServer {
               parents: z.array(z.string()).optional(),
               feature_id: z.string().optional(),
               project: z.string().optional(),
-              docs: z.array(z.string()).optional()
+              docs: z.array(z.string()).optional(),
+              pipeline_template: z.enum(['full_feature', 'quick_fix']).optional()
             })
             .parse(args);
           if (a.docs && a.docs.length > 0) {
@@ -963,6 +965,7 @@ export class KanbanMcpServer {
             boardId: scope.boardId,
             featureId: a.feature_id ?? null,
             docs: a.docs ?? [],
+            pipelineTemplate: a.pipeline_template ?? null,
             ...workspace
           });
           for (const p of a.parents ?? []) commands.link(p, task.id);

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1988,7 +1988,9 @@ export class KanbanStore {
   /** Spec-stage tasks that have completed (status done), for approval-proposal raising. */
   doneSpecTasks(): Task[] {
     const rows = this.db
-      .prepare("SELECT * FROM tasks WHERE pipeline_stage='spec' AND status='done'")
+      .prepare(
+        "SELECT * FROM tasks WHERE pipeline_stage='spec' AND status='done' ORDER BY priority DESC, created_at ASC"
+      )
       .all() as Array<Record<string, unknown>>;
     return rows.map((r) => this.rowToTask(r));
   }

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1985,6 +1985,14 @@ export class KanbanStore {
       .run(this.now(), taskId);
   }
 
+  /** Spec-stage tasks that have completed (status done), for approval-proposal raising. */
+  doneSpecTasks(): Task[] {
+    const rows = this.db
+      .prepare("SELECT * FROM tasks WHERE pipeline_stage='spec' AND status='done'")
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
   /** Review-status worktree tasks awaiting an agent verdict (candidates for reviewTasks()). */
   reviewPendingTasks(): Task[] {
     const rows = this.db

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1544,6 +1544,25 @@ export class KanbanStore {
     return rows.map((r) => this.rowToFeature(r));
   }
 
+  /** Active features that have at least one pipeline-stage task. */
+  activePipelineFeatures(): Feature[] {
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT f.* FROM features f JOIN tasks t ON t.feature_id = f.id
+          WHERE f.status='active' AND t.pipeline_stage IS NOT NULL`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToFeature(r));
+  }
+
+  /** All pipeline-stage tasks for a feature. */
+  pipelineTasksForFeature(featureId: string): Task[] {
+    const rows = this.db
+      .prepare('SELECT * FROM tasks WHERE feature_id=? AND pipeline_stage IS NOT NULL')
+      .all(featureId) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
   updateFeature(id: string, fields: UpdateFeatureInput): void {
     const current = this.getFeature(id);
     if (!current) return;

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -258,6 +258,14 @@ export class KanbanStore {
       this.addColumnIfMissing('boards', 'digest_cron', 'TEXT');
       this.addColumnIfMissing('boards', 'last_digest_at', 'INTEGER');
     }
+    if (current < 18) {
+      // SDLC pipeline templates (#234): stage identity on tasks + a QA verdict on
+      // features. Additive, idempotent. The columns are in SCHEMA_SQL for fresh
+      // installs; add them here for existing DBs. No new indexes.
+      this.addColumnIfMissing('tasks', 'pipeline_template', 'TEXT');
+      this.addColumnIfMissing('tasks', 'pipeline_stage', 'TEXT');
+      this.addColumnIfMissing('features', 'qa_verdict', 'TEXT');
+    }
     // Seed the permanent default board (idempotent: fresh and existing DBs).
     const ts = this.now();
     this.db
@@ -334,6 +342,8 @@ export class KanbanStore {
       conflictFiles: JSON.parse(String(r.conflict_files ?? '[]')) as string[],
       worktreePruned: Number(r.worktree_pruned ?? 0) === 1,
       systemKind: (r.system_kind as string | null) ?? null,
+      pipelineTemplate: (r.pipeline_template as Task['pipelineTemplate']) ?? null,
+      pipelineStage: (r.pipeline_stage as Task['pipelineStage']) ?? null,
       createdAt: Number(r.created_at),
       updatedAt: Number(r.updated_at)
     };
@@ -346,10 +356,10 @@ export class KanbanStore {
       .prepare(
         `INSERT INTO tasks (id, title, body, assignee, status, priority, tenant,
           workspace_kind, workspace_path, repo_path, branch_name, base_branch, model_override, skills, docs, board_id, feature_id, idempotency_key,
-          scheduled_from, system_kind, max_runtime_seconds, max_retries, created_at, updated_at)
+          scheduled_from, system_kind, pipeline_template, pipeline_stage, max_runtime_seconds, max_retries, created_at, updated_at)
          VALUES (@id, @title, @body, @assignee, @status, @priority, @tenant,
           @workspace_kind, @workspace_path, @repo_path, @branch_name, @base_branch, @model_override, @skills, @docs, @board_id, @feature_id, @idempotency_key,
-          @scheduled_from, @system_kind, @max_runtime_seconds, @max_retries, @created_at, @updated_at)`
+          @scheduled_from, @system_kind, @pipeline_template, @pipeline_stage, @max_runtime_seconds, @max_retries, @created_at, @updated_at)`
       )
       .run({
         id,
@@ -372,6 +382,8 @@ export class KanbanStore {
         idempotency_key: input.idempotencyKey ?? null,
         scheduled_from: input.scheduledFrom ?? null,
         system_kind: input.systemKind ?? null,
+        pipeline_template: input.pipelineTemplate ?? null,
+        pipeline_stage: input.pipelineStage ?? null,
         max_runtime_seconds: input.maxRuntimeSeconds ?? null,
         max_retries: input.maxRetries ?? 1,
         created_at: ts,
@@ -1448,6 +1460,7 @@ export class KanbanStore {
       checksState: (r.checks_state as ChecksState | null) ?? null,
       syncedAt: (r.pr_synced_at as number | null) ?? null,
       prSkipNotified: Number(r.pr_skip_notified ?? 0) === 1,
+      qaVerdict: (r.qa_verdict as Feature['qaVerdict']) ?? null,
       createdAt: Number(r.created_at),
       updatedAt: Number(r.updated_at)
     };
@@ -1912,6 +1925,13 @@ export class KanbanStore {
         'UPDATE tasks SET review_verdict=@v, review_head_sha=@sha, updated_at=@ts WHERE id=@id'
       )
       .run({ id: taskId, v: decision, sha: headSha ?? null, ts: this.now() });
+  }
+
+  /** Record the feature-level QA verdict (pipeline §8). null clears it. */
+  setQaVerdict(featureId: string, verdict: 'pass' | 'request_changes' | null): void {
+    this.db
+      .prepare('UPDATE features SET qa_verdict=@v, updated_at=@ts WHERE id=@id')
+      .run({ id: featureId, v: verdict, ts: this.now() });
   }
 
   incrementReviewAttempts(taskId: string): void {

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1813,6 +1813,13 @@ export class KanbanStore {
       .run(status, this.now(), taskId);
   }
 
+  /** Attach a task to a feature (pipeline expander backfills the root's feature). */
+  setFeatureId(taskId: string, featureId: string): void {
+    this.db
+      .prepare('UPDATE tasks SET feature_id=?, updated_at=? WHERE id=?')
+      .run(featureId, this.now(), taskId);
+  }
+
   setWorkerPid(taskId: string, runId: number, pid: number): void {
     const ts = this.now();
     this.db.prepare('UPDATE tasks SET worker_pid=?, updated_at=? WHERE id=?').run(pid, ts, taskId);

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1487,6 +1487,29 @@ export class KanbanStore {
     return row ? this.rowToFeature(row) : null;
   }
 
+  /**
+   * Resolve a full_feature pipeline's gate/qa task ids from the root's pipeline_expanded
+   * event, keyed by feature id. Returns null for non-pipeline features or fallback
+   * expansions (which record `fallback` and no stage ids).
+   */
+  pipelineAnchorForFeature(
+    featureId: string
+  ): { gateId: string; qaId: string; featureId: string } | null {
+    const row = this.db
+      .prepare(
+        "SELECT payload FROM task_events WHERE kind='pipeline_expanded' " +
+          "AND json_extract(payload, '$.featureId')=@f " +
+          "AND json_extract(payload, '$.fallback') IS NULL LIMIT 1"
+      )
+      .get({ f: featureId }) as { payload: string } | undefined;
+    if (!row) return null;
+    const p = JSON.parse(row.payload) as Record<string, unknown>;
+    const gateId = p.gateId;
+    const qaId = p.qaId;
+    if (typeof gateId !== 'string' || typeof qaId !== 'string') return null;
+    return { gateId, qaId, featureId };
+  }
+
   listFeatures(filter: { boardId?: string; status?: FeatureStatus } = {}): Feature[] {
     const where: string[] = [];
     const params: Record<string, unknown> = {};

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -595,6 +595,20 @@ export class KanbanStore {
     return event;
   }
 
+  /**
+   * Drop a spec task's re-arm guards so a re-armed run may re-fan-out AND the dispatcher
+   * may raise a fresh approval proposal once it completes again (pipeline §6). Clears both
+   * the fan-out guard (`children_emitted`) and the one-shot approval guard
+   * (`spec_approval_raised`); leaving the latter would permanently silence raiseSpecApprovals.
+   */
+  clearSpecFanout(specTaskId: string): void {
+    this.db
+      .prepare(
+        "DELETE FROM task_events WHERE task_id=? AND kind IN ('children_emitted','spec_approval_raised')"
+      )
+      .run(specTaskId);
+  }
+
   listEvents(taskId: string): TaskEvent[] {
     const rows = this.db
       .prepare('SELECT * FROM task_events WHERE task_id=? ORDER BY id ASC')

--- a/src/main/kanban/kanban-store.ts
+++ b/src/main/kanban/kanban-store.ts
@@ -1978,6 +1978,34 @@ export class KanbanStore {
       .run({ id: featureId, v: verdict, ts: this.now() });
   }
 
+  /** True when a feature has a qa-stage task (it is a pipeline feature awaiting QA). */
+  featureHasQaStage(featureId: string): boolean {
+    const row = this.db
+      .prepare("SELECT 1 FROM tasks WHERE feature_id=? AND pipeline_stage='qa' LIMIT 1")
+      .get(featureId);
+    return row != null;
+  }
+
+  /**
+   * qa-stage tasks whose feature verdict is request_changes (need a re-arm cycle). Excludes
+   * already-blocked qa tasks: once a task is blocked at the cap its verdict stays
+   * request_changes, so without this filter it would be reselected and re-blocked every tick.
+   */
+  qaTasksNeedingRearm(): Task[] {
+    const rows = this.db
+      .prepare(
+        `SELECT t.* FROM tasks t JOIN features f ON f.id = t.feature_id
+          WHERE t.pipeline_stage='qa' AND f.qa_verdict='request_changes' AND t.status != 'blocked'`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToTask(r));
+  }
+
+  /** Implement-stage tasks linked as parents of a qa task (the children QA waits on). */
+  implementChildrenOf(qaTaskId: string): string[] {
+    return this.parentsOf(qaTaskId).filter((id) => this.getTask(id)?.pipelineStage === 'implement');
+  }
+
   incrementReviewAttempts(taskId: string): void {
     this.db
       .prepare('UPDATE tasks SET review_attempts = review_attempts + 1, updated_at=? WHERE id=?')

--- a/src/main/kanban/pipeline-templates.ts
+++ b/src/main/kanban/pipeline-templates.ts
@@ -1,0 +1,32 @@
+import type { PipelineTemplateId, StageKind } from '../../shared/kanban-types';
+
+export interface PipelineTemplate {
+  id: PipelineTemplateId;
+  /**
+   * Ordered stages the expander lays down. Excludes the LLM-fanned implement
+   * children + their per-child review, which the architect emits at the spec stage.
+   */
+  stages: StageKind[];
+}
+
+/** Max implement children the architect may fan out at the spec stage (spec §5). */
+export const MAX_FANOUT = 12;
+
+/** QA request_changes re-arm cycles before the feature is blocked (spec §8). */
+export const QA_ATTEMPT_CAP = 2;
+
+export const FULL_FEATURE: PipelineTemplate = {
+  id: 'full_feature',
+  stages: ['explore', 'spec', 'gate', 'qa']
+};
+
+export const QUICK_FIX: PipelineTemplate = {
+  id: 'quick_fix',
+  // No expansion: the root task runs today's work → review flow unchanged.
+  stages: []
+};
+
+/** Look up a template by id. Returns QUICK_FIX for null/unknown (the inert default). */
+export function getTemplate(id: PipelineTemplateId | null | undefined): PipelineTemplate {
+  return id === 'full_feature' ? FULL_FEATURE : QUICK_FIX;
+}

--- a/src/main/kanban/proposal-executor.ts
+++ b/src/main/kanban/proposal-executor.ts
@@ -34,6 +34,9 @@ export function executeProposal(
     case 'archive_task':
       commands.archive(targetId);
       return;
+    case 'approve_spec':
+      expectOk(commands.approveSpec(targetId));
+      return;
     default: {
       const exhaustive: never = kind;
       throw new Error(`unknown proposal kind: ${String(exhaustive)}`);

--- a/src/main/kanban/schema.ts
+++ b/src/main/kanban/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 17;
+export const SCHEMA_VERSION = 18;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS tasks (
@@ -52,6 +52,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   review_attempts INTEGER NOT NULL DEFAULT 0,
   review_head_sha TEXT,
   system_kind TEXT,
+  pipeline_template TEXT,
+  pipeline_stage TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
@@ -135,6 +137,7 @@ CREATE TABLE IF NOT EXISTS features (
   checks_state TEXT,
   pr_synced_at INTEGER,
   pr_skip_notified INTEGER NOT NULL DEFAULT 0,
+  qa_verdict TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -138,6 +138,16 @@ function buildPrompt(input: BuildWorkerInput): string {
       `findings. Do not modify the code.\n\n## Diff\n\n\`\`\`diff\n${diff}\n\`\`\``
     );
   }
+  if (mode === 'explore') {
+    return (
+      `explore kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are a read-only cartographer. Map the codebase relevant to this task: affected ` +
+      `files, modules, and patterns; surface risks and unknowns. Write NO code and make NO ` +
+      `edits. Register your findings as a kanban_artifact (path relative to your working ` +
+      `directory) and post a one-paragraph summary comment on this task with kanban_comment. ` +
+      `When done, call kanban_complete with a one-line summary.`
+    );
+  }
   const verifyBlock = input.verifyFailure
     ? `Your previous completion failed the project's verify commands. Fix the cause and call ` +
       `kanban_complete again — it will re-run verification.\n\n\`\`\`\n${input.verifyFailure}\n\`\`\`\n\n`
@@ -188,6 +198,7 @@ function requireToolsForMode(mode: RunMode): string | null {
     case 'work':
     case 'decompose':
     case 'resolve':
+    case 'explore':
       return 'kanban_complete,kanban_block';
     case 'specify':
       return 'kanban_update';

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -10,6 +10,7 @@ import {
   agentHostFor
 } from './agent-context';
 import { renderProfileMarkdown } from './profile-file';
+import { MAX_FANOUT } from './pipeline-templates';
 import { learningsMcpEntry } from '../learnings/learnings-mcp-registrar';
 import { isValidProfileName, type WorkerProfile } from '../../shared/types';
 import type { RunMode, VerifyCommand } from '../../shared/kanban-types';
@@ -148,6 +149,17 @@ function buildPrompt(input: BuildWorkerInput): string {
       `When done, call kanban_complete with a one-line summary.`
     );
   }
+  if (mode === 'spec') {
+    return (
+      `spec kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are the architect. Read the explore artifact and this task with kanban_show, then write ` +
+      `a concrete implementation spec. Decompose the work into independent units: call kanban_create ` +
+      `once per unit with a clear title and a body containing that unit's slice of the spec. Do NOT ` +
+      `set parents, feature_id, or links — the system wires them. Cap your fan-out at ${MAX_FANOUT} ` +
+      `children. Do not implement anything. When the fan-out is complete, call kanban_complete with a ` +
+      `one-line plan summary.`
+    );
+  }
   const verifyBlock = input.verifyFailure
     ? `Your previous completion failed the project's verify commands. Fix the cause and call ` +
       `kanban_complete again — it will re-run verification.\n\n\`\`\`\n${input.verifyFailure}\n\`\`\`\n\n`
@@ -199,6 +211,7 @@ function requireToolsForMode(mode: RunMode): string | null {
     case 'decompose':
     case 'resolve':
     case 'explore':
+    case 'spec':
       return 'kanban_complete,kanban_block';
     case 'specify':
       return 'kanban_update';

--- a/src/main/kanban/spawn-worker.ts
+++ b/src/main/kanban/spawn-worker.ts
@@ -160,6 +160,15 @@ function buildPrompt(input: BuildWorkerInput): string {
       `one-line plan summary.`
     );
   }
+  if (mode === 'qa') {
+    return (
+      `qa kanban task ${task.id}: ${task.title}\n\n${task.body}\n\n` +
+      `You are QA for this feature. Validate the whole feature against the root task's acceptance ` +
+      `criteria. Run the project's verify commands and exercise end-to-end behavior (execution-based, ` +
+      `not a re-read of diffs). Re-check the risks the explore stage flagged. When done, call ` +
+      `kanban_qa_verdict with decision 'pass' or 'request_changes' and a one-line summary.`
+    );
+  }
   const verifyBlock = input.verifyFailure
     ? `Your previous completion failed the project's verify commands. Fix the cause and call ` +
       `kanban_complete again — it will re-run verification.\n\n\`\`\`\n${input.verifyFailure}\n\`\`\`\n\n`
@@ -221,6 +230,8 @@ function requireToolsForMode(mode: RunMode): string | null {
       return 'kanban_suggest_feature,kanban_block';
     case 'review':
       return 'kanban_review_verdict';
+    case 'qa':
+      return 'kanban_qa_verdict';
     case 'verify':
       // A deterministic verify run has no agent and no terminal MCP tool.
       return null;

--- a/src/main/kanban/template-expander.ts
+++ b/src/main/kanban/template-expander.ts
@@ -1,0 +1,140 @@
+import { createLogger } from '../logger';
+import type { KanbanStore } from './kanban-store';
+import type { Task } from '../../shared/kanban-types';
+import type { PipelineTemplate } from './pipeline-templates';
+
+const log = createLogger('template-expander');
+
+/** Profile roles the full_feature pipeline requires; missing any ⇒ fall back to quick_fix. */
+const REQUIRED_ROLES = ['explorer', 'architect', 'qa'] as const;
+
+/** Event kind written on the root once expansion has run, for reclaim-safe idempotency. */
+export const PIPELINE_EXPANDED_EVENT = 'pipeline_expanded';
+
+export interface ExpanderDeps {
+  /** Profile names present per role, used for the graceful-degradation check. */
+  hasRole: (role: string) => boolean;
+}
+
+/**
+ * Lay down the full_feature skeleton for a triage root task, mirroring createSwarm:
+ * ensure a feature, then create explore(ready) → spec(todo) → gate(blocked) → qa(todo)
+ * with the gating links. The implement-children fan-out is NOT created here — the
+ * architect emits it at the spec stage (§5). Idempotent: re-running is a no-op once
+ * the PIPELINE_EXPANDED_EVENT is present. Falls back to quick_fix (no expansion) if a
+ * required role profile is missing.
+ */
+export function expandTemplate(
+  root: Task,
+  template: PipelineTemplate,
+  store: KanbanStore,
+  deps: ExpanderDeps
+): void {
+  if (template.id !== 'full_feature') return; // quick_fix / inert: no expansion
+
+  // Idempotency: a prior expansion left an event on the root.
+  if (store.listEvents(root.id).some((e) => e.kind === PIPELINE_EXPANDED_EVENT)) {
+    return;
+  }
+
+  // Graceful degradation: a missing SDLC role makes the pipeline unrunnable, so
+  // degrade to quick_fix (root runs the normal flow) rather than wedging.
+  const missing = REQUIRED_ROLES.filter((r) => !deps.hasRole(r));
+  if (missing.length > 0) {
+    log.warn('pipeline role(s) missing; falling back to quick_fix', {
+      rootId: root.id,
+      missing
+    });
+    store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, {
+      fallback: 'quick_fix',
+      missing
+    });
+    return; // root stays a triage task and runs today's flow
+  }
+
+  store.transaction(() => {
+    // 1. Ensure the root has a feature so all stages ship as one unit.
+    let featureId = root.featureId;
+    if (!featureId) {
+      const feature = store.createFeature({
+        boardId: root.boardId,
+        name: root.title,
+        repoPath: root.repoPath,
+        baseBranch: root.baseBranch
+      });
+      featureId = feature.id;
+      store.setFeatureId(root.id, featureId);
+    }
+
+    const common = {
+      boardId: root.boardId,
+      featureId,
+      repoPath: root.repoPath ?? undefined,
+      baseBranch: root.baseBranch ?? null,
+      priority: root.priority
+    };
+
+    // 2. explore (read-only mapping) — starts ready so it spawns immediately.
+    const explore = store.createTask({
+      title: `Explore: ${root.title}`,
+      body:
+        `Map the codebase relevant to root task ${root.id}: affected files/modules/patterns, ` +
+        `risks and unknowns. Write NO code. Register findings as a kanban_artifact and post a ` +
+        `one-paragraph summary comment on ${root.id}.\n\nRoot:\n${root.body}`,
+      assignee: 'explorer',
+      status: 'ready',
+      pipelineStage: 'explore',
+      ...common
+    });
+
+    // 3. spec (architect) — gated on explore.
+    const spec = store.createTask({
+      title: `Spec: ${root.title}`,
+      body:
+        `Read the explore artifact + root task ${root.id}, write a concrete implementation spec, ` +
+        `then fan out implementation work by calling kanban_create once per unit (the create path ` +
+        `wires links + feature for you). Do not implement. Root:\n${root.body}`,
+      assignee: 'architect',
+      status: 'todo',
+      pipelineStage: 'spec',
+      ...common
+    });
+    store.addLink(explore.id, spec.id);
+
+    // 4. gate — blocked; only executeProposal('approve_spec') moves it to done.
+    const gate = store.createTask({
+      title: `Approve spec: ${root.title}`,
+      body: `Spec approval gate for feature ${featureId}. Released only by an approve_spec proposal.`,
+      status: 'blocked',
+      systemKind: 'pipeline_gate',
+      pipelineStage: 'gate',
+      ...common
+    });
+    store.addLink(spec.id, gate.id);
+
+    // 5. qa — gated on the gate (baseline; implement children also link → qa in §5).
+    const qa = store.createTask({
+      title: `QA: ${root.title}`,
+      body:
+        `Validate feature ${featureId} against root task ${root.id}'s acceptance criteria. Run the ` +
+        `project verify commands, exercise end-to-end behavior, check explore-identified risks, then ` +
+        `emit a verdict.`,
+      assignee: 'qa',
+      status: 'todo',
+      pipelineStage: 'qa',
+      ...common
+    });
+    store.addLink(gate.id, qa.id);
+
+    // 6. Idempotency marker + audit record of the laid-down graph.
+    store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, {
+      featureId,
+      exploreId: explore.id,
+      specId: spec.id,
+      gateId: gate.id,
+      qaId: qa.id
+    });
+    // The root is the planning anchor; complete it so it doesn't sit in triage.
+    store.completeTask(root.id, 'Pipeline expanded; stages laid down.');
+  });
+}

--- a/src/main/kanban/template-expander.ts
+++ b/src/main/kanban/template-expander.ts
@@ -52,7 +52,7 @@ export function expandTemplate(
     return; // root stays a triage task and runs today's flow
   }
 
-  store.transaction(() => {
+  const expanded = store.transaction(() => {
     // 1. Ensure the root has a feature so all stages ship as one unit.
     let featureId = root.featureId;
     if (!featureId) {
@@ -126,15 +126,20 @@ export function expandTemplate(
     });
     store.addLink(gate.id, qa.id);
 
-    // 6. Idempotency marker + audit record of the laid-down graph.
-    store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, {
+    // The root is the planning anchor; complete it so it doesn't sit in triage.
+    // (completeTask is a plain DB write — no onEvent — so it stays in the transaction.)
+    store.completeTask(root.id, 'Pipeline expanded; stages laid down.');
+
+    return {
       featureId,
       exploreId: explore.id,
       specId: spec.id,
       gateId: gate.id,
       qaId: qa.id
-    });
-    // The root is the planning anchor; complete it so it doesn't sit in triage.
-    store.completeTask(root.id, 'Pipeline expanded; stages laid down.');
+    };
   });
+
+  // Idempotency marker + audit record of the laid-down graph. Emitted after commit
+  // so onEvent observers never fire mid-transaction (matches createSwarm's caller).
+  store.appendEvent(root.id, null, PIPELINE_EXPANDED_EVENT, expanded);
 }

--- a/src/renderer/src/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/src/components/kanban/KanbanBoard.tsx
@@ -71,6 +71,7 @@ export function KanbanBoard(): React.JSX.Element {
   // null = not applicable / still checking; true/false = the picked folder's git-repo status.
   const [folderIsRepo, setFolderIsRepo] = useState<boolean | null>(null);
   const [newStatus, setNewStatus] = useState<TaskStatus>('triage');
+  const [newTemplate, setNewTemplate] = useState<'quick_fix' | 'full_feature'>('quick_fix');
   const draggingId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -188,6 +189,7 @@ export function KanbanBoard(): React.JSX.Element {
           boardId: activeBoardSlug,
           status: newStatus,
           featureId,
+          pipelineTemplate: newTemplate === 'full_feature' ? 'full_feature' : 'quick_fix',
           ...workspace
         });
       }
@@ -201,6 +203,7 @@ export function KanbanBoard(): React.JSX.Element {
     setNewMode('scratch');
     setNewIsolated(true);
     setNewStatus('triage');
+    setNewTemplate('quick_fix');
     setCreating(false);
     clearSeed();
   }
@@ -461,6 +464,19 @@ export function KanbanBoard(): React.JSX.Element {
                 >
                   <option value="triage">Triage</option>
                   <option value="todo">Todo</option>
+                </select>
+              </div>
+              <div className="flex items-center gap-2 text-[11px] font-medium text-neutral-400">
+                Pipeline
+                <select
+                  value={newTemplate}
+                  onChange={(e) =>
+                    setNewTemplate(e.target.value === 'full_feature' ? 'full_feature' : 'quick_fix')
+                  }
+                  className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs font-normal text-neutral-200 outline-none focus:border-blue-500"
+                >
+                  <option value="quick_fix">Quick fix (default)</option>
+                  <option value="full_feature">Full feature (explore → spec → QA)</option>
                 </select>
               </div>
               <div className="text-[11px] font-medium text-neutral-400">

--- a/src/renderer/src/components/kanban/KanbanCard.tsx
+++ b/src/renderer/src/components/kanban/KanbanCard.tsx
@@ -55,6 +55,11 @@ export function KanbanCard({
       </div>
       <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[10px] text-neutral-400">
         <span className="font-mono text-neutral-500">{card.id}</span>
+        {card.pipelineStage && (
+          <span className="rounded bg-sky-500/20 px-1 text-sky-300" title="Pipeline stage">
+            {card.pipelineStage}
+          </span>
+        )}
         {card.assignee && (
           <span className="rounded bg-teal-500/20 px-1 text-teal-300">{card.assignee}</span>
         )}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -138,6 +138,46 @@ export const DEFAULT_SETTINGS: FleetSettings = {
         model: '',
         skills: [],
         instructions: DEFAULT_ORCHESTRATOR_INSTRUCTIONS
+      },
+      {
+        name: 'explorer',
+        role: 'explorer',
+        model: '',
+        skills: [],
+        instructions:
+          'You are a read-only cartographer. Map the files, modules, and patterns affected by the ' +
+          'task; surface risks and unknowns. Never write code. Register your findings as a ' +
+          'kanban_artifact and post a one-paragraph summary on the root task, then call kanban_complete.'
+      },
+      {
+        name: 'architect',
+        role: 'architect',
+        model: '',
+        skills: [],
+        instructions:
+          'You are the architect. Consume the explore findings, write a concrete implementation spec, ' +
+          'then emit the implementation work by calling kanban_create once per unit (capped). Do not ' +
+          'implement anything yourself. Call kanban_complete with a plan summary when the fan-out is done.'
+      },
+      {
+        name: 'reviewer',
+        role: 'reviewer',
+        model: '',
+        skills: ['requesting-code-review'],
+        instructions:
+          'You are an independent code reviewer, distinct from the implementer (prefer a different model ' +
+          'to counter self-preference bias). Judge the diff against the task goal and acceptance criteria; ' +
+          'call kanban_review_verdict with approve or request_changes plus specific findings.'
+      },
+      {
+        name: 'qa',
+        role: 'qa',
+        model: '',
+        skills: [],
+        instructions:
+          'You are feature-level QA. Validate the whole feature against acceptance criteria using ' +
+          'execution (run the project verify commands and exercise behavior), not a re-read of diffs. ' +
+          'Emit your verdict with kanban_qa_verdict: pass or request_changes.'
       }
     ]
   }

--- a/src/shared/kanban-types.ts
+++ b/src/shared/kanban-types.ts
@@ -23,7 +23,16 @@ export type RunMode =
   | 'resolve'
   | 'suggest'
   | 'verify'
-  | 'review';
+  | 'review'
+  | 'explore'
+  | 'spec'
+  | 'qa';
+
+/** A pipeline template id carried on the root task. NULL ⇒ behaves as quick_fix. */
+export type PipelineTemplateId = 'full_feature' | 'quick_fix';
+
+/** Stage identity carried by generated pipeline tasks. NULL ⇒ ordinary non-pipeline task. */
+export type StageKind = 'explore' | 'spec' | 'gate' | 'implement' | 'review' | 'qa';
 
 /** A triage task can be flagged for an orchestrator run. */
 export type PendingMode = 'decompose' | 'specify';
@@ -95,6 +104,8 @@ export interface Feature {
   checksState: ChecksState | null;
   syncedAt: number | null;
   prSkipNotified: boolean;
+  /** Feature-level QA verdict (pipeline §8). NULL ⇒ not yet QA'd / non-pipeline. */
+  qaVerdict: 'pass' | 'request_changes' | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -237,6 +248,10 @@ export interface Task {
   worktreePruned: boolean;
   /** Non-null marks a dispatcher-created system task (e.g. 'feature_sync'); excluded from feature roll-ups. */
   systemKind: string | null;
+  /** Template carried by the root task (NULL ⇒ quick_fix / non-pipeline). */
+  pipelineTemplate: PipelineTemplateId | null;
+  /** Stage identity for a generated pipeline task (NULL ⇒ non-pipeline). */
+  pipelineStage: StageKind | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -299,7 +314,8 @@ export type PmProposalKind =
   | 'accept_review_task'
   | 'ship_feature'
   | 'complete_task'
-  | 'archive_task';
+  | 'archive_task'
+  | 'approve_spec';
 
 export type PmProposalStatus = 'pending' | 'accepted' | 'dismissed' | 'failed';
 
@@ -323,7 +339,8 @@ export const PM_PROPOSAL_KINDS = [
   'accept_review_task',
   'ship_feature',
   'complete_task',
-  'archive_task'
+  'archive_task',
+  'approve_spec'
 ] as const satisfies readonly PmProposalKind[];
 
 export interface TaskComment {
@@ -402,6 +419,8 @@ export interface CreateTaskInput {
   maxRetries?: number;
   scheduledFrom?: string | null;
   systemKind?: string | null;
+  pipelineTemplate?: PipelineTemplateId | null;
+  pipelineStage?: StageKind | null;
 }
 
 export interface UpdateTaskFields {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -147,7 +147,7 @@ export type VisualizerEffects = {
 /** A named worker role materialized to `<workspace>/.rune/profiles/<name>.md`. */
 export type WorkerProfile = {
   name: string; // ^[a-z0-9][a-z0-9_-]*$ (rune's validName)
-  role: 'worker' | 'orchestrator' | 'reviewer'; // orchestrator drives decompose/specify; reviewer drives code-review runs
+  role: 'worker' | 'orchestrator' | 'reviewer' | 'explorer' | 'architect' | 'qa'; // orchestrator drives decompose/specify; reviewer drives code-review runs; explorer/architect/qa drive pipeline stages
   model: string; // '' → leave to rune's normal provider resolution
   skills: string[];
   instructions: string; // persona / system-prompt body


### PR DESCRIPTION
## Summary
Adds selectable **pipeline templates** to the autonomous kanban board (#234, the SDLC-pipeline step of the autonomous-dev-team epic #236, building on the #233 proposal machinery).

A `full_feature` ticket now flows through a real software-development lifecycle:

`explore → spec → (human approval gate) → implement → review → QA`

while `quick_fix`/NULL tickets keep today's lightweight `work → review` flow **unchanged**.

### How it works
- **Deterministic skeleton + LLM fan-out.** `template-expander.ts` lays down `explore(ready) → spec(todo) → gate(blocked) → qa(todo)` with gating links (mirroring `createSwarm`). Only the implement-children fan-out is LLM-decided by the architect at the spec stage.
- **Explore** (read-only cartographer) maps the codebase; **architect** (spec stage) writes a spec and fans out implement children via `kanban_create` — auto-linked off the gate (gate→child, child→qa), runId-keyed idempotent, capped at `MAX_FANOUT=12`.
- **Human approval gate.** The `blocked` gate task is released only by an `approve_spec` proposal (built on #233, PM-agent-independent). Implement children cannot run until approval. Dismiss re-arms the spec for a fresh fan-out.
- **QA** records a feature-level verdict via the new `kanban_qa_verdict` tool. `request_changes` re-arms implement children bounded by `QA_ATTEMPT_CAP=2`; `markFeaturePrReady` gates on a passing verdict.
- **Liveness.** `sweepStalePipelines` flags pipelines idle >24h via a feature-level `blocked` event (surfaced by the #233 PM autopilot).
- Schema `SCHEMA_VERSION 17 → 18` (`tasks.pipeline_template`, `tasks.pipeline_stage`, `features.qa_verdict`); six worker roles (added explorer/architect/qa) + seeded default profiles; `pipeline_template` intake arg through MCP/commands/IPC/preload; renderer template dropdown + stage badges + generic `approve_spec` proposal card.

Spec: `docs/superpowers/specs/2026-06-16-sdlc-pipeline-templates-design.md`
Plan: `docs/superpowers/plans/2026-06-16-sdlc-pipeline-templates.md`

Built via 16-task subagent-driven development; every task got a spec-compliance + code-quality review. The review loop caught and fixed several real bugs (stage persona mis-routing, a stuck-running degraded root, a double-guard dismiss stall, cap-blocked QA re-block spam, and QA reclaim failure-counter creep).

## Test plan
- [x] `npm run typecheck` — green (node + web)
- [x] `npx vitest run` — **1490 passed, 0 failed**
- [x] `npm run build` — succeeds
- [ ] Manual smoke: create a `full_feature` ticket → confirm explore/spec stages spawn under the right personas → approve the spec proposal → implement children promote → QA verdict gates the PR
- [ ] Confirm a `quick_fix`/NULL ticket behaves exactly as before (no new gating/spawns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)