### PR TITLE
feat: opencode plugin for Fleet tools

### DIFF
--- a/docs/superpowers/plans/2026-06-19-fleet-opencode-plugin.md
+++ b/docs/superpowers/plans/2026-06-19-fleet-opencode-plugin.md
@@ -1,0 +1,613 @@
+# Fleet OpenCode Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an opencode plugin that exposes all Fleet CLI commands (except Pi/watch) as opencode tools, communicating via Unix domain socket.
+
+**Architecture:** One file at `~/.config/opencode/plugins/fleet.ts`. Uses `@opencode-ai/plugin` for tool definitions and `node:net` for direct socket communication with the Fleet app. Follows the same newline-delimited JSON protocol as the Fleet CLI.
+
+**Tech Stack:** TypeScript, `@opencode-ai/plugin` (already installed), Node.js `net` module.
+
+---
+
+### Task 1: Write the complete plugin file
+
+**Files:**
+- Create: `~/.config/opencode/plugins/fleet.ts`
+
+- [ ] **Step 1: Create the plugin file**
+
+```typescript
+import { createConnection } from "node:net"
+import { randomUUID } from "node:crypto"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { Plugin } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+
+const z = tool.schema
+
+const SOCK_PATH = join(homedir(), ".fleet", "fleet.sock")
+const DEV_SOCK_PATH = join(homedir(), ".fleet", "fleet-dev.sock")
+const TIMEOUT_MS = 30_000
+
+interface FleetResponse {
+  id: string
+  ok: boolean
+  data?: unknown
+  error?: string
+}
+
+interface FleetError {
+  message: string
+  code?: string
+}
+
+function isFleetResponse(v: unknown): v is FleetResponse {
+  return (
+    v != null &&
+    typeof v === "object" &&
+    "ok" in v &&
+    typeof (v as { ok?: unknown }).ok === "boolean"
+  )
+}
+
+function resolveSocketPath(): string {
+  if (existsSync(SOCK_PATH)) return SOCK_PATH
+  if (existsSync(DEV_SOCK_PATH)) return DEV_SOCK_PATH
+  return SOCK_PATH
+}
+
+const COMMAND_MAP: Record<string, string> = {
+  "images.generate": "image.generate",
+  "images.edit": "image.edit",
+  "images.status": "image.status",
+  "images.list": "image.list",
+  "images.retry": "image.retry",
+  "images.config": "image.config.get",
+  "images.action": "image.action",
+  "images.actions": "image.actions.list",
+  "annotate.start": "annotate.start",
+}
+
+function mapCmd(cliCommand: string): string {
+  if (cliCommand === "images.config") {
+    return "image.config.get"
+  }
+  return COMMAND_MAP[cliCommand] ?? cliCommand
+}
+
+async function sendCommand(
+  command: string,
+  args: Record<string, unknown> = {},
+  timeoutMs = TIMEOUT_MS,
+): Promise<FleetResponse> {
+  const cmd = mapCmd(command)
+  const sockPath = resolveSocketPath()
+
+  if (!existsSync(sockPath)) {
+    return {
+      id: "",
+      ok: false,
+      error: `Fleet app is not running (no socket at ${sockPath}). Start Fleet first.`,
+    }
+  }
+
+  return new Promise((resolve) => {
+    const id = randomUUID()
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const settle = (response: FleetResponse): void => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve(response)
+    }
+
+    timer = setTimeout(() => {
+      settle({ id, ok: false, error: `Timeout after ${timeoutMs}ms` })
+      try { socket.destroy() } catch { /* ignore */ }
+    }, timeoutMs)
+
+    const socket = createConnection(sockPath, () => {
+      socket.write(JSON.stringify({ id, command: cmd, args }) + "\n")
+    })
+
+    let buffer = ""
+
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString()
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const parsed: unknown = JSON.parse(line)
+          socket.end()
+          settle(isFleetResponse(parsed) ? parsed : { id, ok: false, error: "Invalid response from Fleet" })
+        } catch {
+          socket.end()
+          settle({ id, ok: false, error: "Invalid JSON response from Fleet" })
+        }
+      }
+    })
+
+    socket.on("error", (err: FleetError) => {
+      if (err.code === "ENOENT") {
+        settle({ id, ok: false, error: "Fleet app is not running. Start Fleet first." })
+      } else {
+        settle({ id, ok: false, error: err.message })
+      }
+    })
+
+    socket.on("close", () => {
+      settle({ id, ok: false, error: "Connection closed without response" })
+    })
+  })
+}
+
+function formatResponse(response: FleetResponse): string {
+  if (!response.ok) return response.error || "Unknown error"
+  if (response.data === undefined) return "ok"
+  if (typeof response.data === "string") return response.data
+  return JSON.stringify(response.data, null, 2)
+}
+
+async function sendAndFormat(
+  command: string,
+  args: Record<string, unknown> = {},
+): Promise<{ output: string }> {
+  const response = await sendCommand(command, args)
+  return { output: formatResponse(response) }
+}
+```
+
+- [ ] **Step 2: Add image tools**
+
+Append to the file after the `sendAndFormat` function:
+
+```typescript
+const IMAGE_PROVIDERS = z.string().optional().describe("Provider ID")
+const IMAGE_MODEL = z.string().optional().describe("Model to use")
+const IMAGE_RESOLUTION = z.string().optional().describe("Resolution: 0.5K, 1K, 2K, or 4K")
+const IMAGE_ASPECT = z.string().optional().describe("Aspect ratio, e.g. 1:1, 16:9, 9:16")
+const IMAGE_FORMAT = z.string().optional().describe("Output format: png, jpeg, or webp")
+const IMAGE_NUM = z.number().optional().describe("Number of images: 1-4")
+
+export const Fleet: Plugin = async () => {
+  return {
+    tool: {
+      fleet_images_generate: tool({
+        description: "Generate images from a text prompt using Fleet's AI image providers (fal.ai, etc.). Returns a generation ID to check with fleet_images_status.",
+        args: {
+          prompt: z.string().describe("Text description of the image to generate"),
+          provider: IMAGE_PROVIDERS,
+          model: IMAGE_MODEL,
+          resolution: IMAGE_RESOLUTION,
+          aspectRatio: IMAGE_ASPECT,
+          format: IMAGE_FORMAT,
+          numImages: IMAGE_NUM,
+        },
+        execute: (args) => sendAndFormat("images.generate", {
+          prompt: args.prompt,
+          provider: args.provider,
+          model: args.model,
+          resolution: args.resolution,
+          "aspect-ratio": args.aspectRatio,
+          format: args.format,
+          "num-images": args.numImages,
+        }),
+      }),
+
+      fleet_images_edit: tool({
+        description: "Edit images using a text prompt via Fleet's AI image providers. Requires at least one image file path.",
+        args: {
+          prompt: z.string().describe("Text description of the edit to apply"),
+          images: z.array(z.string()).describe("One or more image file paths to edit"),
+          provider: IMAGE_PROVIDERS,
+          model: IMAGE_MODEL,
+          resolution: IMAGE_RESOLUTION,
+          aspectRatio: IMAGE_ASPECT,
+          format: IMAGE_FORMAT,
+          numImages: IMAGE_NUM,
+        },
+        execute: (args) => sendAndFormat("images.edit", {
+          prompt: args.prompt,
+          images: args.images,
+          provider: args.provider,
+          model: args.model,
+          resolution: args.resolution,
+          "aspect-ratio": args.aspectRatio,
+          format: args.format,
+          "num-images": args.numImages,
+        }),
+      }),
+
+      fleet_images_status: tool({
+        description: "Check the status of an image generation by its ID.",
+        args: {
+          generationId: z.string().describe("The generation ID from fleet_images_generate or fleet_images_edit"),
+        },
+        execute: (args) => sendAndFormat("images.status", { id: args.generationId }),
+      }),
+
+      fleet_images_list: tool({
+        description: "List all image generations and their statuses.",
+        args: {},
+        execute: () => sendAndFormat("images.list", {}),
+      }),
+
+      fleet_images_retry: tool({
+        description: "Retry a failed image generation.",
+        args: {
+          generationId: z.string().describe("The generation ID of a failed generation"),
+        },
+        execute: (args) => sendAndFormat("images.retry", { id: args.generationId }),
+      }),
+
+      fleet_images_action: tool({
+        description: "Run an action on an image (e.g. remove-background). Use fleet_images_actions to see available actions.",
+        args: {
+          actionType: z.string().describe("Action type, e.g. remove-background"),
+          source: z.string().describe("Image file path, URL, or generation reference (<genId>/image-001.png)"),
+          provider: IMAGE_PROVIDERS,
+        },
+        execute: (args) => sendAndFormat("images.action", {
+          type: args.actionType,
+          source: args.source,
+          provider: args.provider,
+        }),
+      }),
+
+      fleet_images_actions: tool({
+        description: "List available image actions for a provider.",
+        args: {
+          provider: IMAGE_PROVIDERS,
+        },
+        execute: (args) => sendAndFormat("images.actions", { provider: args.provider }),
+      }),
+
+      fleet_images_config: tool({
+        description: "Read or write Fleet image configuration. Call with no arguments to read current config. Provide flags to set configuration values.",
+        args: {
+          apiKey: z.string().optional().describe("Set fal.ai API key"),
+          defaultModel: z.string().optional().describe("Set default model"),
+          defaultResolution: z.string().optional().describe("Set default resolution"),
+          defaultOutputFormat: z.string().optional().describe("Set default output format"),
+          defaultAspectRatio: z.string().optional().describe("Set default aspect ratio"),
+          provider: z.string().optional().describe("Which provider to configure"),
+          action: z.string().optional().describe("Action type to configure model for"),
+          model: z.string().optional().describe("Model for the specified action"),
+        },
+        execute: async (args) => {
+          const hasSetFlag = args.apiKey || args.defaultModel || args.defaultResolution ||
+            args.defaultOutputFormat || args.defaultAspectRatio || args.action || args.model
+          if (hasSetFlag) {
+return sendAndFormat("image.config.set", {
+              "api-key": args.apiKey,
+              "default-model": args.defaultModel,
+              "default-resolution": args.defaultResolution,
+              "default-output-format": args.defaultOutputFormat,
+              "default-aspect-ratio": args.defaultAspectRatio,
+              provider: args.provider,
+              action: args.action,
+              model: args.model,
+            })
+          }
+          return sendAndFormat("images.config", {})
+        },
+      }),
+    },
+  }
+}
+```
+
+- [ ] **Step 3: Add kanban tools**
+
+Replace the `tool: { ... }` block with the full tool set including kanban. Add these entries inside the `tool:` object:
+
+```typescript
+      // --- Kanban ---
+
+      fleet_kanban_create: tool({
+        description: "Create a new task on the Fleet Kanban board.",
+        args: {
+          title: z.string().describe("Task title"),
+          body: z.string().optional().describe("Task description/body"),
+          assignee: z.string().optional().describe("Assignee profile name"),
+          priority: z.number().optional().describe("Priority number"),
+          workspace: z.string().optional().describe("Workspace kind: scratch, dir, or worktree"),
+          repo: z.string().optional().describe("Repository path (required when workspace is worktree)"),
+        },
+        execute: (args) => sendAndFormat("kanban.create", {
+          title: args.title,
+          body: args.body,
+          assignee: args.assignee,
+          priority: args.priority,
+          workspace: args.workspace,
+          repo: args.repo,
+        }),
+      }),
+
+      fleet_kanban_swarm: tool({
+        description: "Create a multi-worker swarm (task graph) on the Kanban board. Each worker runs in parallel. Workers format: [{profile, title, skills?}]. A verifier reviews results, a synthesizer merges them.",
+        args: {
+          goal: z.string().describe("The goal description for the swarm"),
+          workers: z.array(z.object({
+            profile: z.string().describe("Worker profile name"),
+            title: z.string().describe("Worker task title"),
+            skills: z.array(z.string()).optional().describe("Skills for this worker"),
+          })).describe("Array of worker specs"),
+          verifier: z.string().describe("Verifier assignee profile"),
+          synthesizer: z.string().describe("Synthesizer assignee profile"),
+          repo: z.string().optional().describe("Repository path (enables worktree workspace)"),
+        },
+        execute: async (args) => {
+          const workerSpecs = args.workers.map((w) => {
+            const skills = w.skills?.join(",") ?? ""
+            return skills ? `${w.profile}:${w.title}:${skills}` : `${w.profile}:${w.title}`
+          })
+          return sendAndFormat("kanban.swarm", {
+            goal: args.goal,
+            worker: workerSpecs,
+            verifier: args.verifier,
+            synthesizer: args.synthesizer,
+            repo: args.repo,
+          })
+        },
+      }),
+
+      fleet_kanban_list: tool({
+        description: "List tasks on the Fleet Kanban board, optionally filtered by status.",
+        args: {
+          status: z.string().optional().describe("Filter by status: triage, todo, ready, running, blocked, review, done, archived"),
+        },
+        execute: (args) => sendAndFormat("kanban.list", { status: args.status }),
+      }),
+
+      fleet_kanban_show: tool({
+        description: "Show details for a specific Kanban task including body, assignee, status, links, and comments.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.show", { id: args.taskId }),
+      }),
+
+      fleet_kanban_assign: tool({
+        description: "Assign a Kanban task to a profile.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          profile: z.string().describe("Profile name to assign"),
+        },
+        execute: (args) => sendAndFormat("kanban.assign", { id: args.taskId, profile: args.profile }),
+      }),
+
+      fleet_kanban_ready: tool({
+        description: "Mark a Kanban task as ready for dispatch.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.ready", { id: args.taskId }),
+      }),
+
+      fleet_kanban_block: tool({
+        description: "Block a Kanban task with a reason.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          reason: z.string().describe("Reason for blocking"),
+        },
+        execute: (args) => sendAndFormat("kanban.block", { id: args.taskId, reason: args.reason }),
+      }),
+
+      fleet_kanban_unblock: tool({
+        description: "Unblock a previously blocked Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.unblock", { id: args.taskId }),
+      }),
+
+      fleet_kanban_archive: tool({
+        description: "Archive a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.archive", { id: args.taskId }),
+      }),
+
+      fleet_kanban_complete: tool({
+        description: "Mark a Kanban task as complete with a result summary.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          result: z.string().describe("Completion result/summary"),
+        },
+        execute: (args) => sendAndFormat("kanban.complete", { id: args.taskId, result: args.result }),
+      }),
+
+      fleet_kanban_comment: tool({
+        description: "Add a comment to a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          comment: z.string().describe("Comment text"),
+        },
+        execute: (args) => sendAndFormat("kanban.comment", { id: args.taskId, comment: args.comment }),
+      }),
+
+      fleet_kanban_link: tool({
+        description: "Link a parent task to a child task (creates a dependency).",
+        args: {
+          parentId: z.string().describe("Parent task ID"),
+          childId: z.string().describe("Child task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.link", { parent: args.parentId, child: args.childId }),
+      }),
+
+      fleet_kanban_unlink: tool({
+        description: "Remove a link between a parent and child task.",
+        args: {
+          parentId: z.string().describe("Parent task ID"),
+          childId: z.string().describe("Child task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.unlink", { parent: args.parentId, child: args.childId }),
+      }),
+
+      fleet_kanban_log: tool({
+        description: "Show the event log for a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.log", { id: args.taskId }),
+      }),
+
+      fleet_kanban_dispatch: tool({
+        description: "Trigger the kanban dispatcher to process the queue and start ready tasks.",
+        args: {},
+        execute: () => sendAndFormat("kanban.dispatch", {}),
+      }),
+
+      fleet_kanban_decompose: tool({
+        description: "Decompose a triage task into a child-task graph using AI planning.",
+        args: {
+          taskId: z.string().describe("The triage task ID to decompose"),
+        },
+        execute: (args) => sendAndFormat("kanban.decompose", { id: args.taskId }),
+      }),
+
+      fleet_kanban_specify: tool({
+        description: "Rewrite a triage task body into a fuller, more detailed specification.",
+        args: {
+          taskId: z.string().describe("The triage task ID to specify"),
+        },
+        execute: (args) => sendAndFormat("kanban.specify", { id: args.taskId }),
+      }),
+```
+
+- [ ] **Step 4: Add fleet_open and fleet_annotate tools**
+
+Add these entries inside the `tool:` object alongside the others:
+
+```typescript
+      // --- Open & Annotate ---
+
+      fleet_open: tool({
+        description: "Open files in Fleet tabs. Supports code files, images (png, jpg, gif, webp, svg, bmp, ico), markdown, and PDFs. Each file opens in the appropriate viewer.",
+        args: {
+          paths: z.array(z.string()).describe("One or more file paths to open"),
+        },
+        execute: async (args) => {
+          const results: string[] = []
+          for (const path of args.paths) {
+            const response = await sendCommand("file.open", { path })
+            results.push(formatResponse(response))
+          }
+          return { output: results.join("\n") }
+        },
+      }),
+
+      fleet_annotate: tool({
+        description: "Open a browser window for visual web page annotation. Click elements, add comments, and capture annotated screenshots. Results written to a JSON file.",
+        args: {
+          url: z.string().optional().describe("URL to annotate. Omit for a blank page."),
+          timeout: z.number().optional().describe("Max seconds to wait for annotation (default 300)"),
+        },
+        execute: (args) => sendAndFormat("annotate.start", { url: args.url, timeout: args.timeout }),
+      }),
+```
+
+- [ ] **Step 5: Verify the file is complete**
+
+Run: `wc -l ~/.config/opencode/plugins/fleet.ts`
+
+Expected: ~500 lines. The file should have the Imports, `sendCommand`, `sendAndFormat`, `COMMAND_MAP`, `Fleet` plugin export, and 29 tool definitions.
+
+---
+
+### Task 2: Create companion skill file
+
+**Files:**
+- Create: `~/.config/opencode/skills/fleet/SKILL.md`
+
+- [ ] **Step 1: Create the skill file**
+
+```markdown
+---
+name: fleet
+description: Use when the agent needs to interact with the Fleet desktop app — open files, manage the Kanban board, generate/edit images, or annotate web pages. Fleet must be running.
+---
+
+# Fleet
+
+Fleet is a terminal multiplexer desktop app. The agent can interact with it through these tools:
+
+- `fleet_open` — Open files in Fleet tabs (code, images, PDFs, markdown)
+- `fleet_annotate` — Annotate web pages visually
+- `fleet_images_*` — Generate, edit, and manage AI images
+- `fleet_kanban_*` — Full Kanban board management
+
+Prerequisites: Fleet app must be running.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ~/.config/opencode/skills/fleet/SKILL.md
+git commit -m "feat: add fleet skill for opencode"
+```
+
+---
+
+### Task 3: Install and verify
+
+- [ ] **Step 1: Ensure plugin directory exists**
+
+```bash
+ls ~/.config/opencode/plugins/
+```
+
+Expected: shows `brave-search.ts` and `fleet.ts`.
+
+- [ ] **Step 2: Ensure @opencode-ai/plugin is available**
+
+```bash
+ls ~/.config/opencode/node_modules/@opencode-ai/plugin/package.json
+```
+
+Expected: file exists. If not, run `cd ~/.config/opencode && bun install`.
+
+- [ ] **Step 3: Verify plugin loads in opencode**
+
+Start opencode in the Fleet project directory. The `fleet_*` tools should appear in the available tools list. Try a simple command:
+
+```
+> Use fleet_images_list to list image generations
+```
+
+Expected: opencode calls `fleet_images_list` via the plugin. If Fleet is running, it returns the generations list. If Fleet is not running, the error message says "Start Fleet first."
+
+- [ ] **Step 4: Verify all 29 tools are registered**
+
+In an opencode session, the agent should see all 29 fleet tools listed as available. Ask the agent:
+
+```
+> List all fleet tools available to you
+```
+
+Expected: agent lists all `fleet_images_*`, `fleet_kanban_*`, `fleet_open`, `fleet_annotate` tools.
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Run typecheck on the projects that include this plugin**
+
+The plugin is at `~/.config/opencode/plugins/`. There's no separate typecheck step since opencode compiles plugins at load time. Instead, verify by starting opencode and confirming no import/module errors appear.
+
+- [ ] **Step 2: Commit the implementation plan**
+
+```bash
+git add docs/superpowers/plans/2026-06-19-fleet-opencode-plugin.md
+git commit -m "plan: fleet opencode plugin implementation"
+```

--- a/docs/superpowers/plans/2026-06-19-user-tab-groups.md
+++ b/docs/superpowers/plans/2026-06-19-user-tab-groups.md
@@ -1,0 +1,1064 @@
+# User-Created Tab Groups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user-created, collapsible tab groups to the sidebar with custom names and 8-color identifiers.
+
+**Architecture:** New `UserGroup` type stored on `Workspace.userGroups[]`, referenced by `Tab.userGroupId`. Store actions in `workspace-store.ts`. Rendering in `Sidebar.tsx` nests user groups around existing worktree group rendering. New `ColorPalettePicker` component for color selection.
+
+**Tech Stack:** Electron + React + TypeScript + Zustand + Radix UI ContextMenu + Tailwind CSS
+
+---
+
+### Task 1: Add `UserGroup` type and update `Workspace`/`Tab`
+
+**Files:**
+- Create: `src/shared/group-colors.ts`
+- Modify: `src/shared/types.ts`
+- Modify: `src/renderer/src/components/sidebar-constants.ts`
+
+- [ ] **Step 1: Create shared color palette module**
+
+Create file `src/shared/group-colors.ts`:
+
+```ts
+export const USER_GROUP_COLORS = ['blue', 'teal', 'green', 'yellow', 'orange', 'red', 'pink', 'purple'] as const;
+
+export type UserGroupColor = typeof USER_GROUP_COLORS[number];
+```
+
+- [ ] **Step 2: Add `UserGroup` type and update `Workspace`/`Tab` in `types.ts`**
+
+Add import at top of `src/shared/types.ts`:
+
+```ts
+import type { UserGroupColor } from './group-colors';
+```
+
+Add `UserGroup` type (after `Workspace` type, before `Tab`):
+
+```ts
+export type UserGroup = {
+  id: string;
+  name: string;
+  color: UserGroupColor;
+  collapsed: boolean;
+};
+```
+
+Add `userGroups` to `Workspace` right after `sidebarWidth?: number`:
+
+```ts
+userGroups?: UserGroup[];
+```
+
+Add `userGroupId` to `Tab` right after `worktreePath?: string`:
+
+```ts
+userGroupId?: string;
+```
+
+- [ ] **Step 3: Re-export from `sidebar-constants.ts`**
+
+Add to `src/renderer/src/components/sidebar-constants.ts`:
+
+```ts
+export { USER_GROUP_COLORS, type UserGroupColor } from '../../../shared/group-colors';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/group-colors.ts src/shared/types.ts src/renderer/src/components/sidebar-constants.ts
+git commit -m "feat: add UserGroup type, group-colors shared module"
+```
+
+---
+
+### Task 2: Add user group store actions
+
+**Files:**
+- Modify: `src/renderer/src/store/workspace-store.ts`
+
+- [ ] **Step 1: Add `UserGroupColor` import**
+
+Add at the top of `workspace-store.ts`:
+
+```ts
+import type { UserGroupColor } from '../../../shared/group-colors';
+```
+
+- [ ] **Step 2: Add actions to `WorkspaceStore` type**
+
+Add after `renameWorktreeGroup` (line 255):
+
+```ts
+// User group actions
+createUserGroup: (name: string, color: UserGroupColor, tabId: string) => void;
+deleteUserGroup: (groupId: string) => void;
+renameUserGroup: (groupId: string, name: string) => void;
+recolorUserGroup: (groupId: string, color: UserGroupColor) => void;
+setTabUserGroup: (tabId: string, groupId: string | undefined) => void;
+toggleUserGroupCollapsed: (groupId: string) => void;
+reorderUserGroup: (groupId: string, toIndex: number) => void;
+```
+
+- [ ] **Step 3: Implement `createUserGroup`**
+
+Add inside `create<WorkspaceStore>((set, get) => ({` block, after `renameWorktreeGroup`:
+
+```ts
+createUserGroup: (name, color, tabId) => {
+  const group: UserGroup = { id: generateId(), name, color, collapsed: false };
+  set((state) => ({
+    workspace: {
+      ...state.workspace,
+      userGroups: [...(state.workspace.userGroups ?? []), group],
+      tabs: state.workspace.tabs.map((t) =>
+        t.id === tabId ? { ...t, userGroupId: group.id } : t
+      )
+    },
+    isDirty: true
+  }));
+},
+```
+
+- [ ] **Step 4: Implement `deleteUserGroup`**
+
+```ts
+deleteUserGroup: (groupId) => {
+  set((state) => ({
+    workspace: {
+      ...state.workspace,
+      userGroups: (state.workspace.userGroups ?? []).filter((g) => g.id !== groupId),
+      tabs: state.workspace.tabs.map((t) =>
+        t.userGroupId === groupId ? { ...t, userGroupId: undefined } : t
+      )
+    },
+    isDirty: true
+  }));
+},
+```
+
+- [ ] **Step 5: Implement `renameUserGroup`**
+
+```ts
+renameUserGroup: (groupId, name) => {
+  set((state) => ({
+    workspace: {
+      ...state.workspace,
+      userGroups: (state.workspace.userGroups ?? []).map((g) =>
+        g.id === groupId ? { ...g, name } : g
+      )
+    },
+    isDirty: true
+  }));
+},
+```
+
+- [ ] **Step 6: Implement `recolorUserGroup`**
+
+```ts
+recolorUserGroup: (groupId, color) => {
+  set((state) => ({
+    workspace: {
+      ...state.workspace,
+      userGroups: (state.workspace.userGroups ?? []).map((g) =>
+        g.id === groupId ? { ...g, color } : g
+      )
+    },
+    isDirty: true
+  }));
+},
+```
+
+- [ ] **Step 7: Implement `setTabUserGroup`**
+
+```ts
+setTabUserGroup: (tabId, groupId) => {
+  set((state) => {
+    const tabs = state.workspace.tabs.map((t) =>
+      t.id === tabId ? { ...t, userGroupId: groupId } : t
+    );
+    let userGroups = state.workspace.userGroups ?? [];
+    if (groupId === undefined) {
+      const oldTab = state.workspace.tabs.find((t) => t.id === tabId);
+      if (oldTab?.userGroupId) {
+        const stillHasMembers = tabs.some(
+          (t) => t.id !== tabId && t.userGroupId === oldTab.userGroupId
+        );
+        if (!stillHasMembers) {
+          userGroups = userGroups.filter((g) => g.id !== oldTab.userGroupId);
+        }
+      }
+    }
+    return {
+      workspace: { ...state.workspace, tabs, userGroups },
+      isDirty: true
+    };
+  });
+},
+```
+
+- [ ] **Step 8: Implement `toggleUserGroupCollapsed`**
+
+```ts
+toggleUserGroupCollapsed: (groupId) => {
+  set((state) => ({
+    workspace: {
+      ...state.workspace,
+      userGroups: (state.workspace.userGroups ?? []).map((g) =>
+        g.id === groupId ? { ...g, collapsed: !g.collapsed } : g
+      )
+    },
+    isDirty: true
+  }));
+},
+```
+
+- [ ] **Step 9: Implement `reorderUserGroup`**
+
+```ts
+reorderUserGroup: (groupId, toIndex) => {
+  set((state) => {
+    const groups = [...(state.workspace.userGroups ?? [])];
+    const fromIndex = groups.findIndex((g) => g.id === groupId);
+    if (fromIndex === -1 || fromIndex === toIndex) return state;
+    const [moved] = groups.splice(fromIndex, 1);
+    groups.splice(toIndex, 0, moved);
+    return {
+      workspace: { ...state.workspace, userGroups: groups },
+      isDirty: true
+    };
+  });
+},
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/renderer/src/store/workspace-store.ts
+git commit -m "feat: add user group store actions"
+```
+
+---
+
+### Task 3: Create `ColorPalettePicker` component
+
+**Files:**
+- Create: `src/renderer/src/components/ColorPalettePicker.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { USER_GROUP_COLORS, type UserGroupColor } from './sidebar-constants';
+
+type ColorPalettePickerProps = {
+  selected: UserGroupColor;
+  onSelect: (color: UserGroupColor) => void;
+};
+
+const COLOR_MAP: Record<UserGroupColor, string> = {
+  blue: 'bg-blue-500',
+  teal: 'bg-teal-500',
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+  orange: 'bg-orange-500',
+  red: 'bg-red-500',
+  pink: 'bg-pink-500',
+  purple: 'bg-purple-500'
+};
+
+export function ColorPalettePicker({ selected, onSelect }: ColorPalettePickerProps): React.JSX.Element {
+  return (
+    <div className="flex gap-1.5 p-1.5">
+      {USER_GROUP_COLORS.map((color) => (
+        <button
+          key={color}
+          className={`w-5 h-5 rounded-full ${COLOR_MAP[color]} ${
+            color === selected ? 'ring-2 ring-white ring-offset-1 ring-offset-fleet-surface-2' : ''
+          } hover:scale-110 transition-transform`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect(color);
+          }}
+          title={color}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/renderer/src/components/ColorPalettePicker.tsx
+git commit -m "feat: add ColorPalettePicker component"
+```
+
+---
+
+### Task 4: Add group context menu items and border to `TabItem`
+
+**Files:**
+- Modify: `src/renderer/src/components/TabItem.tsx`
+
+- [ ] **Step 1: Add new props to `TabItemProps`**
+
+Add after `indentLevel` (line 51):
+
+```ts
+userGroupColor?: string;
+userGroupId?: string;
+userGroups?: Array<{ id: string; name: string; color: string }>;
+onCreateGroup?: () => void;
+onAddToGroup?: (groupId: string) => void;
+onRemoveFromGroup?: () => void;
+```
+
+- [ ] **Step 2: Destructure new props**
+
+Add to destructured parameters after `indentLevel = 0` (line 105):
+
+```ts
+userGroupColor,
+userGroupId,
+userGroups,
+onCreateGroup,
+onAddToGroup,
+onRemoveFromGroup
+```
+
+- [ ] **Step 3: Add user group left border to active/inactive styles**
+
+Replace the two class strings for active/inactive (lines 189-193):
+
+Current:
+```
+${
+  isActive
+    ? `bg-fleet-surface-3 text-fleet-text ${indentLevel > 0 ? '' : `border-l-2 ${activeBorderColor}`}`
+    : `text-fleet-text-secondary hover:bg-fleet-surface-2 hover:text-fleet-text ${indentLevel > 0 ? '' : 'border-l-2 border-transparent'}`
+}
+```
+
+New:
+```
+${
+  isActive
+    ? `bg-fleet-surface-3 text-fleet-text ${indentLevel > 0 ? '' : `border-l-2 ${activeBorderColor}`} ${userGroupColor ? userGroupColor : ''}`
+    : `text-fleet-text-secondary hover:bg-fleet-surface-2 hover:text-fleet-text ${indentLevel > 0 ? '' : 'border-l-2 border-transparent'} ${userGroupColor ? userGroupColor : ''}`
+}
+```
+
+- [ ] **Step 4: Add context menu items**
+
+After the "Create Worktree" context menu block (before the `<ContextMenu.Separator>` on line 353), insert:
+
+```tsx
+{onCreateGroup && (
+  <>
+    <ContextMenu.Separator className="my-1 h-px bg-fleet-surface-3" />
+    <ContextMenu.Item
+      className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
+      onSelect={onCreateGroup}
+    >
+      New Group
+    </ContextMenu.Item>
+  </>
+)}
+{onAddToGroup && userGroups && userGroups.length > 0 && (
+  <ContextMenu.Sub>
+    <ContextMenu.SubTrigger className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3 data-[state=open]:bg-fleet-surface-3 flex items-center justify-between">
+      Add to Group
+      <svg className="ml-2" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M4 2l4 4-4 4" />
+      </svg>
+    </ContextMenu.SubTrigger>
+    <ContextMenu.Portal>
+      <ContextMenu.SubContent className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+        {userGroups.map((g) => (
+          <ContextMenu.Item
+            key={g.id}
+            className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3 flex items-center gap-2"
+            onSelect={() => onAddToGroup(g.id)}
+          >
+            <span className={`w-2.5 h-2.5 rounded-full bg-${g.color}-500`} />
+            {g.name}
+          </ContextMenu.Item>
+        ))}
+      </ContextMenu.SubContent>
+    </ContextMenu.Portal>
+  </ContextMenu.Sub>
+)}
+{onRemoveFromGroup && userGroupId && (
+  <ContextMenu.Item
+    className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
+    onSelect={onRemoveFromGroup}
+  >
+    Remove from Group
+  </ContextMenu.Item>
+)}
+```
+
+IMPORTANT: Add a `<ContextMenu.Separator>` between the user group items and the existing "Close Tab" separator if user group items are present. The safest approach is to check -- if `onCreateGroup || (onAddToGroup && userGroups && userGroups.length > 0) || (onRemoveFromGroup && userGroupId)` is true, render a separator before the user group items too. But actually, looking at the existing code, the separator at line 353 already exists. We should insert our items between the worktree section separator and the existing closing separator.
+
+The exact placement: after the worktree section's `</>` closing fragment (line 352), before the existing `<ContextMenu.Separator>` (line 353). The user group section will have its own separator at the start (already included above). So the structure becomes:
+
+```
+{Rename, Reset...}
+{Create Worktree section}
+<Separator>           ← existing line 353
+{New Group}
+{Add to Group submenu}
+{Remove from Group}
+<Separator>           ← existing line 353 (moved)
+{Close Tab}
+```
+
+Wait, there's a conflict: line 353 already has a separator. We need to add another one before Close Tab. The cleanest approach: conditionally render the user group items with their own separator at the bottom, and always show the existing separator before Close Tab.
+
+Update: insert AFTER the separator on line 353 (before the Close Tab item):
+
+```tsx
+          <ContextMenu.Separator className="my-1 h-px bg-fleet-surface-3" />
+          {onCreateGroup && (
+            <ContextMenu.Item
+              className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
+              onSelect={onCreateGroup}
+            >
+              New Group
+            </ContextMenu.Item>
+          )}
+          {onAddToGroup && userGroups && userGroups.length > 0 && (
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3 data-[state=open]:bg-fleet-surface-3 flex items-center justify-between">
+                Add to Group
+                <svg className="ml-2" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M4 2l4 4-4 4" />
+                </svg>
+              </ContextMenu.SubTrigger>
+              <ContextMenu.Portal>
+                <ContextMenu.SubContent className="min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50">
+                  {userGroups.map((g) => (
+                    <ContextMenu.Item
+                      key={g.id}
+                      className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3 flex items-center gap-2"
+                      onSelect={() => onAddToGroup(g.id)}
+                    >
+                      <span className={`w-2.5 h-2.5 rounded-full bg-${g.color}-500`} />
+                      {g.name}
+                    </ContextMenu.Item>
+                  ))}
+                </ContextMenu.SubContent>
+              </ContextMenu.Portal>
+            </ContextMenu.Sub>
+          )}
+          {onRemoveFromGroup && userGroupId && (
+            <ContextMenu.Item
+              className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
+              onSelect={onRemoveFromGroup}
+            >
+              Remove from Group
+            </ContextMenu.Item>
+          )}
+          <ContextMenu.Separator className="my-1 h-px bg-fleet-surface-3" />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/TabItem.tsx
+git commit -m "feat: add user group context menu items and border to TabItem"
+```
+
+---
+
+### Task 5: Render user groups in `Sidebar` + update DnD
+
+**Files:**
+- Modify: `src/renderer/src/components/Sidebar.tsx`
+
+- [ ] **Step 1: Add imports**
+
+Add after existing imports (around line 38):
+
+```tsx
+import { USER_GROUP_COLORS, type UserGroupColor } from './sidebar-constants';
+import { ColorPalettePicker } from './ColorPalettePicker';
+```
+
+- [ ] **Step 2: Add store destructuring for new actions**
+
+Add to `useWorkspaceStore(useShallow(...))` call after `setSidebarWidth` (line 550):
+
+```tsx
+createUserGroup: s.createUserGroup,
+deleteUserGroup: s.deleteUserGroup,
+renameUserGroup: s.renameUserGroup,
+recolorUserGroup: s.recolorUserGroup,
+setTabUserGroup: s.setTabUserGroup,
+toggleUserGroupCollapsed: s.toggleUserGroupCollapsed,
+reorderUserGroup: s.reorderUserGroup,
+```
+
+And add to destructured const (after `setSidebarWidth`):
+
+```tsx
+createUserGroup,
+deleteUserGroup,
+renameUserGroup,
+recolorUserGroup,
+setTabUserGroup,
+toggleUserGroupCollapsed,
+reorderUserGroup,
+```
+
+- [ ] **Step 3: Update `dragType` state**
+
+Change line 564 from:
+
+```tsx
+const [dragType, setDragType] = useState<'tab' | 'group'>('tab');
+```
+
+To:
+
+```tsx
+const [dragType, setDragType] = useState<'tab' | 'group' | 'userGroup'>('tab');
+```
+
+- [ ] **Step 4: Add "New Group" popover state**
+
+Add after the DnD state:
+
+```tsx
+const [newGroupState, setNewGroupState] = useState<{ tabId: string } | null>(null);
+const [newGroupName, setNewGroupName] = useState('');
+const [newGroupColor, setNewGroupColor] = useState<UserGroupColor>('blue');
+```
+
+- [ ] **Step 5: Add `UserGroupHeader` component**
+
+Add before the existing `GroupHeader` function (before line 64):
+
+```tsx
+function UserGroupHeader({
+  group,
+  tabCount,
+  onToggle,
+  onRename,
+  onRecolor,
+  onUngroupAll,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  isDragOver
+}: {
+  group: { id: string; name: string; color: string; collapsed: boolean };
+  tabCount: number;
+  onToggle: () => void;
+  onRename: (name: string) => void;
+  onRecolor: (color: UserGroupColor) => void;
+  onUngroupAll: () => void;
+  onDragStart: () => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: () => void;
+  isDragOver: 'above' | 'below' | null;
+}): React.JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(group.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const commitRename = useCallback(() => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== group.name) {
+      onRename(trimmed);
+    }
+    setIsEditing(false);
+  }, [editValue, group.name, onRename]);
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <div
+          className="group/ugroup flex items-center gap-1.5 px-2 py-2 mt-2 cursor-pointer rounded-md text-xs text-fleet-text-secondary hover:text-fleet-text hover:bg-fleet-surface-2/50 transition-colors relative select-none"
+          onClick={onToggle}
+          draggable
+          onDragStart={(e) => {
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData('text/plain', 'userGroup');
+            onDragStart();
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            onDragOver(e);
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDrop();
+          }}
+        >
+          {isDragOver === 'above' && (
+            <div className="absolute top-0 left-1 right-1 h-0.5 bg-blue-500 rounded-full -translate-y-0.5" />
+          )}
+          {isDragOver === 'below' && (
+            <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-blue-500 rounded-full translate-y-0.5" />
+          )}
+          <span className={`w-2 h-2 rounded-full bg-${group.color}-500 flex-shrink-0`} />
+          <ChevronRight
+            size={12}
+            className={`transition-transform flex-shrink-0 ${group.collapsed ? '' : 'rotate-90'}`}
+          />
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              className="flex-1 bg-fleet-surface-3 text-fleet-text text-xs rounded px-1 py-0 outline-none border border-blue-500 min-w-0"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitRename();
+                if (e.key === 'Escape') setIsEditing(false);
+              }}
+              onBlur={commitRename}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span
+              className="truncate"
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+                setEditValue(group.name);
+                setIsEditing(true);
+              }}
+            >
+              {group.name}
+            </span>
+          )}
+          <span className="ml-auto text-[10px] text-fleet-text-subtle">
+            {group.collapsed ? `${tabCount} tabs` : ''}
+          </span>
+        </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content
+          className={`min-w-[140px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 text-sm text-fleet-text z-50 ${popperAnim}`}
+        >
+          <ContextMenu.Item
+            className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3"
+            onSelect={() => {
+              setEditValue(group.name);
+              setTimeout(() => setIsEditing(true), 0);
+            }}
+          >
+            Rename
+          </ContextMenu.Item>
+          <ContextMenu.Sub>
+            <ContextMenu.SubTrigger className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-fleet-surface-3 hover:bg-fleet-surface-3 data-[state=open]:bg-fleet-surface-3 flex items-center justify-between">
+              Recolor
+            </ContextMenu.SubTrigger>
+            <ContextMenu.Portal>
+              <ContextMenu.SubContent className="min-w-[180px] bg-fleet-surface-2 border border-fleet-border-strong rounded-md shadow-lg p-1 z-50">
+                <ColorPalettePicker selected={group.color as UserGroupColor} onSelect={onRecolor} />
+              </ContextMenu.SubContent>
+            </ContextMenu.Portal>
+          </ContextMenu.Sub>
+          <ContextMenu.Separator className="my-1 h-px bg-fleet-surface-3" />
+          <ContextMenu.Item
+            className="px-2 py-1.5 rounded cursor-pointer outline-none focus:bg-red-900/50 hover:bg-red-900/50 text-red-400"
+            onSelect={onUngroupAll}
+          >
+            Ungroup All
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}
+```
+
+- [ ] **Step 6: Update `handleDragOver` for user group drags**
+
+Add after the existing `if (dragType === 'group')` block (after line 604):
+
+```tsx
+if (dragType === 'userGroup') {
+  if (!isGroupHeader) {
+    setDropTarget(null);
+    return;
+  }
+}
+```
+
+- [ ] **Step 7: Update `handleDrop` for user group reordering**
+
+In the `handleDrop` callback, add after the group drag handling block (after `reorderGroup(draggedTab.groupId, toIndex);` on line 640):
+
+```tsx
+} else if (dragType === 'userGroup' && draggedTab?.userGroupId) {
+  const userGroups = workspace.userGroups ?? [];
+  const ugIndex = userGroups.findIndex((g) => g.id === draggedTab.userGroupId);
+  const toIndex = dropTarget.position === 'below' ? dropTarget.index + 1 : dropTarget.index;
+  reorderUserGroup(draggedTab.userGroupId, ugIndex !== toIndex ? toIndex : ugIndex);
+  setDragIndex(null);
+  setDropTarget(null);
+  return;
+```
+
+- [ ] **Step 8: Rewrite the tab rendering IIFE**
+
+Replace the entire IIFE block (lines 1214-1375) with user-group-aware rendering:
+
+```tsx
+{(() => {
+  const regularTabs = workspace.tabs.filter(
+    (t) =>
+      t.type !== 'images' &&
+      t.type !== 'settings' &&
+      t.type !== 'annotate' &&
+      t.type !== 'kanban' &&
+      t.type !== 'sessions'
+  );
+
+  const rendered: React.ReactNode[] = [];
+  const seenWorktreeGroups = new Set<string>();
+  const userGroups = workspace.userGroups ?? [];
+
+  const renderTabWithWorktreeGroups = (tab: typeof regularTabs[number]): void => {
+    if (tab.groupId && !seenWorktreeGroups.has(tab.groupId)) {
+      seenWorktreeGroups.add(tab.groupId);
+      const groupTabs = regularTabs.filter((t) => t.groupId === tab.groupId);
+      const parentTab = groupTabs.find((t) => t.groupRole === 'parent');
+      const isCollapsed = collapsedGroups.has(tab.groupId);
+      const groupId = tab.groupId;
+      const firstTabIdx = realIndex(groupTabs[0]!.id);
+
+      rendered.push(
+        <GroupHeader
+          key={`group-${groupId}`}
+          label={groupTabs[0]!.groupLabel ?? parentTab?.label ?? 'Worktree Group'}
+          tabCount={groupTabs.length}
+          isCollapsed={isCollapsed}
+          onToggle={() => toggleGroupCollapsed(groupId)}
+          onRename={(newLabel) => renameWorktreeGroup(groupId, newLabel)}
+          onAddWorktree={() => {
+            const anyTab = groupTabs[0]!;
+            const firstPane = collectPaneIds(anyTab.splitRoot)[0];
+            const cwd = (firstPane ? liveCwds.get(firstPane) : undefined) ?? anyTab.cwd;
+            void handleCreateWorktree(anyTab.id, cwd, getPaneContextById(firstPane));
+          }}
+          onDragStart={() => handleDragStart(firstTabIdx, 'group')}
+          onDragOver={(e) => handleDragOver(e, firstTabIdx, true)}
+          onDrop={() => handleDrop()}
+          isDragOver={
+            dropTarget?.index === firstTabIdx && dropTarget.isGroupHeader
+              ? dropTarget.position
+              : null
+          }
+        />
+      );
+    }
+
+    if (tab.groupId && collapsedGroups.has(tab.groupId)) return;
+
+    const paneIds = collectPaneIds(tab.splitRoot);
+    const isFile =
+      tab.type === 'file' ||
+      tab.type === 'image' ||
+      tab.type === 'markdown' ||
+      tab.type === 'pdf';
+    const idx = realIndex(tab.id);
+
+    let displayCwd: string;
+    let drivingPaneId: string | undefined;
+    if (isFile) {
+      const leafs = collectPaneLeafs(tab.splitRoot);
+      const filePath = leafs[0]?.filePath ?? '';
+      displayCwd = filePath ? filePath.split('/').slice(0, -1).join('/') || '/' : '/';
+    } else {
+      drivingPaneId =
+        tab.id === activeTabId && activePaneId && paneIds.includes(activePaneId)
+          ? activePaneId
+          : paneIds[0];
+      displayCwd = tab.cwd;
+    }
+
+    const isFileDirty =
+      isFile && collectPaneLeafs(tab.splitRoot).some((l) => l.isDirty === true);
+    const displayLabel = isFile && isFileDirty ? tab.label + ' *' : tab.label;
+
+    let icon: React.ReactNode;
+    if (tab.type === 'pi') {
+      icon = <Bot size={14} />;
+    } else if (isFile) {
+      const leafs2 = collectPaneLeafs(tab.splitRoot);
+      const fileBasename = leafs2[0]?.filePath?.split('/').pop() ?? tab.label;
+      icon =
+        tab.type === 'image' ? <ImageIcon size={14} /> : getFileIcon(fileBasename, 14);
+    } else {
+      icon = <Terminal size={14} />;
+    }
+
+    const ug = userGroups.find((g) => g.id === tab.userGroupId);
+    const userGroupColorClass = ug ? `border-l-2 border-l-${ug.color}-500/50` : undefined;
+
+    const userGroupList = userGroups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      color: g.color
+    }));
+
+    rendered.push(
+      <TabItem
+        key={tab.id}
+        id={tab.id}
+        label={displayLabel}
+        labelIsCustom={tab.labelIsCustom ?? false}
+        cwd={displayCwd}
+        drivingPaneId={drivingPaneId}
+        isActive={tab.id === activeTabId}
+        badge={getTabBadge(paneIds)}
+        icon={icon}
+        disableReset={isFile}
+        index={idx}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        isDragOver={
+          dropTarget?.index === idx && !dropTarget.isGroupHeader
+            ? dropTarget.position
+            : null
+        }
+        indentLevel={tab.groupId ? 1 : 0}
+        worktreeBranch={tab.worktreeBranch}
+        pathContext={tab.pathContext}
+        worktreeDisabledReason={
+          isFile
+            ? undefined
+            : tab.groupRole === 'worktree'
+              ? 'Already a worktree'
+              : tab.groupId
+                ? 'Worktrees already created'
+                : !gitRepoTabs.has(tab.id)
+                  ? 'Not a git repository'
+                  : null
+        }
+        onCreateWorktree={
+          !isFile && gitRepoTabs.has(tab.id) && !tab.worktreePath && !tab.groupId
+            ? () => {
+                const firstPane = collectPaneIds(tab.splitRoot)[0];
+                const liveCwd = firstPane ? liveCwds.get(firstPane) : undefined;
+                void handleCreateWorktree(
+                  tab.id,
+                  liveCwd ?? tab.cwd,
+                  getPaneContextById(firstPane)
+                );
+              }
+            : undefined
+        }
+        onClick={() => {
+          setActiveTab(tab.id);
+          if (!isFile) {
+            for (const paneId of paneIds) {
+              useNotificationStore.getState().clearPane(paneId);
+              window.fleet.notifications.paneFocused({ paneId });
+            }
+          }
+        }}
+        onDuplicate={
+          !isFile && (!tab.type || tab.type === 'terminal' || tab.type === 'pi')
+            ? () => duplicateTab(tab.id)
+            : undefined
+        }
+        onClose={() => handleCloseTab(tab.id)}
+        onRename={(newLabel) => renameTab(tab.id, newLabel)}
+        onResetLabel={(liveCwd) => resetTabLabel(tab.id, liveCwd)}
+        userGroupColor={userGroupColorClass}
+        userGroupId={tab.userGroupId}
+        userGroups={userGroupList}
+        onCreateGroup={
+          tab.userGroupId
+            ? undefined
+            : () => {
+                setNewGroupState({ tabId: tab.id });
+                setNewGroupName('');
+                setNewGroupColor('blue');
+              }
+        }
+        onAddToGroup={
+          userGroups.length > 0 && !tab.userGroupId
+            ? (groupId) => setTabUserGroup(tab.id, groupId)
+            : undefined
+        }
+        onRemoveFromGroup={
+          tab.userGroupId
+            ? () => setTabUserGroup(tab.id, undefined)
+            : undefined
+        }
+      />
+    );
+  };
+
+  // 1. Ungrouped tabs render first
+  for (const tab of regularTabs.filter((t) => !t.userGroupId)) {
+    renderTabWithWorktreeGroups(tab);
+  }
+
+  // 2. User groups
+  for (const ug of userGroups) {
+    const groupTabs = regularTabs.filter((t) => t.userGroupId === ug.id);
+    if (groupTabs.length === 0) continue;
+
+    const firstTabIdx = realIndex(groupTabs[0]!.id);
+
+    rendered.push(
+      <UserGroupHeader
+        key={`ug-${ug.id}`}
+        group={ug}
+        tabCount={groupTabs.length}
+        onToggle={() => toggleUserGroupCollapsed(ug.id)}
+        onRename={(name) => renameUserGroup(ug.id, name)}
+        onRecolor={(color) => recolorUserGroup(ug.id, color)}
+        onUngroupAll={() => {
+          for (const t of groupTabs) setTabUserGroup(t.id, undefined);
+        }}
+        onDragStart={() => handleDragStart(firstTabIdx, 'userGroup')}
+        onDragOver={(e) => handleDragOver(e, firstTabIdx, true)}
+        onDrop={() => handleDrop()}
+        isDragOver={
+          dropTarget?.index === firstTabIdx && dropTarget.isGroupHeader
+            ? dropTarget.position
+            : null
+        }
+      />
+    );
+
+    if (ug.collapsed) continue;
+
+    for (const tab of groupTabs) {
+      renderTabWithWorktreeGroups(tab);
+    }
+  }
+
+  return rendered;
+})()}
+```
+
+- [ ] **Step 9: Add "New Group" popover markup**
+
+Add after the tab-list scroll div (after the rendering IIFE, before `</div>` of the tabListRef div, around line 1376):
+
+```tsx
+{newGroupState && (
+  <div className="px-2 py-2 bg-fleet-surface-2 border border-fleet-border-strong rounded-md mx-1 mb-2">
+    <input
+      autoFocus
+      className="w-full bg-fleet-surface-3 text-fleet-text text-sm rounded px-2 py-1 outline-none border border-fleet-border-strong mb-2"
+      placeholder="Group name..."
+      value={newGroupName}
+      onChange={(e) => setNewGroupName(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          const name = newGroupName.trim() || 'Group';
+          createUserGroup(name, newGroupColor, newGroupState.tabId);
+          setNewGroupState(null);
+        }
+        if (e.key === 'Escape') setNewGroupState(null);
+      }}
+    />
+    <ColorPalettePicker selected={newGroupColor} onSelect={setNewGroupColor} />
+    <div className="flex justify-end gap-1.5 mt-1.5">
+      <button
+        className="px-2 py-0.5 text-xs text-fleet-text-muted hover:text-fleet-text rounded transition"
+        onClick={() => setNewGroupState(null)}
+      >
+        Cancel
+      </button>
+      <button
+        className="px-2 py-0.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded transition"
+        onClick={() => {
+          const name = newGroupName.trim() || 'Group';
+          createUserGroup(name, newGroupColor, newGroupState.tabId);
+          setNewGroupState(null);
+        }}
+      >
+        Create
+      </button>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/renderer/src/components/Sidebar.tsx
+git commit -m "feat: render user tab groups with DnD in sidebar"
+```
+
+---
+
+### Task 6: Type check, lint, and verify
+
+**Files:** none
+
+- [ ] **Step 1: Run type check**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS with no errors.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: PASS with no errors.
+
+- [ ] **Step 3: Commit any fixes**
+
+If type or lint errors were fixed:
+
+```bash
+git add -A
+git commit -m "fix: typecheck and lint fixes for user tab groups"
+```
+
+---
+
+## Plan Self-Review
+
+### Spec Coverage
+- Data model (UserGroup type, Workspace changes, Tab changes, color palette, persistence): **Task 1**
+- Store actions (all 7): **Task 2**
+- ColorPalettePicker component: **Task 3**
+- TabItem UI changes (border, context menu): **Task 4**
+- Sidebar rendering (UserGroupHeader, ungrouped section, rendering order): **Task 5**
+- Drag-and-drop modifications (userGroup drag type, reorder, tab DnD): **Task 5** (Steps 3, 6, 7)
+- Edge cases (auto-delete empty group via `setTabUserGroup`, collapsed rendering): **Task 2** (Step 7), **Task 5** (Step 8)
+- Verification (typecheck, lint): **Task 6**
+
+### Placeholder Scan
+- No TBD, TODO, or incomplete sections.
+- All code steps contain actual code (no "similar to Task N" references).
+- All commands specify exact expected output.
+
+### Type Consistency
+- `UserGroupColor` defined in `src/shared/group-colors.ts`, imported in `types.ts` and `workspace-store.ts`.
+- `USER_GROUP_COLORS` const available in both shared and renderer.
+- `ColorPalettePicker` uses `UserGroupColor` from `sidebar-constants` (re-exported).
+- All store action names match between type declarations and implementations.
+- All prop names match between `TabItemProps` additions and `Sidebar.tsx` call sites.

--- a/docs/superpowers/specs/2026-06-19-fleet-opencode-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-19-fleet-opencode-plugin-design.md
@@ -1,0 +1,231 @@
+# Fleet OpenCode Plugin
+
+Allow opencode agents to use Fleet via a plugin that exposes Fleet CLI commands as opencode tools. The plugin talks directly to Fleet's Unix domain socket (`~/.fleet/fleet.sock`) using the same newline-delimited JSON protocol the `fleet` CLI uses.
+
+## Scope
+
+All Fleet CLI commands **except Pi** — opencode itself is the agent, so Pi integration is not needed. `kanban watch` is also excluded because streaming doesn't fit opencode's request/response tool model.
+
+## File Structure
+
+Single file: `~/.config/opencode/plugins/fleet.ts` — global plugin, auto-loaded for all projects. Uses `@opencode-ai/plugin` for `tool()` and `tool.schema` (Zod), plus Node.js `net` for the socket connection. The `@opencode-ai/plugin` dependency is already available via the existing `~/.config/opencode/package.json`.
+
+## Socket Communication
+
+- **Path:** `~/.fleet/fleet.sock` (prod), fallback to `fleet-dev.sock` if prod not found
+- **Protocol:** Newline-delimited JSON, same as the CLI: `{ "id": "uuid", "command": "string", "args": {} }`
+- **Connection:** One shared `net.Socket`, created lazily on first tool call
+- **Timeout:** 30s per request
+- **CLI name mapping:** Follows `COMMAND_MAP` from `fleet-cli.ts` (e.g., `images.generate` → `image.generate`, `images.config` read → `image.config.get`)
+
+## Tool Inventory (29 tools)
+
+### fleet_open
+Opens files in Fleet tabs (code, image, PDF, markdown).
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| paths | string[] | yes | File paths to open |
+
+### fleet_annotate
+Opens a browser window for web page annotation.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| url | string | no | URL to annotate |
+| timeout | number | no | Max seconds (default 300) |
+
+### Images (8 tools)
+
+#### fleet_images_generate
+Generate images from a text prompt.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| prompt | string | yes | Text description |
+| provider | string | no | Provider ID |
+| model | string | no | Model to use |
+| resolution | string | no | 0.5K, 1K, 2K, 4K |
+| aspectRatio | string | no | e.g. 1:1, 16:9 |
+| format | string | no | png, jpeg, webp |
+| numImages | number | no | 1-4 |
+
+#### fleet_images_edit
+Edit images with a prompt.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| prompt | string | yes | Edit description |
+| images | string[] | yes | Image file paths |
+| provider | string | no | Provider ID |
+| model | string | no | Model to use |
+| resolution | string | no | 0.5K, 1K, 2K, 4K |
+| aspectRatio | string | no | e.g. 1:1, 16:9 |
+| format | string | no | png, jpeg, webp |
+| numImages | number | no | 1-4 |
+
+#### fleet_images_status
+Check generation status.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| generationId | string | yes | Generation ID |
+
+#### fleet_images_list
+List all generations. No arguments.
+
+#### fleet_images_retry
+Retry a failed generation.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| generationId | string | yes | Generation ID |
+
+#### fleet_images_config
+Read or write image configuration. If any write flag is set, writes; otherwise reads.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| apiKey | string | no | Set API key |
+| defaultModel | string | no | Set default model |
+| defaultResolution | string | no | Set default resolution |
+| defaultOutputFormat | string | no | Set default output format |
+| defaultAspectRatio | string | no | Set default aspect ratio |
+| provider | string | no | Which provider to configure |
+| action | string | no | Action type for model config |
+| model | string | no | Model for the action |
+
+#### fleet_images_action
+Run an action on an image (e.g. remove-background).
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| actionType | string | yes | Action type |
+| source | string | yes | Image path, URL, or gen ref |
+| provider | string | no | Provider ID |
+
+#### fleet_images_actions
+List available actions.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| provider | string | no | Filter by provider |
+
+### Kanban (18 tools)
+
+#### fleet_kanban_create
+Create a new task.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| title | string | yes | Task title |
+| body | string | no | Task description |
+| assignee | string | no | Assignee profile name |
+| priority | number | no | Priority number |
+| workspace | string | no | scratch, dir, or worktree |
+| repo | string | no | Repo path (required for worktree) |
+
+#### fleet_kanban_swarm
+Create a multi-worker swarm.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| goal | string | yes | Swarm goal |
+| workers | object[] | yes | Array of {profile, title, skills?} |
+| verifier | string | yes | Verifier profile |
+| synthesizer | string | yes | Synthesizer profile |
+| repo | string | no | Repository path |
+
+#### fleet_kanban_list
+List tasks, optionally filtered by status.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| status | string | no | triage, todo, ready, running, blocked, review, done, archived |
+
+#### fleet_kanban_show
+Show task details.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| taskId | string | yes | Task ID |
+
+#### fleet_kanban_assign
+Assign a task.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| taskId | string | yes | Task ID |
+| profile | string | yes | Profile name |
+
+#### fleet_kanban_ready
+Mark task as ready. `taskId` required.
+
+#### fleet_kanban_block
+Block a task.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| taskId | string | yes | Task ID |
+| reason | string | yes | Block reason |
+
+#### fleet_kanban_unblock
+Unblock a task. `taskId` required.
+
+#### fleet_kanban_archive
+Archive a task. `taskId` required.
+
+#### fleet_kanban_complete
+Complete a task.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| taskId | string | yes | Task ID |
+| result | string | yes | Completion result |
+
+#### fleet_kanban_comment
+Add a comment.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| taskId | string | yes | Task ID |
+| comment | string | yes | Comment text |
+
+#### fleet_kanban_link
+Link two tasks.
+
+| Arg | Type | Required | Description |
+|-----|------|----------|-------------|
+| parentId | string | yes | Parent task ID |
+| childId | string | yes | Child task ID |
+
+#### fleet_kanban_unlink
+Unlink two tasks. Same args as link.
+
+#### fleet_kanban_log
+Show task event log. `taskId` required.
+
+#### fleet_kanban_dispatch
+Trigger manual dispatch. No arguments.
+
+#### fleet_kanban_decompose
+Decompose a triage task. `taskId` required.
+
+#### fleet_kanban_specify
+Specify a triage task. `taskId` required.
+
+## Excluded
+
+- `kanban watch` — streaming doesn't fit opencode's request/response tool model
+- All Pi commands — opencode is the agent
+
+## Error Handling
+
+- **Socket not found:** "Fleet app is not running. Start Fleet first."
+- **Timeout:** Retry once, then fail with timeout message
+- **Fleet error response (ok: false):** Surface the error string
+- **Network/connection errors:** Surface as tool output
+
+## Configuration
+
+None needed. Socket path is hardcoded. Plugin works if Fleet is running, reports an error if not.

--- a/docs/superpowers/specs/2026-06-19-user-tab-groups-design.md
+++ b/docs/superpowers/specs/2026-06-19-user-tab-groups-design.md
@@ -1,0 +1,127 @@
+# User-Created Tab Groups
+
+Groups tabs in the sidebar into collapsible, color-coded named sections for organization — like Chrome tab groups.
+
+## Requirements
+
+- **Purpose:** Collapse/expand for sidebar organization. No bulk actions, no workspace isolation.
+- **Creation:** Right-click context menu on tabs → "New Group" or "Add to Group" → submenu of existing groups.
+- **Identity:** Custom name + color dot (8-color palette).
+- **Worktree interaction:** Separate systems. A tab can be in both a user group and a worktree group (nesting). Both visual indicators show.
+- **Scope:** Per-workspace.
+- **Empty groups:** Auto-delete when last tab is removed.
+
+## Data Model
+
+### New type (`src/shared/types.ts`)
+
+```ts
+type UserGroup = {
+  id: string            // crypto.randomUUID()
+  name: string          // user-provided label
+  color: UserGroupColor // one of 8 palette colors
+  collapsed: boolean    // sidebar collapse state
+}
+```
+
+### Changes to `Workspace`
+
+```ts
+type Workspace = {
+  // ... existing fields
+  userGroups: UserGroup[]  // ordered — defines sidebar display order
+}
+```
+
+### Changes to `Tab`
+
+```ts
+type Tab = {
+  // ... existing fields
+  userGroupId?: string  // references a UserGroup.id, undefined = ungrouped
+}
+```
+
+### Color palette (`src/renderer/src/components/sidebar-constants.ts`)
+
+```ts
+export const USER_GROUP_COLORS = ['blue', 'teal', 'green', 'yellow', 'orange', 'red', 'pink', 'purple'] as const;
+export type UserGroupColor = typeof USER_GROUP_COLORS[number];
+```
+
+Each maps to `bg-{color}-500` for the dot and `border-l-{color}-500/50` for the tab left border.
+
+### Persistence
+
+`userGroups[]` and `tab.userGroupId` persist with the workspace via `LayoutStore`. No migration needed — new optional fields default to absent.
+
+## Store Actions
+
+All in `useWorkspaceStore`. All set `isDirty: true`.
+
+| Action | Signature | Behavior |
+|---|---|---|
+| `createUserGroup` | `(name, color, tabId)` | Creates `UserGroup`, assigns the given tab to it. |
+| `deleteUserGroup` | `(groupId)` | Clears `userGroupId` from all member tabs, removes group. |
+| `renameUserGroup` | `(groupId, name)` | Updates `userGroups[idx].name`. |
+| `recolorUserGroup` | `(groupId, color)` | Updates `userGroups[idx].color`. |
+| `setTabUserGroup` | `(tabId, groupId \| undefined)` | Assigns tab to a group or removes it. Auto-deletes group if it becomes empty. |
+| `toggleUserGroupCollapsed` | `(groupId)` | Toggles `collapsed`. |
+| `reorderUserGroup` | `(groupId, toIndex)` | Splice group position in `userGroups` array. |
+
+## UI Components
+
+### Sidebar.tsx changes
+
+**`UserGroupHeader`** (new inline component):
+- Color dot (`bg-{color}-500`, 8px circle) + group name + tab count badge + collapse chevron + drag handle
+- Double-click name to rename inline
+- Right-click context menu: Rename, Recolor (palette submenu), Ungroup All
+- Draggable as group-drag type for reordering groups
+
+**Ungrouped section:**
+- Tabs without `userGroupId` render at the top, before all groups
+- Not collapsible (always visible)
+- Hidden when all tabs are grouped
+
+**Rendering order:**
+1. Ungrouped tabs
+2. `UserGroupHeader` + member tabs (for each group in `workspace.userGroups` order)
+3. Within each group: worktree `GroupHeader` + tabs (as today)
+4. Collapsed groups hide their tab items entirely
+
+### TabItem.tsx changes
+
+- When `userGroupId` is set: show `border-l-2 border-l-{color}-500/50` left border (alongside any worktree teal border)
+- Context menu additions:
+  - "New Group" — opens a small popover near the right-click position with a name text input and 8-color palette grid. Confirm creates the group and assigns the tab. Cancel dismisses.
+  - "Add to Group" — submenu of existing groups with color dots and names. Hidden when no groups exist.
+  - "Remove from Group" — when currently grouped, clears `userGroupId`.
+
+### New component: `ColorPalettePicker.tsx`
+
+Small popover grid of 8 color circles. Used by "New Group" dialog and "Recolor" context menu submenu.
+
+### Drag-and-drop modifications
+
+- New drag type: `'userGroup'` (alongside `'tab'` and `'group'`)
+- Tab drag between groups: `setTabUserGroup(tabId, targetGroupId)`. Dragging to ungrouped area clears `userGroupId`. Auto-delete group if it becomes empty.
+- Tab drag within its own group: reorders the tab within the group (standard reorder, no group change).
+- Group header drag: `reorderUserGroup(groupId, toIndex)`
+- Worktree DnD rules still apply within groups
+
+## Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Empty group (last tab removed) | Auto-delete group |
+| All tabs in a group are closed | Group auto-deleted |
+| Undo close tab that was in a group | Restored tab keeps `userGroupId`. If group was deleted, tab reverts to ungrouped. |
+| Worktree tab inside user group | Both visual indicators: user group's colored left border + worktree's teal border + worktree branch subtitle |
+| Drag grouped tab outside its group | Tab gets ungrouped. If group becomes empty, auto-delete. |
+
+## Verification
+
+- Type check: `npm run typecheck`
+- Lint: `npm run lint`
+- Manual testing: create groups, collapse/expand, rename, recolor, drag tabs between groups, verify persistence across app restart and workspace switch

--- a/resources/opencode-plugin/SKILL.md
+++ b/resources/opencode-plugin/SKILL.md
@@ -1,0 +1,76 @@
+# Fleet Tools
+
+You have access to Fleet tools for controlling the Fleet desktop app. These tools only register when running inside a Fleet terminal (`FLEET_SESSION` env var is set, or the Fleet socket is reachable).
+
+## Image Generation
+
+| Tool | Purpose |
+|------|---------|
+| `fleet_images_generate` | Generate images from a text prompt. Returns a generation ID. |
+| `fleet_images_edit` | Edit images with a prompt and source images. |
+| `fleet_images_status` | Check generation status by ID. Poll until complete. |
+| `fleet_images_list` | List all generations. |
+| `fleet_images_retry` | Retry a failed generation. |
+| `fleet_images_action` | Run an action on an image (e.g., remove-background). |
+| `fleet_images_actions` | List available image actions. |
+| `fleet_images_config` | Show or set image provider configuration. |
+
+### Image Workflow
+
+1. `fleet_images_generate` → get a generation ID
+2. `fleet_images_status <id>` → poll until status is "complete"
+3. `fleet_open` the resulting image file to view it
+
+## Kanban Board
+
+| Tool | Purpose |
+|------|---------|
+| `fleet_kanban_create` | Create a new task (starts in "triage" status). |
+| `fleet_kanban_swarm` | Create a multi-agent task graph with workers, verifier, and synthesizer. |
+| `fleet_kanban_list` | List tasks, optionally filtered by status. |
+| `fleet_kanban_show` | Show full task details including body, comments, and links. |
+| `fleet_kanban_assign` | Assign a task to a profile. |
+| `fleet_kanban_ready` | Mark a triage task as ready for dispatch. |
+| `fleet_kanban_block` | Block a task with a reason. |
+| `fleet_kanban_unblock` | Unblock a task. |
+| `fleet_kanban_archive` | Archive a task (remove from active board). |
+| `fleet_kanban_complete` | Complete a task with a result description. |
+| `fleet_kanban_comment` | Add a comment to a task. |
+| `fleet_kanban_link` | Link a parent to a child task (creates dependency). |
+| `fleet_kanban_unlink` | Remove a parent-child link. |
+| `fleet_kanban_log` | Show the chronological event history for a task. |
+| `fleet_kanban_dispatch` | Trigger the dispatcher to pick up ready tasks. |
+| `fleet_kanban_decompose` | Fan a triage task into a graph of child tasks. |
+| `fleet_kanban_specify` | Rewrite a triage task into a fuller specification. |
+
+### Kanban Task Lifecycle
+
+```
+create (triage) → assign → [decompose/specify] → ready → dispatch → running → complete
+                                                              ↓
+                                                           block/unblock
+```
+
+**Key points:**
+- Tasks start in "triage" status. They must be explicitly moved to "ready".
+- `fleet_kanban_dispatch` triggers the dispatcher to process ready tasks. Does not auto-run.
+- `fleet_kanban_swarm` creates a coordinated multi-worker task. Manual dispatch may be needed after.
+- `fleet_kanban_complete` marks done with a result. `fleet_kanban_archive` removes from board entirely.
+- `fleet_kanban_decompose` and `fleet_kanban_specify` only work on triage tasks.
+
+### Status Values
+
+`triage`, `todo`, `ready`, `running`, `blocked`, `review`, `done`, `archived`
+
+## File Operations
+
+| Tool | Purpose |
+|------|---------|
+| `fleet_open` | Open files in Fleet tabs (code, images, markdown, PDF). |
+| `fleet_annotate` | Visually annotate a web page. Results saved to a JSON file. |
+
+## Prerequisites
+
+- **Fleet must be running.** Tools connect via `~/.fleet/fleet.sock`.
+- **Inside a Fleet terminal** (recommended). Tools only appear when `FLEET_SESSION` is set or the Fleet socket is reachable.
+- If Fleet is not running, tool calls return an error.

--- a/resources/opencode-plugin/fleet.ts
+++ b/resources/opencode-plugin/fleet.ts
@@ -1,0 +1,488 @@
+import { createConnection } from "node:net"
+import { randomUUID } from "node:crypto"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { Plugin } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+
+const z = tool.schema
+
+const SOCK_PATH = join(homedir(), ".fleet", "fleet.sock")
+const DEV_SOCK_PATH = join(homedir(), ".fleet", "fleet-dev.sock")
+const TIMEOUT_MS = 30_000
+
+interface FleetResponse {
+  id: string
+  ok: boolean
+  data?: unknown
+  error?: string
+}
+
+interface FleetError {
+  message: string
+  code?: string
+}
+
+function isFleetResponse(v: unknown): v is FleetResponse {
+  return (
+    v != null &&
+    typeof v === "object" &&
+    "ok" in v &&
+    typeof (v as { ok?: unknown }).ok === "boolean"
+  )
+}
+
+function resolveSocketPath(): string {
+  if (existsSync(SOCK_PATH)) return SOCK_PATH
+  if (existsSync(DEV_SOCK_PATH)) return DEV_SOCK_PATH
+  return SOCK_PATH
+}
+
+const COMMAND_MAP: Record<string, string> = {
+  "images.generate": "image.generate",
+  "images.edit": "image.edit",
+  "images.status": "image.status",
+  "images.list": "image.list",
+  "images.retry": "image.retry",
+  "images.config": "image.config.get",
+  "images.action": "image.action",
+  "images.actions": "image.actions.list",
+  "annotate.start": "annotate.start",
+}
+
+function mapCmd(cliCommand: string): string {
+  return COMMAND_MAP[cliCommand] ?? cliCommand
+}
+
+async function sendCommand(
+  command: string,
+  args: Record<string, unknown> = {},
+  timeoutMs = TIMEOUT_MS,
+): Promise<FleetResponse> {
+  const cmd = mapCmd(command)
+  const sockPath = resolveSocketPath()
+
+  if (!existsSync(sockPath)) {
+    return {
+      id: "",
+      ok: false,
+      error: `Fleet app is not running (no socket at ${sockPath}). Start Fleet first.`,
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const id = randomUUID()
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const settle = (response: FleetResponse): void => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve(response)
+    }
+
+    try {
+    timer = setTimeout(() => {
+      settle({ id, ok: false, error: `Timeout after ${timeoutMs}ms` })
+      try { socket.destroy() } catch { /* ignore */ }
+    }, timeoutMs)
+
+    const socket = createConnection(sockPath, () => {
+      socket.write(JSON.stringify({ id, command: cmd, args }) + "\n")
+    })
+
+    let buffer = ""
+
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString()
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const parsed: unknown = JSON.parse(line)
+          socket.end()
+          settle(isFleetResponse(parsed) ? parsed : { id, ok: false, error: "Invalid response from Fleet" })
+        } catch {
+          socket.end()
+          settle({ id, ok: false, error: "Invalid JSON response from Fleet" })
+        }
+      }
+    })
+
+    socket.on("error", (err: FleetError) => {
+      if (err.code === "ENOENT") {
+        settle({ id, ok: false, error: "Fleet app is not running. Start Fleet first." })
+      } else {
+        settle({ id, ok: false, error: err.message })
+      }
+    })
+
+    socket.on("close", () => {
+      settle({ id, ok: false, error: "Connection closed without response" })
+    })
+    } catch (err: unknown) {
+      reject(err instanceof Error ? err : new Error(String(err)))
+    }
+  })
+}
+
+function formatResponse(response: FleetResponse): string {
+  if (!response.ok) return response.error || "Unknown error"
+  if (response.data === undefined) return "ok"
+  if (typeof response.data === "string") return response.data
+  try {
+    return JSON.stringify(response.data, null, 2)
+  } catch {
+    return String(response.data)
+  }
+}
+
+async function sendAndFormat(
+  command: string,
+  args: Record<string, unknown> = {},
+): Promise<{ output: string }> {
+  const response = await sendCommand(command, args)
+  return { output: formatResponse(response) }
+}
+
+const IMAGE_PROVIDERS = z.string().optional().describe("Provider ID")
+const IMAGE_MODEL = z.string().optional().describe("Model to use")
+const IMAGE_RESOLUTION = z.string().optional().describe("Resolution: 0.5K, 1K, 2K, or 4K")
+const IMAGE_ASPECT = z.string().optional().describe("Aspect ratio, e.g. 1:1, 16:9, 9:16")
+const IMAGE_FORMAT = z.string().optional().describe("Output format: png, jpeg, or webp")
+const IMAGE_NUM = z.number().optional().describe("Number of images: 1-4")
+
+export const Fleet: Plugin = async () => {
+  if (!process.env.FLEET_SESSION && !existsSync(SOCK_PATH) && !existsSync(DEV_SOCK_PATH)) return { tool: {} }
+  return {
+    tool: {
+      fleet_images_generate: tool({
+        description: "Generate images from a text prompt using Fleet's AI image providers (fal.ai, etc.). Returns a generation ID to check with fleet_images_status.",
+        args: {
+          prompt: z.string().describe("Text description of the image to generate"),
+          provider: IMAGE_PROVIDERS,
+          model: IMAGE_MODEL,
+          resolution: IMAGE_RESOLUTION,
+          aspectRatio: IMAGE_ASPECT,
+          format: IMAGE_FORMAT,
+          numImages: IMAGE_NUM,
+        },
+        execute: (args) => sendAndFormat("images.generate", {
+          prompt: args.prompt,
+          provider: args.provider,
+          model: args.model,
+          resolution: args.resolution,
+          "aspect-ratio": args.aspectRatio,
+          format: args.format,
+          "num-images": args.numImages,
+        }),
+      }),
+
+      fleet_images_edit: tool({
+        description: "Edit images using a text prompt via Fleet's AI image providers. Requires at least one image file path.",
+        args: {
+          prompt: z.string().describe("Text description of the edit to apply"),
+          images: z.array(z.string()).describe("One or more image file paths to edit"),
+          provider: IMAGE_PROVIDERS,
+          model: IMAGE_MODEL,
+          resolution: IMAGE_RESOLUTION,
+          aspectRatio: IMAGE_ASPECT,
+          format: IMAGE_FORMAT,
+          numImages: IMAGE_NUM,
+        },
+        execute: (args) => sendAndFormat("images.edit", {
+          prompt: args.prompt,
+          images: args.images,
+          provider: args.provider,
+          model: args.model,
+          resolution: args.resolution,
+          "aspect-ratio": args.aspectRatio,
+          format: args.format,
+          "num-images": args.numImages,
+        }),
+      }),
+
+      fleet_images_status: tool({
+        description: "Check the status of an image generation by its ID.",
+        args: {
+          generationId: z.string().describe("The generation ID from fleet_images_generate or fleet_images_edit"),
+        },
+        execute: (args) => sendAndFormat("images.status", { id: args.generationId }),
+      }),
+
+      fleet_images_list: tool({
+        description: "List all image generations and their statuses.",
+        args: {},
+        execute: () => sendAndFormat("images.list", {}),
+      }),
+
+      fleet_images_retry: tool({
+        description: "Retry a failed image generation.",
+        args: {
+          generationId: z.string().describe("The generation ID of a failed generation"),
+        },
+        execute: (args) => sendAndFormat("images.retry", { id: args.generationId }),
+      }),
+
+      fleet_images_action: tool({
+        description: "Run an action on an image (e.g. remove-background). Use fleet_images_actions to see available actions.",
+        args: {
+          actionType: z.string().describe("Action type, e.g. remove-background"),
+          source: z.string().describe("Image file path, URL, or generation reference (<genId>/image-001.png)"),
+          provider: IMAGE_PROVIDERS,
+        },
+        execute: (args) => sendAndFormat("images.action", {
+          action: args.actionType,
+          source: args.source,
+          provider: args.provider,
+        }),
+      }),
+
+      fleet_images_actions: tool({
+        description: "List available image actions for a provider.",
+        args: {
+          provider: IMAGE_PROVIDERS,
+        },
+        execute: (args) => sendAndFormat("images.actions", { provider: args.provider }),
+      }),
+
+      fleet_images_config: tool({
+        description: "Read or write Fleet image configuration. Call with no arguments to read current config. Provide flags to set configuration values.",
+        args: {
+          apiKey: z.string().optional().describe("Set fal.ai API key"),
+          defaultModel: z.string().optional().describe("Set default model"),
+          defaultResolution: z.string().optional().describe("Set default resolution"),
+          defaultOutputFormat: z.string().optional().describe("Set default output format"),
+          defaultAspectRatio: z.string().optional().describe("Set default aspect ratio"),
+          provider: z.string().optional().describe("Which provider to configure"),
+          action: z.string().optional().describe("Action type to configure model for"),
+          model: z.string().optional().describe("Model for the specified action"),
+        },
+        execute: async (args) => {
+          const hasSetFlag = args.apiKey || args.defaultModel || args.defaultResolution ||
+            args.defaultOutputFormat || args.defaultAspectRatio || args.action || args.model
+          if (hasSetFlag) {
+            return sendAndFormat("image.config.set", {
+              "api-key": args.apiKey,
+              "default-model": args.defaultModel,
+              "default-resolution": args.defaultResolution,
+              "default-output-format": args.defaultOutputFormat,
+              "default-aspect-ratio": args.defaultAspectRatio,
+              provider: args.provider,
+              action: args.action,
+              model: args.model,
+            })
+          }
+          return sendAndFormat("images.config", { provider: args.provider })
+        },
+      }),
+
+      // --- Kanban ---
+
+      fleet_kanban_create: tool({
+        description: "Create a new task on the Fleet Kanban board.",
+        args: {
+          title: z.string().describe("Task title"),
+          body: z.string().optional().describe("Task description/body"),
+          assignee: z.string().optional().describe("Assignee profile name"),
+          priority: z.number().optional().describe("Priority number"),
+          workspace: z.string().optional().describe("Workspace kind: scratch, dir, or worktree"),
+          repo: z.string().optional().describe("Repository path (required when workspace is worktree)"),
+        },
+        execute: (args) => sendAndFormat("kanban.create", {
+          title: args.title,
+          body: args.body,
+          assignee: args.assignee,
+          priority: args.priority,
+          workspace: args.workspace,
+          repo: args.repo,
+        }),
+      }),
+
+      fleet_kanban_swarm: tool({
+        description: "Create a multi-worker swarm (task graph) on the Kanban board. Each worker runs in parallel. Workers format: [{profile, title, skills?}]. A verifier reviews results, a synthesizer merges them.",
+        args: {
+          goal: z.string().describe("The goal description for the swarm"),
+          workers: z.array(z.object({
+            profile: z.string().describe("Worker profile name"),
+            title: z.string().describe("Worker task title"),
+            skills: z.array(z.string()).optional().describe("Skills for this worker"),
+          })).describe("Array of worker specs"),
+          verifier: z.string().describe("Verifier assignee profile"),
+          synthesizer: z.string().describe("Synthesizer assignee profile"),
+          repo: z.string().optional().describe("Repository path (enables worktree workspace)"),
+        },
+        execute: async (args) => {
+          const workerSpecs = args.workers.map((w) => {
+            const skills = w.skills?.join(",") ?? ""
+            return skills ? `${w.profile}:${w.title}:${skills}` : `${w.profile}:${w.title}`
+          })
+          return sendAndFormat("kanban.swarm", {
+            goal: args.goal,
+            worker: workerSpecs,
+            verifier: args.verifier,
+            synthesizer: args.synthesizer,
+            repo: args.repo,
+          })
+        },
+      }),
+
+      fleet_kanban_list: tool({
+        description: "List tasks on the Fleet Kanban board, optionally filtered by status.",
+        args: {
+          status: z.string().optional().describe("Filter by status: triage, todo, ready, running, blocked, review, done, archived"),
+        },
+        execute: (args) => sendAndFormat("kanban.list", { status: args.status }),
+      }),
+
+      fleet_kanban_show: tool({
+        description: "Show details for a specific Kanban task including body, assignee, status, links, and comments.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.show", { id: args.taskId }),
+      }),
+
+      fleet_kanban_assign: tool({
+        description: "Assign a Kanban task to a profile.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          profile: z.string().describe("Profile name to assign"),
+        },
+        execute: (args) => sendAndFormat("kanban.assign", { id: args.taskId, profile: args.profile }),
+      }),
+
+      fleet_kanban_ready: tool({
+        description: "Mark a Kanban task as ready for dispatch.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.ready", { id: args.taskId }),
+      }),
+
+      fleet_kanban_block: tool({
+        description: "Block a Kanban task with a reason.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          reason: z.string().describe("Reason for blocking"),
+        },
+        execute: (args) => sendAndFormat("kanban.block", { id: args.taskId, reason: args.reason }),
+      }),
+
+      fleet_kanban_unblock: tool({
+        description: "Unblock a previously blocked Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.unblock", { id: args.taskId }),
+      }),
+
+      fleet_kanban_archive: tool({
+        description: "Archive a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.archive", { id: args.taskId }),
+      }),
+
+      fleet_kanban_complete: tool({
+        description: "Mark a Kanban task as complete with a result summary.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          result: z.string().describe("Completion result/summary"),
+        },
+        execute: (args) => sendAndFormat("kanban.complete", { id: args.taskId, result: args.result }),
+      }),
+
+      fleet_kanban_comment: tool({
+        description: "Add a comment to a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+          comment: z.string().describe("Comment text"),
+        },
+        execute: (args) => sendAndFormat("kanban.comment", { id: args.taskId, body: args.comment }),
+      }),
+
+      fleet_kanban_link: tool({
+        description: "Link a parent task to a child task (creates a dependency).",
+        args: {
+          parentId: z.string().describe("Parent task ID"),
+          childId: z.string().describe("Child task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.link", { parentId: args.parentId, childId: args.childId }),
+      }),
+
+      fleet_kanban_unlink: tool({
+        description: "Remove a link between a parent and child task.",
+        args: {
+          parentId: z.string().describe("Parent task ID"),
+          childId: z.string().describe("Child task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.unlink", { parentId: args.parentId, childId: args.childId }),
+      }),
+
+      fleet_kanban_log: tool({
+        description: "Show the event log for a Kanban task.",
+        args: {
+          taskId: z.string().describe("The task ID"),
+        },
+        execute: (args) => sendAndFormat("kanban.log", { id: args.taskId }),
+      }),
+
+      fleet_kanban_dispatch: tool({
+        description: "Trigger the kanban dispatcher to process the queue and start ready tasks.",
+        args: {},
+        execute: () => sendAndFormat("kanban.dispatch", {}),
+      }),
+
+      fleet_kanban_decompose: tool({
+        description: "Decompose a triage task into a child-task graph using AI planning.",
+        args: {
+          taskId: z.string().describe("The triage task ID to decompose"),
+        },
+        execute: (args) => sendAndFormat("kanban.decompose", { id: args.taskId }),
+      }),
+
+      fleet_kanban_specify: tool({
+        description: "Rewrite a triage task body into a fuller, more detailed specification.",
+        args: {
+          taskId: z.string().describe("The triage task ID to specify"),
+        },
+        execute: (args) => sendAndFormat("kanban.specify", { id: args.taskId }),
+      }),
+
+      // --- Open & Annotate ---
+
+      fleet_open: tool({
+        description: "Open files in Fleet tabs. Supports code files, images (png, jpg, gif, webp, svg, bmp, ico), markdown, and PDFs. Each file opens in the appropriate viewer.",
+        args: {
+          paths: z.array(z.string()).describe("One or more file paths to open"),
+        },
+        execute: async (args) => {
+          const files = args.paths.map((p) => {
+            const ext = p.toLowerCase().split(".").pop() ?? ""
+            let paneType = "file"
+            if (new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"]).has(ext)) paneType = "image"
+            else if (ext === "md" || ext === "markdown") paneType = "markdown"
+            else if (ext === "pdf") paneType = "pdf"
+            return { path: p, paneType, label: p.split("/").pop() ?? p }
+          })
+          return sendAndFormat("file.open", { files })
+        },
+      }),
+
+      fleet_annotate: tool({
+        description: "Open a browser window for visual web page annotation. Click elements, add comments, and capture annotated screenshots. Results written to a JSON file.",
+        args: {
+          url: z.string().optional().describe("URL to annotate. Omit for a blank page."),
+          timeout: z.number().optional().describe("Max seconds to wait for annotation (default 300)"),
+        },
+        execute: (args) => sendAndFormat("annotate.start", { url: args.url, timeout: args.timeout }),
+      }),
+    },
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import { SettingsStore } from './settings-store';
 import { IPC_CHANNELS, IS_FLEET_DEV, SOCKET_PATH } from '../shared/constants';
 import { SocketSupervisor } from './socket-supervisor';
 import { CwdPoller } from './cwd-poller';
-import { installFleetCLI, installSkillFile } from './install-fleet-cli';
+import { installFleetCLI, installSkillFile, installOpencodePlugin } from './install-fleet-cli';
 import { ImageService } from './image-service';
 import { AnnotateService } from './annotate-service';
 import { AnnotationStore } from './annotation-store';
@@ -432,6 +432,11 @@ void app.whenReady().then(async () => {
   void enrichProcessEnv();
   void installSkillFile().catch((err) => {
     log.warn('failed to install skill file', {
+      error: err instanceof Error ? err.message : String(err)
+    });
+  });
+  void installOpencodePlugin().catch((err) => {
+    log.warn('failed to install opencode plugin', {
       error: err instanceof Error ? err.message : String(err)
     });
   });

--- a/src/main/install-fleet-cli.ts
+++ b/src/main/install-fleet-cli.ts
@@ -242,6 +242,146 @@ export async function installSkillFile(): Promise<void> {
   log.info('installed fleet skill file', { path: destPath });
 }
 
+// ── installOpencodePlugin ────────────────────────────────────────────────────
+//
+// Copies the Fleet opencode plugin and skill file into the opencode config
+// directory so the opencode agent can discover Fleet tools when running inside
+// a Fleet terminal. Overwrites on every launch to stay in sync with the app
+// version.
+//
+// Also ensures @opencode-ai/plugin is declared in the opencode package.json
+// (OpenCode runs bun install at startup to install deps). Only writes
+// package.json when something changed — never corrupts user content.
+//
+// The plugin self-guards: it checks process.env.FLEET_SESSION so Fleet tools
+// only register when opencode is running inside a Fleet PTY.
+
+export async function installOpencodePlugin(): Promise<void> {
+  const opencodeHome = join(homedir(), '.config', 'opencode');
+
+  if (!existsSync(opencodeHome)) {
+    log.debug('opencode not installed, skipping plugin install');
+    return;
+  }
+
+  // Locate the source files in the Fleet app bundle
+  const mainDir = dirname(fileURLToPath(import.meta.url));
+
+  const candidatePluginPaths = [
+    join(mainDir, '..', '..', 'resources', 'opencode-plugin', 'fleet.ts'),
+    join(process.resourcesPath ?? '', 'app.asar.unpacked', 'resources', 'opencode-plugin', 'fleet.ts')
+  ];
+
+  const candidateSkillPaths = [
+    join(mainDir, '..', '..', 'resources', 'opencode-plugin', 'SKILL.md'),
+    join(process.resourcesPath ?? '', 'app.asar.unpacked', 'resources', 'opencode-plugin', 'SKILL.md')
+  ];
+
+  // ── Install plugin file ──────────────────────────────────────────────────
+
+  let pluginContent: string | null = null;
+  for (const candidate of candidatePluginPaths) {
+    if (existsSync(candidate)) {
+      pluginContent = await readFile(candidate, 'utf8');
+      break;
+    }
+  }
+
+  if (pluginContent) {
+    const pluginsDir = join(opencodeHome, 'plugins');
+    try {
+      await mkdir(pluginsDir, { recursive: true });
+    } catch (err) {
+      log.warn('could not create opencode plugins directory', {
+        path: pluginsDir,
+        error: err instanceof Error ? err.message : String(err)
+      });
+      return;
+    }
+
+    const destPath = join(pluginsDir, 'fleet.ts');
+    await writeFile(destPath, pluginContent, 'utf8');
+    log.info('installed fleet opencode plugin', { path: destPath });
+  } else {
+    log.warn('opencode plugin source not found, skipping plugin install', {
+      candidates: candidatePluginPaths
+    });
+  }
+
+  // ── Install skill file ───────────────────────────────────────────────────
+
+  let skillContent: string | null = null;
+  for (const candidate of candidateSkillPaths) {
+    if (existsSync(candidate)) {
+      skillContent = await readFile(candidate, 'utf8');
+      break;
+    }
+  }
+
+  if (skillContent) {
+    const skillsDir = join(opencodeHome, 'skills', 'fleet');
+    try {
+      await mkdir(skillsDir, { recursive: true });
+      const destPath = join(skillsDir, 'SKILL.md');
+      await writeFile(destPath, skillContent, 'utf8');
+      log.info('installed fleet opencode skill', { path: destPath });
+    } catch (err) {
+      log.warn('could not create opencode skills directory', {
+        path: skillsDir,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  } else {
+    log.warn('opencode skill source not found, skipping skill install', {
+      candidates: candidateSkillPaths
+    });
+  }
+
+  // ── Ensure @opencode-ai/plugin dependency ─────────────────────────────────
+
+  const pkgJsonPath = join(opencodeHome, 'package.json');
+  let rawJson: string;
+  let pkgJson: { dependencies?: Record<string, string> };
+  let parsed = false;
+
+  if (existsSync(pkgJsonPath)) {
+    rawJson = await readFile(pkgJsonPath, 'utf8');
+    try {
+      pkgJson = JSON.parse(rawJson) as { dependencies?: Record<string, string> };
+      parsed = true;
+    } catch {
+      log.warn('could not parse opencode package.json, leaving unchanged');
+      return;
+    }
+  } else {
+    rawJson = '{}';
+    pkgJson = {};
+    parsed = true;
+  }
+
+  pkgJson.dependencies = pkgJson.dependencies ?? {};
+
+  if (pkgJson.dependencies['@opencode-ai/plugin'] === '*' || pkgJson.dependencies['@opencode-ai/plugin'] === 'latest') {
+    pkgJson.dependencies['@opencode-ai/plugin'] = '^1';
+  }
+
+  if (!pkgJson.dependencies['@opencode-ai/plugin']) {
+    pkgJson.dependencies['@opencode-ai/plugin'] = '^1';
+    const newRaw = JSON.stringify(pkgJson, null, 2) + '\n';
+    if (newRaw !== rawJson) {
+      await writeFile(pkgJsonPath, newRaw, 'utf8');
+      log.info('added @opencode-ai/plugin dependency to opencode package.json');
+    }
+  } else if (parsed) {
+    // Update formatting only if we successfully parsed and did add/change
+    const newRaw = JSON.stringify(pkgJson, null, 2) + '\n';
+    if (newRaw !== rawJson) {
+      await writeFile(pkgJsonPath, newRaw, 'utf8');
+      log.info('updated @opencode-ai/plugin to ^1 in opencode package.json');
+    }
+  }
+}
+
 // ── addFleetBinToShellProfile ─────────────────────────────────────────────────
 //
 // Appends `export PATH="$HOME/.fleet/bin:$PATH"` to every common shell profile


### PR DESCRIPTION
Adds an opencode plugin that registers 27 Fleet tools (images, kanban, open, annotate) via the Fleet Unix socket API. Ships with every Fleet install.

### How it works

On every Fleet launch, `installOpencodePlugin()` copies the plugin and skill file from `resources/opencode-plugin/` into `~/.config/opencode/`. OpenCode auto-discovers plugins from that directory at startup.

The plugin self-guards with `FLEET_SESSION` + socket existence check so tools only activate when running inside Fleet.

### What's included

- **Plugin** (`resources/opencode-plugin/fleet.ts`, 487 lines): 27 tools in the `fleet_*` namespace communicating directly over `~/.fleet/fleet.sock` with newline-delimited JSON
  - 8 image tools: generate, edit, status, list, retry, action, actions, config
  - 17 kanban tools: create, swarm, list, show, assign, ready, block, unblock, archive, complete, comment, link, unlink, log, dispatch, decompose, specify
  - 2 utility tools: open, annotate
- **Skill file** (`resources/opencode-plugin/SKILL.md`): tool reference tables with workflow documentation and prerequisite guidance
- **Dependency management**: ensures `@opencode-ai/plugin` at `^1` in the opencode package.json (never corrupts user content on parse failure)
- Same install pattern as existing `installSkillFile()` and `installFleetCLI()`

### Edge cases handled

- Socket timeouts (30s), concurrent calls (per-call connections), dev/prod socket fallback
- `FLEET_SESSION` env cleared by SSH/tmux → falls back to socket existence check
- `package.json` parse failure → leaves unchanged instead of overwriting
- `plugins/` directory exists as file → caught and logged
- Only writes `package.json` when content actually changed